### PR TITLE
Authenticate exact-dependent concept migrations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1644"
+version = "0.2.1645"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -28,6 +28,7 @@ LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3 = "axiom-encode/legacy-fresh-reencode-recei
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4 = "axiom-encode/legacy-fresh-reencode-receipt/v4"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5 = "axiom-encode/legacy-fresh-reencode-receipt/v5"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6 = "axiom-encode/legacy-fresh-reencode-receipt/v6"
+LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7 = "axiom-encode/legacy-fresh-reencode-receipt/v7"
 LEGACY_EXACT_DEPENDENT_TOOL = (
     "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
 )
@@ -1808,6 +1809,11 @@ def _validate_legacy_exact_dependents(
         _repair_proof_import_hashes,
         _strict_legacy_replacement_map,
     )
+    from axiom_encode.legacy_exact_dependent_concepts import (
+        canonicalized_concept_replacements,
+        derive_exact_dependent_parameter_replacements,
+        validate_exact_dependent_concept_rewrite,
+    )
     from axiom_encode.legacy_replacement import (
         legacy_receipt_v1_manifest_issues,
         migrate_legacy_exact_dependent_source_verification,
@@ -1841,6 +1847,33 @@ def _validate_legacy_exact_dependents(
     replacement_source_citations = _legacy_primary_source_citations(
         replacement_source_raw
     )
+    retained_modules: list[tuple[Path, Path, bytes, bytes]] = []
+    if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7:
+        raw_successors = receipt_replacement.get("retained_successors")
+        if not isinstance(raw_successors, list):
+            raise ValueError("legacy replacement retained successors are malformed")
+        for successor in raw_successors:
+            if not isinstance(successor, dict):
+                raise ValueError("legacy replacement retained successor is malformed")
+            source = _safe_relative_path(
+                successor.get("source"), label="retained successor source"
+            )
+            destination = _safe_relative_path(
+                successor.get("destination"), label="retained successor destination"
+            )
+            source_raw = _base_regular_blob(repo, base_commit, source, required=True)
+            destination_raw = _base_regular_blob(
+                repo, base_commit, destination, required=True
+            )
+            assert source_raw is not None and destination_raw is not None
+            retained_modules.append(
+                (
+                    Path(source),
+                    Path(destination),
+                    source_raw,
+                    destination_raw,
+                )
+            )
     for index, raw_dependent in enumerate(raw_dependents):
         label = f"{root_manifest} exact_dependents[{index}]"
         expected_dependent_fields = {
@@ -1853,8 +1886,11 @@ def _validate_legacy_exact_dependents(
         if receipt_schema in {
             LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
             LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+            LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
         }:
             expected_dependent_fields.add("source_verification_migration")
+        if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7:
+            expected_dependent_fields.add("concept_replacements")
         if (
             not isinstance(raw_dependent, dict)
             or set(raw_dependent) != expected_dependent_fields
@@ -1866,6 +1902,7 @@ def _validate_legacy_exact_dependents(
             in {
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
             }
             else None
         )
@@ -1986,6 +2023,7 @@ def _validate_legacy_exact_dependents(
         if receipt_schema in {
             LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
             LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+            LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
         }:
             _unused_primary, source_verification_migration = (
                 migrate_legacy_exact_dependent_source_verification(
@@ -2025,6 +2063,24 @@ def _validate_legacy_exact_dependents(
         raw_rewrites = raw_dependent.get("rewrites")
         if not isinstance(raw_rewrites, list) or not raw_rewrites:
             raise ValueError(f"{label}.rewrites is malformed")
+        exact_authoritative_replacements = authoritative_replacements
+        exact_concept_replacements: dict[str, str] = {}
+        if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7:
+            derived_concepts = derive_exact_dependent_parameter_replacements(
+                dependent_primary_raw=base_by_path[primary],
+                retained_modules=retained_modules,
+            )
+            expected_concept_records = [
+                {"from": old, "to": new}
+                for old, new in sorted(derived_concepts.items())
+            ]
+            if raw_dependent.get("concept_replacements") != expected_concept_records:
+                raise ValueError(f"{label} concept rewrite proof differs")
+            exact_concept_replacements = derived_concepts
+            exact_authoritative_replacements = {
+                **authoritative_replacements,
+                **exact_concept_replacements,
+            }
         rewrite_paths: set[PurePosixPath] = set()
         for rewrite_index, rewrite in enumerate(raw_rewrites):
             rewrite_label = f"{label}.rewrites[{rewrite_index}]"
@@ -2035,7 +2091,10 @@ def _validate_legacy_exact_dependents(
                 "replacements",
                 "proof_import_repairs",
             }
-            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6:
+            if receipt_schema in {
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
+            }:
                 expected_rewrite_fields.add("proof_excerpt_reanchors")
             if not isinstance(rewrite, dict) or set(rewrite) != expected_rewrite_fields:
                 raise ValueError(f"{rewrite_label} is malformed")
@@ -2059,7 +2118,11 @@ def _validate_legacy_exact_dependents(
                 or isinstance(rewrite.get("proof_import_repairs"), bool)
                 or rewrite["proof_import_repairs"] < 0
                 or (
-                    receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6
+                    receipt_schema
+                    in {
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
+                    }
                     and not isinstance(rewrite.get("proof_excerpt_reanchors"), list)
                 )
             ):
@@ -2067,13 +2130,37 @@ def _validate_legacy_exact_dependents(
             try:
                 expected_live, observed_counts = rewrite_exact_references(
                     base_by_path[rewrite_path],
-                    authoritative_replacements,
+                    exact_authoritative_replacements,
                 )
+                if exact_concept_replacements:
+                    path_rewritten, _path_counts = rewrite_exact_references(
+                        base_by_path[rewrite_path],
+                        authoritative_replacements,
+                    )
+                    canonical_concepts = canonicalized_concept_replacements(
+                        exact_concept_replacements,
+                        path_replacements=authoritative_replacements,
+                    )
+                    concept_rewritten, _concept_counts = rewrite_exact_references(
+                        path_rewritten,
+                        canonical_concepts,
+                    )
+                    if concept_rewritten != expected_live:
+                        raise ValueError(
+                            f"{rewrite_label} concept rewrite order differs"
+                        )
+                    validate_exact_dependent_concept_rewrite(
+                        path_rewritten_raw=path_rewritten,
+                        concept_rewritten_raw=concept_rewritten,
+                        replacements=canonical_concepts,
+                        primary=rewrite_path == primary,
+                    )
                 observed_proof_repairs = 0
                 if rewrite_path == primary:
                     if receipt_schema in {
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
                     }:
                         expected_live, observed_source_migration = (
                             migrate_legacy_exact_dependent_source_verification(
@@ -2088,7 +2175,10 @@ def _validate_legacy_exact_dependents(
                         raise ValueError(
                             f"{label}.source_verification_migration schema differs"
                         )
-                    if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6:
+                    if receipt_schema in {
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
+                    }:
                         if corpus_release is None:
                             raise ValueError(
                                 f"{rewrite_label} proof-excerpt verification requires "
@@ -2100,9 +2190,10 @@ def _validate_legacy_exact_dependents(
                                 corpus_release=corpus_release,
                             )
                         )
-                        if list(observed_reanchors) != rewrite[
-                            "proof_excerpt_reanchors"
-                        ]:
+                        if (
+                            list(observed_reanchors)
+                            != rewrite["proof_excerpt_reanchors"]
+                        ):
                             raise ValueError(
                                 f"{rewrite_label} proof-excerpt corpus replay differs"
                             )
@@ -2118,7 +2209,11 @@ def _validate_legacy_exact_dependents(
                     )
                     expected_live = expected_text.encode("utf-8")
                 elif (
-                    receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6
+                    receipt_schema
+                    in {
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
+                    }
                     and rewrite["proof_excerpt_reanchors"]
                 ):
                     raise ValueError(
@@ -2146,6 +2241,7 @@ def _validate_legacy_exact_dependents(
             in {
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
             }
             and primary not in rewrite_paths
             and source_verification_migration is not None
@@ -2322,6 +2418,7 @@ def authorized_changed_paths(
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                    LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
                 }
                 or receipt.get("tool") != LEGACY_REPLACEMENT_TOOL
             ):
@@ -2387,6 +2484,7 @@ def authorized_changed_paths(
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
             }:
                 if not isinstance(retained_successors, list) or not isinstance(
                     metadata_reconciliations, list
@@ -2418,6 +2516,7 @@ def authorized_changed_paths(
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
             }:
                 identity_deleted_files.extend(
                     {"path": item.get("path"), "deleted": True}
@@ -2465,6 +2564,7 @@ def authorized_changed_paths(
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
                     }
                     else None
                 ),
@@ -2476,6 +2576,7 @@ def authorized_changed_paths(
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
                     }
                     else None
                 ),
@@ -2487,6 +2588,7 @@ def authorized_changed_paths(
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
                     }
                     else None
                 ),
@@ -2497,6 +2599,7 @@ def authorized_changed_paths(
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
                     }
                     else None
                 ),
@@ -2507,6 +2610,7 @@ def authorized_changed_paths(
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
                     }
                     else None
                 ),
@@ -2520,6 +2624,7 @@ def authorized_changed_paths(
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
             } and (
                 not isinstance(
                     receipt_replacement.get("destination_predecessor_class"), str
@@ -2573,6 +2678,7 @@ def authorized_changed_paths(
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
             }:
                 predecessor_issues = _legacy_destination_predecessor_issues(
                     repo,
@@ -3086,6 +3192,7 @@ def authorized_changed_paths(
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7,
             }:
                 exact_unchanged_claims = _validate_legacy_exact_dependents(
                     repo,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1644"
+__version__ = "0.2.1645"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -263,6 +263,12 @@ from .harness.validator_pipeline import (
     repair_nonnegative_amount_reductions,
     repair_source_table_band_scalar_parameters,
 )
+from .legacy_exact_dependent_concepts import (
+    LegacyExactDependentConceptError,
+    canonicalized_concept_replacements,
+    derive_exact_dependent_parameter_replacements,
+    validate_exact_dependent_concept_rewrite,
+)
 from .legacy_replacement import (
     DESTINATION_PREDECESSOR_ABSENT as APPLIED_ENCODING_DESTINATION_PREDECESSOR_ABSENT,
 )
@@ -301,6 +307,9 @@ from .legacy_replacement import (
 )
 from .legacy_replacement import (
     RECEIPT_SCHEMA_V5 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+)
+from .legacy_replacement import (
+    RECEIPT_SCHEMA_V6 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
 )
 from .legacy_replacement import (
     RETAINED_SUCCESSOR_TOOL as APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL,
@@ -8670,6 +8679,7 @@ def _legacy_replacement_pending_paths(
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -8735,6 +8745,7 @@ def _legacy_replacement_pending_paths(
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         } and _legacy_destination_predecessor_issues(
             repo_path,
@@ -8916,6 +8927,7 @@ def _legacy_replacement_pending_paths(
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -22985,6 +22997,7 @@ def _legacy_replacement_manifest_issues(
     if receipt_schema in {
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
     }:
         identity_deleted_files.extend(
@@ -23037,6 +23050,7 @@ def _legacy_replacement_manifest_issues(
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             else None
@@ -23048,6 +23062,7 @@ def _legacy_replacement_manifest_issues(
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             and isinstance(receipt_replacement, dict)
@@ -23063,6 +23078,7 @@ def _legacy_replacement_manifest_issues(
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             and isinstance(receipt_replacement, dict)
@@ -23077,6 +23093,7 @@ def _legacy_replacement_manifest_issues(
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             else None
@@ -23087,6 +23104,7 @@ def _legacy_replacement_manifest_issues(
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             and isinstance(receipt_replacement, dict)
@@ -23108,6 +23126,7 @@ def _legacy_replacement_manifest_issues(
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -23210,6 +23229,7 @@ def _legacy_replacement_manifest_issues(
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }
                 else set()
@@ -23224,6 +23244,7 @@ def _legacy_replacement_manifest_issues(
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }
                 else set()
@@ -23234,6 +23255,7 @@ def _legacy_replacement_manifest_issues(
                 in {
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }
                 else set()
@@ -23279,6 +23301,7 @@ def _legacy_replacement_manifest_issues(
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
     }:
         issues.extend(
@@ -23567,6 +23590,34 @@ def _legacy_replacement_manifest_issues(
     if not isinstance(exact_dependents, list):
         issues.append(f"{manifest_label} exact dependents are malformed")
         exact_dependents = []
+    receipt_retained_modules: list[tuple[Path, Path, bytes, bytes]] = []
+    if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+        for successor in receipt_retained_successors:
+            if not isinstance(successor, dict):
+                continue
+            source_raw = successor.get("source")
+            destination_raw = successor.get("destination")
+            if not isinstance(source_raw, str) or not isinstance(destination_raw, str):
+                continue
+            source_path = Path(source_raw)
+            destination_path = Path(destination_raw)
+            try:
+                source_module_raw = _rulespec_migration_base_blob(
+                    repo_path, base_commit, source_path
+                )
+                destination_module_raw = _rulespec_migration_base_blob(
+                    repo_path, base_commit, destination_path
+                )
+            except RuntimeError:
+                continue
+            receipt_retained_modules.append(
+                (
+                    source_path,
+                    destination_path,
+                    source_module_raw,
+                    destination_module_raw,
+                )
+            )
     seen_exact_primaries: set[str] = set()
     seen_exact_files: set[str] = set()
     for dependent in exact_dependents:
@@ -23579,9 +23630,12 @@ def _legacy_replacement_manifest_issues(
         }
         if receipt_schema in {
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }:
             expected_dependent_fields.add("source_verification_migration")
+        if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+            expected_dependent_fields.add("concept_replacements")
         if (
             not isinstance(dependent, dict)
             or set(dependent) != expected_dependent_fields
@@ -23598,6 +23652,7 @@ def _legacy_replacement_manifest_issues(
             if receipt_schema
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             else None
@@ -23716,6 +23771,7 @@ def _legacy_replacement_manifest_issues(
             legacy_manifest_payload = json.loads(legacy_manifest_raw.decode("utf-8"))
         except (UnicodeError, json.JSONDecodeError, RecursionError):
             legacy_manifest_payload = None
+        base_primary_raw = b""
         try:
             base_primary_raw = _rulespec_migration_base_blob(
                 repo_path, base_commit, primary_path
@@ -23724,6 +23780,37 @@ def _legacy_replacement_manifest_issues(
             base_primary_citations = ()
         else:
             base_primary_citations = _legacy_primary_source_citations(base_primary_raw)
+        exact_authoritative_replacements = authoritative_replacements
+        exact_concept_replacements: dict[str, str] = {}
+        if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+            try:
+                derived_concept_replacements = (
+                    derive_exact_dependent_parameter_replacements(
+                        dependent_primary_raw=base_primary_raw,
+                        retained_modules=receipt_retained_modules,
+                    )
+                )
+            except LegacyExactDependentConceptError as exc:
+                issues.append(
+                    f"{manifest_label} cannot derive exact-dependent concept "
+                    f"rewrites for {primary}: {exc}"
+                )
+                derived_concept_replacements = {}
+            expected_concept_records = [
+                {"from": old, "to": new}
+                for old, new in sorted(derived_concept_replacements.items())
+            ]
+            if dependent.get("concept_replacements") != expected_concept_records:
+                issues.append(
+                    f"{manifest_label} exact-dependent concept rewrite proof "
+                    f"is incomplete or stale for {primary}"
+                )
+            else:
+                exact_concept_replacements = derived_concept_replacements
+                exact_authoritative_replacements = {
+                    **authoritative_replacements,
+                    **exact_concept_replacements,
+                }
         legacy_manifest_issues = _legacy_receipt_v1_manifest_issues(
             legacy_manifest_payload,
             owner_class=legacy.get("owner_class"),
@@ -23768,22 +23855,44 @@ def _legacy_replacement_manifest_issues(
                     required_mode=0o644,
                 )
                 rewritten, counts = rewrite_exact_references(
-                    base_raw, authoritative_replacements
+                    base_raw, exact_authoritative_replacements
                 )
+                if exact_concept_replacements:
+                    path_rewritten, _path_counts = rewrite_exact_references(
+                        base_raw, authoritative_replacements
+                    )
+                    canonical_concepts = canonicalized_concept_replacements(
+                        exact_concept_replacements,
+                        path_replacements=authoritative_replacements,
+                    )
+                    concept_rewritten, _concept_counts = rewrite_exact_references(
+                        path_rewritten,
+                        canonical_concepts,
+                    )
+                    if concept_rewritten != rewritten:
+                        raise ValueError(
+                            "exact-dependent concept rewrite is not order-independent"
+                        )
+                    validate_exact_dependent_concept_rewrite(
+                        path_rewritten_raw=path_rewritten,
+                        concept_rewritten_raw=concept_rewritten,
+                        replacements=canonical_concepts,
+                        primary=path == primary_path,
+                    )
                 source_verification_migration = None
                 if path == primary_path and receipt_schema in {
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }:
                     rewritten, source_verification_migration = (
                         _migrate_legacy_exact_dependent_source_verification(rewritten)
                     )
                 proof_excerpt_reanchors: tuple[dict[str, object], ...] = ()
-                if (
-                    path == primary_path
-                    and receipt_schema
-                    == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
-                ):
+                if path == primary_path and receipt_schema in {
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+                }:
                     receipt_rewrite = rewrite_by_path.get(path)
                     raw_reanchors = (
                         receipt_rewrite.get("proof_excerpt_reanchors")
@@ -23923,7 +24032,10 @@ def _legacy_replacement_manifest_issues(
                     "replacements",
                     "proof_import_repairs",
                 }
-                if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+                if receipt_schema in {
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+                }:
                     expected_rewrite_fields.add("proof_excerpt_reanchors")
                 if (
                     not isinstance(rewrite, dict)
@@ -23934,7 +24046,10 @@ def _legacy_replacement_manifest_issues(
                     or rewrite.get("proof_import_repairs") != proof_import_repairs
                     or (
                         receipt_schema
-                        == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+                        in {
+                            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+                        }
                         and rewrite.get("proof_excerpt_reanchors")
                         != list(proof_excerpt_reanchors)
                     )
@@ -23959,6 +24074,7 @@ def _legacy_replacement_manifest_issues(
             receipt_schema
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             and receipt_source_verification_migration is not None
@@ -24522,6 +24638,7 @@ def _legacy_exact_dependent_manifest_issues(
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -24693,6 +24810,7 @@ def _legacy_retained_successor_manifest_issues(
         not in {
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -27403,6 +27521,42 @@ def _resolve_legacy_replacement_contract(
             dependent_manifest_raw,
         )
 
+    retained_modules = tuple(
+        (
+            successor.source,
+            successor.destination,
+            next(
+                item.raw
+                for item in successor.legacy_files
+                if item.path == successor.source
+            ),
+            next(
+                item.raw
+                for item in successor.successor_files
+                if item.path == successor.destination
+            ),
+        )
+        for successor in retained_successors
+    )
+    exact_concept_replacements: dict[Path, dict[str, str]] = {}
+    for primary, files in exact_legacy_files.items():
+        primary_raw = next(item.raw for item in files if item.path == primary)
+        concept_replacements = derive_exact_dependent_parameter_replacements(
+            dependent_primary_raw=primary_raw,
+            retained_modules=retained_modules,
+        )
+        conflicts = {
+            old
+            for old, new in concept_replacements.items()
+            if old in replacements and replacements[old] != new
+        }
+        if conflicts:
+            raise ValueError(
+                "legacy exact-dependent concept rewrites conflict with path "
+                "rewrites: " + ", ".join(sorted(conflicts))
+            )
+        exact_concept_replacements[primary] = concept_replacements
+
     pending_by_primary: dict[Path, list[_LegacyReplacementPendingFile]] = {
         primary: [] for primary in scheduled_groups
     }
@@ -27480,10 +27634,42 @@ def _resolve_legacy_replacement_contract(
             max_bytes=16 * 1024 * 1024,
             required_mode=0o644,
         )
-        rewritten, counts = rewrite_exact_references(raw, replacements)
+        dependent_primary = dependent_owner.get(relative)
+        file_replacements = replacements
+        concept_replacements: dict[str, str] = {}
+        if dependent_primary is not None and dependent_primary in exact_groups:
+            concept_replacements = exact_concept_replacements.get(dependent_primary, {})
+            file_replacements = {**replacements, **concept_replacements}
+        rewritten, counts = rewrite_exact_references(raw, file_replacements)
+        if concept_replacements:
+            path_rewritten, _path_counts = rewrite_exact_references(raw, replacements)
+            canonical_concepts = canonicalized_concept_replacements(
+                concept_replacements,
+                path_replacements=replacements,
+            )
+            concept_rewritten, _concept_counts = rewrite_exact_references(
+                path_rewritten,
+                canonical_concepts,
+            )
+            if concept_rewritten != rewritten:
+                raise ValueError(
+                    "legacy exact-dependent concept rewrite is not order-independent "
+                    f"for {relative}"
+                )
+            try:
+                validate_exact_dependent_concept_rewrite(
+                    path_rewritten_raw=path_rewritten,
+                    concept_rewritten_raw=concept_rewritten,
+                    replacements=canonical_concepts,
+                    primary=relative == dependent_primary,
+                )
+            except LegacyExactDependentConceptError as exc:
+                raise ValueError(
+                    "legacy exact-dependent concept rewrite is unsafe for "
+                    f"{relative}: {exc}"
+                ) from exc
         _source_verification_migration = None
         proof_excerpt_reanchors: tuple[dict[str, object], ...] = ()
-        dependent_primary = dependent_owner.get(relative)
         if (
             dependent_primary is not None
             and dependent_primary in exact_groups
@@ -27641,6 +27827,10 @@ def _resolve_legacy_replacement_contract(
                 legacy_files=exact_legacy_files[primary],
                 live_files=live_files,
                 rewrites=tuple(exact_rewrites_by_primary[primary]),
+                concept_replacements=tuple(
+                    {"from": old, "to": new}
+                    for old, new in sorted(exact_concept_replacements[primary].items())
+                ),
                 source_verification_migration=primary_source_migration,
             )
         )
@@ -49338,6 +49528,7 @@ def _build_apply_validation_snapshot(
                         {"path": item.path.as_posix(), "sha256": item.sha256}
                         for item in dependent.live_files
                     ],
+                    "concept_replacements": list(dependent.concept_replacements),
                     "source_verification_migration": (
                         {
                             "legacy_corpus_citation_paths": list(
@@ -49893,6 +50084,7 @@ def _stage_signed_legacy_replacement_provenance(
                 {"path": item.path.as_posix(), "sha256": item.sha256}
                 for item in dependent.live_files
             ],
+            "concept_replacements": list(dependent.concept_replacements),
             "source_verification_migration": (
                 {
                     "legacy_corpus_citation_paths": list(

--- a/src/axiom_encode/legacy_exact_dependent_concepts.py
+++ b/src/axiom_encode/legacy_exact_dependent_concepts.py
@@ -1,0 +1,479 @@
+"""Authenticated concept rewrites for legacy exact-dependent migrations."""
+
+from __future__ import annotations
+
+import copy
+import re
+from datetime import date, timedelta
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import yaml
+
+from .rulespec_path_migration import rulespec_identity
+
+_CONCEPT_NAME = re.compile(r"[a-z][a-z0-9_]*")
+_NUMERIC_LITERAL = re.compile(r"[+-]?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?")
+_IDENTIFIER_CHARACTER = "A-Za-z0-9_"
+
+
+class LegacyExactDependentConceptError(ValueError):
+    """Raised when a concept rewrite cannot be proved behavior-preserving."""
+
+
+def _load_mapping(raw: bytes, *, label: str) -> dict[str, object]:
+    try:
+        payload = yaml.safe_load(raw.decode("utf-8"))
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise LegacyExactDependentConceptError(
+            f"{label} is not valid UTF-8 YAML"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise LegacyExactDependentConceptError(f"{label} is not a YAML mapping")
+    return payload
+
+
+def _rules_by_name(payload: Mapping[str, object]) -> dict[str, dict[str, object]]:
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return {}
+    result: dict[str, dict[str, object]] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = rule.get("name")
+        if not isinstance(name, str) or _CONCEPT_NAME.fullmatch(name) is None:
+            continue
+        if name in result:
+            raise LegacyExactDependentConceptError(
+                f"RuleSpec module exports duplicate concept {name!r}"
+            )
+        result[name] = rule
+    return result
+
+
+def _parse_date(value: object, *, label: str) -> date:
+    if not isinstance(value, str):
+        raise LegacyExactDependentConceptError(f"{label} is not an ISO date")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise LegacyExactDependentConceptError(f"{label} is not an ISO date") from exc
+
+
+def _formula_segments(formula: str) -> tuple[tuple[bool, str], ...]:
+    """Split formula text into unquoted and quoted segments without parsing it."""
+
+    segments: list[tuple[bool, str]] = []
+    start = 0
+    index = 0
+    quote: str | None = None
+    while index < len(formula):
+        character = formula[index]
+        if quote is None:
+            if character in {'"', "'"}:
+                if start < index:
+                    segments.append((True, formula[start:index]))
+                start = index
+                quote = character
+            index += 1
+            continue
+        if character == "\\":
+            index = min(index + 2, len(formula))
+            continue
+        if character == quote:
+            if index + 1 < len(formula) and formula[index + 1] == quote:
+                index += 2
+                continue
+            index += 1
+            segments.append((False, formula[start:index]))
+            start = index
+            quote = None
+            continue
+        index += 1
+    if start < len(formula):
+        segments.append((quote is None, formula[start:]))
+    return tuple(segments)
+
+
+def _formula_mentions(formula: object, concept: str) -> bool:
+    if not isinstance(formula, str):
+        return False
+    pattern = re.compile(
+        rf"(?<![{_IDENTIFIER_CHARACTER}]){re.escape(concept)}"
+        rf"(?![{_IDENTIFIER_CHARACTER}])"
+    )
+    return any(
+        unquoted and pattern.search(segment) is not None
+        for unquoted, segment in _formula_segments(formula)
+    )
+
+
+def _dependent_use_windows(
+    payload: Mapping[str, object], concept: str
+) -> tuple[tuple[date, date], ...]:
+    rules = payload.get("rules")
+    windows: list[tuple[date, date]] = []
+    if not isinstance(rules, list):
+        return ()
+    for rule_index, rule in enumerate(rules):
+        versions = rule.get("versions") if isinstance(rule, dict) else None
+        if not isinstance(versions, list):
+            continue
+        for version_index, version in enumerate(versions):
+            if not isinstance(version, dict) or not _formula_mentions(
+                version.get("formula"), concept
+            ):
+                continue
+            start = _parse_date(
+                version.get("effective_from"),
+                label=(
+                    f"dependent rule[{rule_index}].versions[{version_index}]"
+                    ".effective_from"
+                ),
+            )
+            end_raw = version.get("effective_to")
+            end = (
+                _parse_date(
+                    end_raw,
+                    label=(
+                        f"dependent rule[{rule_index}].versions[{version_index}]"
+                        ".effective_to"
+                    ),
+                )
+                if end_raw is not None
+                else date.max
+            )
+            if end < start:
+                raise LegacyExactDependentConceptError(
+                    f"dependent concept {concept!r} has an inverted use window"
+                )
+            windows.append((start, end))
+    return tuple(sorted(set(windows)))
+
+
+def _parameter_versions(
+    rule: Mapping[str, object], *, concept: str
+) -> tuple[tuple[date, date | None, Decimal], ...]:
+    if rule.get("kind") != "parameter" or rule.get("indexed_by") is not None:
+        raise LegacyExactDependentConceptError(
+            f"legacy concept {concept!r} is not a scalar parameter"
+        )
+    versions = rule.get("versions")
+    if not isinstance(versions, list) or not versions:
+        raise LegacyExactDependentConceptError(f"parameter {concept!r} has no versions")
+    parsed: list[tuple[date, date | None, Decimal]] = []
+    for index, version in enumerate(versions):
+        if not isinstance(version, dict):
+            raise LegacyExactDependentConceptError(
+                f"parameter {concept!r} version {index} is malformed"
+            )
+        formula = version.get("formula")
+        formula_text = str(formula).strip() if isinstance(formula, (str, int)) else ""
+        if _NUMERIC_LITERAL.fullmatch(formula_text) is None:
+            raise LegacyExactDependentConceptError(
+                f"parameter {concept!r} version {index} is not a numeric literal"
+            )
+        try:
+            value = Decimal(formula_text)
+        except InvalidOperation as exc:
+            raise LegacyExactDependentConceptError(
+                f"parameter {concept!r} version {index} is not numeric"
+            ) from exc
+        start = _parse_date(
+            version.get("effective_from"),
+            label=f"parameter {concept!r} version {index} effective_from",
+        )
+        end_raw = version.get("effective_to")
+        if end_raw is not None:
+            raise LegacyExactDependentConceptError(
+                f"parameter {concept!r} version {index} uses effective_to, which "
+                "cannot be proved by the scalar-parameter runtime contract"
+            )
+        end = (
+            _parse_date(
+                end_raw,
+                label=f"parameter {concept!r} version {index} effective_to",
+            )
+            if end_raw is not None
+            else None
+        )
+        if end is not None and end < start:
+            raise LegacyExactDependentConceptError(
+                f"parameter {concept!r} version {index} has an inverted period"
+            )
+        parsed.append((start, end, value))
+    if [item[0] for item in parsed] != sorted(item[0] for item in parsed):
+        raise LegacyExactDependentConceptError(
+            f"parameter {concept!r} versions are not ordered"
+        )
+    return tuple(parsed)
+
+
+def _active_parameter_value(
+    versions: Sequence[tuple[date, date | None, Decimal]], at: date
+) -> Decimal | None:
+    active: Decimal | None = None
+    for start, end, value in versions:
+        if start <= at and (end is None or at <= end):
+            active = value
+    return active
+
+
+def _parameters_equal_over_windows(
+    old_versions: Sequence[tuple[date, date | None, Decimal]],
+    new_versions: Sequence[tuple[date, date | None, Decimal]],
+    windows: Sequence[tuple[date, date]],
+) -> bool:
+    for window_start, window_end in windows:
+        probes = {window_start, window_end}
+        for versions in (old_versions, new_versions):
+            for start, end, _value in versions:
+                if window_start <= start <= window_end:
+                    probes.add(start)
+                if end is not None and end < date.max:
+                    after = end + timedelta(days=1)
+                    if window_start <= after <= window_end:
+                        probes.add(after)
+        for probe in probes:
+            old_value = _active_parameter_value(old_versions, probe)
+            new_value = _active_parameter_value(new_versions, probe)
+            if old_value is None or new_value is None or old_value != new_value:
+                return False
+    return True
+
+
+def _compatible_parameter_surface(
+    old_rule: Mapping[str, object], new_rule: Mapping[str, object]
+) -> bool:
+    return all(
+        old_rule.get(field) == new_rule.get(field)
+        for field in ("kind", "dtype", "entity", "unit", "period", "indexed_by")
+    )
+
+
+def derive_exact_dependent_parameter_replacements(
+    *,
+    dependent_primary_raw: bytes,
+    retained_modules: Sequence[tuple[Path, Path, bytes, bytes]],
+) -> dict[str, str]:
+    """Derive unique active-period-equivalent parameter renames.
+
+    The returned mapping is intentionally suitable for the existing exact-token
+    replacement ledger: it contains the full legacy import reference and the bare
+    formula symbol. No mapping is emitted when the canonical successor preserves
+    the old fragment.
+    """
+
+    dependent = _load_mapping(dependent_primary_raw, label="legacy exact dependent")
+    imports = dependent.get("imports")
+    if imports is None:
+        return {}
+    if not isinstance(imports, list) or not all(
+        isinstance(item, str) for item in imports
+    ):
+        raise LegacyExactDependentConceptError(
+            "legacy exact dependent imports are malformed"
+        )
+    dependent_rules = _rules_by_name(dependent)
+
+    replacements: dict[str, str] = {}
+    destination_fragments: set[str] = set()
+    for source_path, destination_path, source_raw, destination_raw in retained_modules:
+        source_base = rulespec_identity(source_path)
+        destination_base = rulespec_identity(destination_path)
+        source_rules = _rules_by_name(
+            _load_mapping(source_raw, label=f"retained legacy module {source_path}")
+        )
+        destination_rules = _rules_by_name(
+            _load_mapping(
+                destination_raw,
+                label=f"retained canonical module {destination_path}",
+            )
+        )
+        for imported in imports:
+            prefix = f"{source_base}#"
+            if not imported.startswith(prefix):
+                continue
+            old_name = imported.removeprefix(prefix)
+            if _CONCEPT_NAME.fullmatch(old_name) is None:
+                raise LegacyExactDependentConceptError(
+                    f"legacy imported concept {imported!r} is malformed"
+                )
+            same_fragment_imports = [
+                item for item in imports if item.rsplit("#", 1)[-1] == old_name
+            ]
+            if same_fragment_imports != [imported] or old_name in dependent_rules:
+                raise LegacyExactDependentConceptError(
+                    f"legacy concept {old_name!r} is not an unambiguous imported symbol"
+                )
+            if old_name in destination_rules:
+                continue
+            old_rule = source_rules.get(old_name)
+            if old_rule is None:
+                raise LegacyExactDependentConceptError(
+                    f"legacy import {imported!r} is not exported by its source module"
+                )
+            windows = _dependent_use_windows(dependent, old_name)
+            if not windows:
+                raise LegacyExactDependentConceptError(
+                    f"retired imported concept {imported!r} has no formula use window"
+                )
+            old_versions = _parameter_versions(old_rule, concept=old_name)
+            candidates: list[str] = []
+            for new_name, new_rule in destination_rules.items():
+                if not _compatible_parameter_surface(old_rule, new_rule):
+                    continue
+                try:
+                    new_versions = _parameter_versions(new_rule, concept=new_name)
+                except LegacyExactDependentConceptError as exc:
+                    if "uses effective_to" in str(exc):
+                        raise
+                    continue
+                if _parameters_equal_over_windows(old_versions, new_versions, windows):
+                    candidates.append(new_name)
+            if len(candidates) != 1:
+                detail = "none" if not candidates else ", ".join(sorted(candidates))
+                raise LegacyExactDependentConceptError(
+                    "retired imported parameter has no unique active-period-equivalent "
+                    f"canonical successor: {imported!r}; candidates: {detail}"
+                )
+            new_name = candidates[0]
+            destination_import = f"{destination_base}#{new_name}"
+            if any(
+                item == destination_import or item.rsplit("#", 1)[-1] == new_name
+                for item in imports
+            ):
+                raise LegacyExactDependentConceptError(
+                    f"canonical concept {new_name!r} is already imported"
+                )
+            if old_name in replacements and replacements[old_name] != new_name:
+                raise LegacyExactDependentConceptError(
+                    f"legacy concept {old_name!r} has conflicting canonical successors"
+                )
+            if new_name in destination_fragments:
+                raise LegacyExactDependentConceptError(
+                    "multiple retired concepts would collapse into one imported "
+                    f"successor {new_name!r}"
+                )
+            destination_fragments.add(new_name)
+            replacements[imported] = destination_import
+            replacements[old_name] = new_name
+    return replacements
+
+
+def canonicalized_concept_replacements(
+    replacements: Mapping[str, str],
+    *,
+    path_replacements: Mapping[str, str],
+) -> dict[str, str]:
+    """Translate full legacy refs so they apply after path-only rewriting."""
+
+    canonical: dict[str, str] = {}
+    for old, new in replacements.items():
+        canonical_old = old
+        for path_old in sorted(path_replacements, key=lambda item: (-len(item), item)):
+            if canonical_old == path_old or canonical_old.startswith(f"{path_old}#"):
+                canonical_old = (
+                    path_replacements[path_old] + canonical_old[len(path_old) :]
+                )
+                break
+        canonical[canonical_old] = new
+    return canonical
+
+
+def _replace_identifier(text: str, old: str, new: str) -> str:
+    pattern = re.compile(
+        rf"(?<![{_IDENTIFIER_CHARACTER}]){re.escape(old)}"
+        rf"(?![{_IDENTIFIER_CHARACTER}])"
+    )
+    return "".join(
+        pattern.sub(lambda _match: new, segment) if unquoted else segment
+        for unquoted, segment in _formula_segments(text)
+    )
+
+
+def _expected_primary_payload(
+    payload: dict[str, object], replacements: Mapping[str, str]
+) -> dict[str, object]:
+    expected = copy.deepcopy(payload)
+    full = {old: new for old, new in replacements.items() if "#" in old}
+    bare = {old: new for old, new in replacements.items() if "#" not in old}
+    imports = expected.get("imports")
+    if isinstance(imports, list):
+        expected["imports"] = [full.get(item, item) for item in imports]
+    rules = expected.get("rules")
+    if isinstance(rules, list):
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            versions = rule.get("versions")
+            if isinstance(versions, list):
+                for version in versions:
+                    formula = (
+                        version.get("formula") if isinstance(version, dict) else None
+                    )
+                    if not isinstance(formula, str):
+                        continue
+                    for old, new in bare.items():
+                        formula = _replace_identifier(formula, old, new)
+                    version["formula"] = formula
+            metadata = rule.get("metadata")
+            proof = metadata.get("proof") if isinstance(metadata, dict) else None
+            atoms = proof.get("atoms") if isinstance(proof, dict) else None
+            if not isinstance(atoms, list):
+                continue
+            for atom in atoms:
+                imported = atom.get("import") if isinstance(atom, dict) else None
+                target = imported.get("target") if isinstance(imported, dict) else None
+                if isinstance(target, str) and target in full:
+                    imported["target"] = full[target]
+                output = imported.get("output") if isinstance(imported, dict) else None
+                if isinstance(output, str) and output in bare:
+                    imported["output"] = bare[output]
+    return expected
+
+
+def _replace_test_mapping_keys(value: object, full: Mapping[str, str]) -> object:
+    if isinstance(value, dict):
+        return {
+            full.get(key, key)
+            if isinstance(key, str)
+            else key: _replace_test_mapping_keys(item, full)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_replace_test_mapping_keys(item, full) for item in value]
+    return value
+
+
+def validate_exact_dependent_concept_rewrite(
+    *,
+    path_rewritten_raw: bytes,
+    concept_rewritten_raw: bytes,
+    replacements: Mapping[str, str],
+    primary: bool,
+) -> None:
+    """Reject concept substitutions outside imports, formulas, proof imports, and tests."""
+
+    try:
+        before = yaml.safe_load(path_rewritten_raw.decode("utf-8"))
+        after = yaml.safe_load(concept_rewritten_raw.decode("utf-8"))
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise LegacyExactDependentConceptError(
+            "exact-dependent concept rewrite produced invalid YAML"
+        ) from exc
+    if primary:
+        if not isinstance(before, dict):
+            raise LegacyExactDependentConceptError(
+                "exact-dependent primary is not a YAML mapping"
+            )
+        expected: object = _expected_primary_payload(before, replacements)
+    else:
+        full = {old: new for old, new in replacements.items() if "#" in old}
+        expected = _replace_test_mapping_keys(before, full)
+    if after != expected:
+        raise LegacyExactDependentConceptError(
+            "exact-dependent concept rewrite changed an unauthorized YAML surface"
+        )

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -34,7 +34,8 @@ RECEIPT_SCHEMA_V2: Final = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 RECEIPT_SCHEMA_V3: Final = "axiom-encode/legacy-fresh-reencode-receipt/v3"
 RECEIPT_SCHEMA_V4: Final = "axiom-encode/legacy-fresh-reencode-receipt/v4"
 RECEIPT_SCHEMA_V5: Final = "axiom-encode/legacy-fresh-reencode-receipt/v5"
-RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v6"
+RECEIPT_SCHEMA_V6: Final = "axiom-encode/legacy-fresh-reencode-receipt/v6"
+RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v7"
 RECEIPT_DIR: Final = ".axiom/legacy-replacements"
 DESTINATION_PREDECESSOR_ABSENT: Final = "absent"
 DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE: Final = (
@@ -156,6 +157,7 @@ class LegacyReplacementExactDependent(NamedTuple):
     legacy_files: tuple[LegacyReplacementFile, ...]
     live_files: tuple[LegacyReplacementFile, ...]
     rewrites: tuple[LegacyReplacementRewrite, ...]
+    concept_replacements: tuple[dict[str, str], ...] = ()
     source_verification_migration: (
         LegacyReplacementSourceVerificationMigration | None
     ) = None

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1644"
+ENCODER_VERSION = "0.2.1645"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14864,16 +14864,47 @@ class TestCmdEncode:
             successor = checkout / f"us-la/statutes/47/{section}.yaml"
             legacy.parent.mkdir(parents=True, exist_ok=True)
             successor.parent.mkdir(parents=True, exist_ok=True)
+            legacy_rules = (
+                "rules:\n"
+                "  - name: later_low_income_percentage\n"
+                "    kind: parameter\n"
+                "    dtype: Rate\n"
+                "    versions:\n"
+                "      - effective_from: '0001-01-01'\n"
+                "        formula: '0.50'\n"
+                if section == 297
+                else "rules: []\n"
+            )
+            successor_rules = (
+                "rules:\n"
+                "  - name: low_income_percentage\n"
+                "    kind: parameter\n"
+                "    dtype: Rate\n"
+                "    versions:\n"
+                "      - effective_from: '2006-01-01'\n"
+                "        formula: '0.25'\n"
+                "      - effective_from: '2007-01-01'\n"
+                "        formula: '0.50'\n"
+                if section == 297
+                else "rules: []\n"
+            )
             legacy.write_text(
                 "format: rulespec/v1\n"
                 "module:\n"
                 "  source_verification:\n"
                 "    corpus_citation_path: us-la/statute/47/32\n"
                 f"    source_sha256: {source_attestation['source_sha256']}\n"
-                "rules: []\n"
+                f"{legacy_rules}"
             )
             legacy.with_name(f"47:{section}.test.yaml").write_text("[]\n")
-            successor.write_bytes(legacy.read_bytes())
+            successor.write_text(
+                "format: rulespec/v1\n"
+                "module:\n"
+                "  source_verification:\n"
+                "    corpus_citation_path: us-la/statute/47/32\n"
+                f"    source_sha256: {source_attestation['source_sha256']}\n"
+                f"{successor_rules}"
+            )
             successor.with_name(f"{section}.test.yaml").write_text("[]\n")
             retained_pairs.append(
                 (legacy.relative_to(checkout), successor.relative_to(checkout))
@@ -14902,6 +14933,7 @@ class TestCmdEncode:
             "    required: true\n"
             "imports:\n"
             "  - us-la:statutes/47:32#amount\n"
+            "  - us-la:statutes/47:297#later_low_income_percentage\n"
             "rules:\n"
             "  - name: liability\n"
             "    kind: derived\n"
@@ -14917,13 +14949,20 @@ class TestCmdEncode:
             "              output: amount\n"
             f"              hash: sha256:{source_before_sha256}\n"
             "          - path: versions[0].formula\n"
+            "            kind: import\n"
+            "            import:\n"
+            "              target: us-la:statutes/47:297#later_low_income_percentage\n"
+            "              output: later_low_income_percentage\n"
+            f"              hash: sha256:{_sha256_file(checkout / 'us-la/statutes/47:297.yaml')}\n"
+            "          - path: versions[0].formula\n"
             "            kind: parameter\n"
             "            source:\n"
             "              corpus_citation_path: us-la/statute/47/32\n"
             "              excerpt: Enter on Line 3 the Louisiana estimated standard deduction\n"
             "    versions:\n"
             "      - effective_from: '2026-01-01'\n"
-            "        formula: amount\n"
+            "        effective_to: '2026-12-31'\n"
+            "        formula: amount * later_low_income_percentage\n"
         )
         dependent_test.write_text("[]\n")
         second_dependent.parent.mkdir(parents=True, exist_ok=True)
@@ -15307,6 +15346,8 @@ class TestCmdEncode:
         for overlay_bytes in observed_overlay["bytes"]:
             assert b"us-la:statutes/47/32#amount" in overlay_bytes
             assert b"us-la:statutes/47:32#amount" not in overlay_bytes
+            assert b"us-la:statutes/47/297#low_income_percentage" in overlay_bytes
+            assert b"later_low_income_percentage" not in overlay_bytes
             assert f"hash: sha256:{_sha256_file(generated)}".encode() in overlay_bytes
             assert b"    corpus_citation_paths:\n" not in overlay_bytes
             assert b"    corpus_citation_path: us-la/statute/47/32\n" in overlay_bytes
@@ -15440,6 +15481,8 @@ class TestCmdEncode:
         assert destination.exists()
         assert destination_test.exists()
         assert b"us-la:statutes/47/32#amount" in dependent.read_bytes()
+        assert b"us-la:statutes/47/297#low_income_percentage" in dependent.read_bytes()
+        assert b"later_low_income_percentage" not in dependent.read_bytes()
         assert b"    corpus_citation_paths:\n" not in dependent.read_bytes()
         assert (
             b"    corpus_citation_path: us-la/statute/47/32\n" in dependent.read_bytes()
@@ -15453,6 +15496,11 @@ class TestCmdEncode:
         assert dependent_test.read_bytes() == dependent_test_before
         assert dependent_manifest.read_bytes() != dependent_manifest_before
         assert b"us-la:statutes/47/32#amount" in second_dependent.read_bytes()
+        assert (
+            b"us-la:statutes/47/297#low_income_percentage"
+            in second_dependent.read_bytes()
+        )
+        assert b"later_low_income_percentage" not in second_dependent.read_bytes()
         assert (
             f"hash: sha256:{_sha256_file(destination)}".encode()
             in second_dependent.read_bytes()
@@ -15492,7 +15540,7 @@ class TestCmdEncode:
         outer = json.loads(destination_manifest.read_text())
         receipt_path = checkout / outer["replacement"]["receipt_path"]
         receipt = json.loads(receipt_path.read_text())
-        assert receipt["schema_version"].endswith("/v6")
+        assert receipt["schema_version"].endswith("/v7")
         assert len(receipt["replacement"]["retained_successors"]) == 4
         assert {
             item["destination"]
@@ -15542,11 +15590,33 @@ class TestCmdEncode:
         }
         exact = exact_by_primary[dependent_relative.as_posix()]
         assert exact["primary"] == dependent_relative.as_posix()
-        assert exact["rewrites"][0]["proof_import_repairs"] == 1
+        exact_replacement_map = {
+            replacement["from"]: replacement["to"]
+            for rewrite in exact["rewrites"]
+            for replacement in rewrite["replacements"]
+        }
+        assert (
+            exact_replacement_map["us-la:statutes/47:297#later_low_income_percentage"]
+            == "us-la:statutes/47/297#low_income_percentage"
+        )
+        assert exact_replacement_map["later_low_income_percentage"] == (
+            "low_income_percentage"
+        )
+        assert exact["concept_replacements"] == [
+            {
+                "from": "later_low_income_percentage",
+                "to": "low_income_percentage",
+            },
+            {
+                "from": "us-la:statutes/47:297#later_low_income_percentage",
+                "to": "us-la:statutes/47/297#low_income_percentage",
+            },
+        ]
+        assert exact["rewrites"][0]["proof_import_repairs"] == 2
         assert exact["rewrites"][0]["proof_excerpt_reanchors"] == [
             {
                 "rule": "liability",
-                "atom_index": 1,
+                "atom_index": 2,
                 "field": "excerpt",
                 "corpus_citation_path": "us-la/statute/47/32",
                 "before": (
@@ -15688,10 +15758,17 @@ class TestCmdEncode:
             path: path.read_bytes() for path in persisted_manifests[1:]
         }
 
-        def rebind_linked_manifests(receipt_sha256: str) -> None:
+        def rebind_linked_manifests(
+            receipt_sha256: str,
+            receipt_relative: Path | None = None,
+        ) -> None:
             for path, original in linked_manifest_bytes.items():
                 payload = json.loads(original)
                 payload["legacy_migration"]["receipt_sha256"] = receipt_sha256
+                if receipt_relative is not None:
+                    payload["legacy_migration"]["receipt_path"] = (
+                        receipt_relative.as_posix()
+                    )
                 _sign_applied_encoding_manifest(
                     payload,
                     TEST_APPLY_SIGNING_BROKER,
@@ -15745,6 +15822,115 @@ class TestCmdEncode:
             )
         destination_manifest.write_bytes(outer_before_tamper)
         receipt_path.write_bytes(receipt_before_tamper)
+        restore_linked_manifests()
+
+        tampered_receipt = copy.deepcopy(receipt)
+        tampered_exact = tampered_receipt["replacement"]["exact_dependents"][0]
+        removed_concept_sources = {
+            record["from"] for record in tampered_exact["concept_replacements"]
+        }
+        tampered_exact["concept_replacements"] = []
+        for rewrite in tampered_exact["rewrites"]:
+            rewrite["replacements"] = [
+                record
+                for record in rewrite["replacements"]
+                if record["from"] not in removed_concept_sources
+            ]
+        _sign_applied_encoding_manifest(
+            tampered_receipt,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        from axiom_encode.legacy_replacement import (
+            receipt_identity_payload,
+            receipt_identity_sha256,
+        )
+
+        tampered_replacement = tampered_receipt["replacement"]
+        tampered_legacy = tampered_receipt["legacy"]
+        tampered_live_paths = {
+            item["path"] for item in tampered_replacement["live_files"]
+        }
+        tampered_deleted_files = [
+            {"path": item["path"], "deleted": True}
+            for item in tampered_legacy["files"]
+            if item["path"] not in tampered_live_paths
+        ]
+        tampered_deleted_files.extend(
+            {"path": item["path"], "deleted": True}
+            for successor in tampered_replacement["retained_successors"]
+            for item in successor["legacy_files"]
+        )
+        tampered_identity = receipt_identity_payload(
+            base_commit=tampered_receipt["repository"]["base_commit"],
+            base_tree=tampered_receipt["repository"]["base_tree"],
+            legacy_manifest_sha256=tampered_legacy["manifest"]["sha256"],
+            model_manifest_sha256=tampered_replacement["model_manifest_sha256"],
+            live_files=tampered_replacement["live_files"],
+            deleted_files=tampered_deleted_files,
+            rewrites=tampered_replacement["rewrites"],
+            scheduled_dependents=tampered_replacement["scheduled_dependents"],
+            exact_dependents=tampered_replacement["exact_dependents"],
+            destination_predecessor_class=tampered_replacement[
+                "destination_predecessor_class"
+            ],
+            destination_predecessor_files=tampered_replacement[
+                "destination_predecessor_files"
+            ],
+            retained_successors=tampered_replacement["retained_successors"],
+            metadata_reconciliations=tampered_replacement["metadata_reconciliations"],
+        )
+        tampered_receipt_relative = receipt_path.relative_to(checkout).with_name(
+            f"{receipt_identity_sha256(tampered_identity)}.json"
+        )
+        tampered_receipt_path = checkout / tampered_receipt_relative
+        receipt_path.unlink()
+        tampered_receipt_path.write_text(
+            json.dumps(tampered_receipt, indent=2, sort_keys=True) + "\n"
+        )
+        tampered_receipt_sha256 = hashlib.sha256(
+            tampered_receipt_path.read_bytes()
+        ).hexdigest()
+        tampered_outer = copy.deepcopy(outer)
+        tampered_outer["replacement"]["receipt_path"] = (
+            tampered_receipt_relative.as_posix()
+        )
+        tampered_outer["replacement"]["receipt_sha256"] = tampered_receipt_sha256
+        _sign_applied_encoding_manifest(
+            tampered_outer,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        destination_manifest.write_text(
+            json.dumps(tampered_outer, indent=2, sort_keys=True) + "\n"
+        )
+        rebind_linked_manifests(
+            tampered_receipt_sha256,
+            tampered_receipt_relative,
+        )
+        _verified, _root, _digest, issues = (
+            _load_verified_applied_encoding_manifest_payload(
+                checkout,
+                destination_manifest.relative_to(checkout).as_posix(),
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+                expected_waiver_set_sha256=post_migration_waiver_sha256,
+                expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+                local_corpus_release=release,
+            )
+        )
+        assert any(
+            "concept rewrite proof is incomplete or stale" in issue for issue in issues
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+            ),
+            pytest.raises(ValueError, match="concept rewrite proof differs"),
+        ):
+            authorized_changed_paths(checkout, corpus_root=corpus_path)
+
+        tampered_receipt_path.unlink()
+        receipt_path.write_bytes(receipt_before_tamper)
+        destination_manifest.write_bytes(outer_before_tamper)
         restore_linked_manifests()
 
         tampered_receipt = copy.deepcopy(receipt)

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1644"
+ENCODER_VERSION = "0.2.1645"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1644"
+ENCODER_VERSION = "0.2.1645"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_exact_dependent_concepts.py
+++ b/tests/test_legacy_exact_dependent_concepts.py
@@ -1,0 +1,273 @@
+from pathlib import Path
+
+import pytest
+
+from axiom_encode.legacy_exact_dependent_concepts import (
+    LegacyExactDependentConceptError,
+    canonicalized_concept_replacements,
+    derive_exact_dependent_parameter_replacements,
+    validate_exact_dependent_concept_rewrite,
+)
+from axiom_encode.rulespec_path_migration import rewrite_exact_references
+
+LEGACY_PATH = Path("us-la/statutes/47:297/4.yaml")
+SUCCESSOR_PATH = Path("us-la/statutes/47/297/4.yaml")
+
+
+def _legacy_parameter() -> bytes:
+    return b"""format: rulespec/v1
+rules:
+  - name: later_low_income_unreduced_federal_credit_percentage
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '0001-01-01'
+        formula: '0.50'
+"""
+
+
+def _successor_parameter(*, duplicate: bool = False) -> bytes:
+    duplicate_rule = (
+        """
+  - name: other_low_income_percentage
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2007-01-01'
+        formula: '0.50'
+"""
+        if duplicate
+        else ""
+    )
+    return f"""format: rulespec/v1
+rules:
+  - name: low_income_unreduced_federal_credit_percentage
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2006-01-01'
+        formula: '0.25'
+      - effective_from: '2007-01-01'
+        formula: '0.50'
+{duplicate_rule}""".encode()
+
+
+def _dependent(*, year: int = 2026, source_note: str = "") -> bytes:
+    return f"""format: rulespec/v1
+module:
+  summary: {source_note or "Exact dependent"}
+imports:
+  - us-la:statutes/47:297/4#later_low_income_unreduced_federal_credit_percentage
+rules:
+  - name: nominal_child_care_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '{year}-01-01'
+        effective_to: '{year}-12-31'
+        formula: amount * later_low_income_unreduced_federal_credit_percentage
+""".encode()
+
+
+def _retained_modules(*, duplicate: bool = False):
+    return (
+        (
+            LEGACY_PATH,
+            SUCCESSOR_PATH,
+            _legacy_parameter(),
+            _successor_parameter(duplicate=duplicate),
+        ),
+    )
+
+
+def test_derives_unique_active_period_equivalent_parameter_rewrite():
+    replacements = derive_exact_dependent_parameter_replacements(
+        dependent_primary_raw=_dependent(),
+        retained_modules=_retained_modules(),
+    )
+
+    assert replacements == {
+        "us-la:statutes/47:297/4#later_low_income_unreduced_federal_credit_percentage": (
+            "us-la:statutes/47/297/4#low_income_unreduced_federal_credit_percentage"
+        ),
+        "later_low_income_unreduced_federal_credit_percentage": (
+            "low_income_unreduced_federal_credit_percentage"
+        ),
+    }
+
+
+def test_rejects_parameter_that_differs_during_dependent_use_window():
+    with pytest.raises(
+        LegacyExactDependentConceptError,
+        match="no unique active-period-equivalent canonical successor",
+    ):
+        derive_exact_dependent_parameter_replacements(
+            dependent_primary_raw=_dependent(year=2006),
+            retained_modules=_retained_modules(),
+        )
+
+
+def test_rejects_ambiguous_equivalent_successors():
+    with pytest.raises(
+        LegacyExactDependentConceptError,
+        match="candidates: low_income_unreduced.*other_low_income_percentage",
+    ):
+        derive_exact_dependent_parameter_replacements(
+            dependent_primary_raw=_dependent(),
+            retained_modules=_retained_modules(duplicate=True),
+        )
+
+
+def test_rejects_parameter_effective_to_not_enforced_by_scalar_runtime():
+    successor = _successor_parameter().replace(
+        b"        formula: '0.50'\n",
+        b"        effective_to: '2030-12-31'\n        formula: '0.50'\n",
+    )
+    with pytest.raises(
+        LegacyExactDependentConceptError,
+        match="effective_to.*cannot be proved",
+    ):
+        derive_exact_dependent_parameter_replacements(
+            dependent_primary_raw=_dependent(),
+            retained_modules=(
+                (LEGACY_PATH, SUCCESSOR_PATH, _legacy_parameter(), successor),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "dependent",
+    [
+        _dependent().replace(
+            b"imports:\n",
+            b"imports:\n"
+            b"  - other:module#later_low_income_unreduced_federal_credit_percentage\n",
+        ),
+        _dependent().replace(
+            b"rules:\n",
+            b"rules:\n"
+            b"  - name: later_low_income_unreduced_federal_credit_percentage\n"
+            b"    kind: parameter\n"
+            b"    dtype: Rate\n"
+            b"    versions:\n"
+            b"      - effective_from: '2026-01-01'\n"
+            b"        formula: '0.50'\n",
+        ),
+    ],
+)
+def test_rejects_ambiguous_imported_symbol(dependent):
+    with pytest.raises(
+        LegacyExactDependentConceptError,
+        match="not an unambiguous imported symbol",
+    ):
+        derive_exact_dependent_parameter_replacements(
+            dependent_primary_raw=dependent,
+            retained_modules=_retained_modules(),
+        )
+
+
+def test_validates_rewrite_is_limited_to_import_and_formula_surfaces():
+    path_replacements = {"us-la:statutes/47:297/4": "us-la:statutes/47/297/4"}
+    concepts = derive_exact_dependent_parameter_replacements(
+        dependent_primary_raw=_dependent(),
+        retained_modules=_retained_modules(),
+    )
+    path_rewritten, _counts = rewrite_exact_references(_dependent(), path_replacements)
+    canonical = canonicalized_concept_replacements(
+        concepts, path_replacements=path_replacements
+    )
+    concept_rewritten, _counts = rewrite_exact_references(path_rewritten, canonical)
+
+    validate_exact_dependent_concept_rewrite(
+        path_rewritten_raw=path_rewritten,
+        concept_rewritten_raw=concept_rewritten,
+        replacements=canonical,
+        primary=True,
+    )
+
+
+def test_validates_proof_import_target_and_output_rewrite():
+    raw = _dependent().replace(
+        b"        formula: amount * later_low_income_unreduced_federal_credit_percentage\n",
+        b"        formula: amount * later_low_income_unreduced_federal_credit_percentage\n"
+        b"    metadata:\n"
+        b"      proof:\n"
+        b"        atoms:\n"
+        b"          - kind: import\n"
+        b"            import:\n"
+        b"              target: us-la:statutes/47:297/4#later_low_income_unreduced_federal_credit_percentage\n"
+        b"              output: later_low_income_unreduced_federal_credit_percentage\n",
+    )
+    path_replacements = {"us-la:statutes/47:297/4": "us-la:statutes/47/297/4"}
+    concepts = derive_exact_dependent_parameter_replacements(
+        dependent_primary_raw=raw,
+        retained_modules=_retained_modules(),
+    )
+    path_rewritten, _counts = rewrite_exact_references(raw, path_replacements)
+    canonical = canonicalized_concept_replacements(
+        concepts, path_replacements=path_replacements
+    )
+    concept_rewritten, _counts = rewrite_exact_references(path_rewritten, canonical)
+
+    validate_exact_dependent_concept_rewrite(
+        path_rewritten_raw=path_rewritten,
+        concept_rewritten_raw=concept_rewritten,
+        replacements=canonical,
+        primary=True,
+    )
+
+
+def test_rejects_rewrite_of_unrelated_summary_text():
+    raw = _dependent(source_note="later_low_income_unreduced_federal_credit_percentage")
+    path_replacements = {"us-la:statutes/47:297/4": "us-la:statutes/47/297/4"}
+    concepts = derive_exact_dependent_parameter_replacements(
+        dependent_primary_raw=raw,
+        retained_modules=_retained_modules(),
+    )
+    path_rewritten, _counts = rewrite_exact_references(raw, path_replacements)
+    canonical = canonicalized_concept_replacements(
+        concepts, path_replacements=path_replacements
+    )
+    concept_rewritten, _counts = rewrite_exact_references(path_rewritten, canonical)
+
+    with pytest.raises(
+        LegacyExactDependentConceptError,
+        match="unauthorized YAML surface",
+    ):
+        validate_exact_dependent_concept_rewrite(
+            path_rewritten_raw=path_rewritten,
+            concept_rewritten_raw=concept_rewritten,
+            replacements=canonical,
+            primary=True,
+        )
+
+
+def test_rejects_global_rewrite_of_quoted_formula_literal():
+    raw = _dependent().replace(
+        b"amount * later_low_income_unreduced_federal_credit_percentage",
+        b'if label == "later_low_income_unreduced_federal_credit_percentage" then '
+        b"amount * later_low_income_unreduced_federal_credit_percentage else 0",
+    )
+    path_replacements = {"us-la:statutes/47:297/4": "us-la:statutes/47/297/4"}
+    concepts = derive_exact_dependent_parameter_replacements(
+        dependent_primary_raw=raw,
+        retained_modules=_retained_modules(),
+    )
+    path_rewritten, _counts = rewrite_exact_references(raw, path_replacements)
+    canonical = canonicalized_concept_replacements(
+        concepts, path_replacements=path_replacements
+    )
+    concept_rewritten, _counts = rewrite_exact_references(path_rewritten, canonical)
+
+    with pytest.raises(
+        LegacyExactDependentConceptError,
+        match="unauthorized YAML surface",
+    ):
+        validate_exact_dependent_concept_rewrite(
+            path_rewritten_raw=path_rewritten,
+            concept_rewritten_raw=concept_rewritten,
+            replacements=canonical,
+            primary=True,
+        )

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1644"
+ENCODER_VERSION = "0.2.1645"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1644"
+ENCODER_VERSION = "0.2.1645"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1644"
+ENCODER_VERSION = "0.2.1645"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1644"
+ENCODER_VERSION = "0.2.1645"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1184,6 +1184,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
         "axiom-encode/legacy-fresh-reencode-receipt/v4",
         "axiom-encode/legacy-fresh-reencode-receipt/v5",
         "axiom-encode/legacy-fresh-reencode-receipt/v6",
+        "axiom-encode/legacy-fresh-reencode-receipt/v7",
     }:
         assert isinstance(retained_successors, list)
         deleted_files.extend(
@@ -1211,6 +1212,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
                 "axiom-encode/legacy-fresh-reencode-receipt/v6",
+                "axiom-encode/legacy-fresh-reencode-receipt/v7",
             }
             else None
         ),
@@ -1222,6 +1224,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
                 "axiom-encode/legacy-fresh-reencode-receipt/v6",
+                "axiom-encode/legacy-fresh-reencode-receipt/v7",
             }
             else None
         ),
@@ -1233,6 +1236,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
                 "axiom-encode/legacy-fresh-reencode-receipt/v6",
+                "axiom-encode/legacy-fresh-reencode-receipt/v7",
             }
             else None
         ),
@@ -1243,6 +1247,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
                 "axiom-encode/legacy-fresh-reencode-receipt/v6",
+                "axiom-encode/legacy-fresh-reencode-receipt/v7",
             }
             else None
         ),
@@ -1253,6 +1258,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
                 "axiom-encode/legacy-fresh-reencode-receipt/v6",
+                "axiom-encode/legacy-fresh-reencode-receipt/v7",
             }
             else None
         ),

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1644"')
+        .startswith('__version__ = "0.2.1645"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1644"
+    assert encoder_package["version"] == "0.2.1645"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1644"
+    assert project["project"]["version"] == "0.2.1645"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1644"')
+        .startswith('__version__ = "0.2.1645"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1644"
+    assert encoder_package["version"] == "0.2.1645"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1644"
+    assert project["project"]["version"] == "0.2.1645"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1644"')
+        .startswith('__version__ = "0.2.1645"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1644"
+ENCODER_VERSION = "0.2.1645"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1644"
+version = "0.2.1645"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- deterministically migrate retired exact-dependent scalar parameter concepts to their unique authenticated canonical successors
- add receipt v7 with a mandatory identity-bound `concept_replacements` inventory and v1-v6 replay compatibility
- replay the same proof in the encoder verifier and signed-backfill publisher
- restrict changes to imports, unquoted formula identifiers, proof-import target/output fields, and test mapping keys

## Louisiana failure fixed

The canonical `47/297` successor consolidates the legacy `later_low_income_percentage` into versioned `low_income_percentage`. The former path-only migration retained the retired fragment and formula symbol, so the compiler interpreted it as a missing input. This fix derives and proves the concept rename from authenticated legacy/successor bytes. It adds no caller input, changes no dispatch input, and does not special-case the test.

## Review cycle

The first independent review found four actionable issues: implicit-v6 downgrade, scalar `effective_to` runtime mismatch, proof-import atom handling, and quoted-literal substitution. All were fixed. The second independent review reported no actionable findings.

## Checks

- Ruff and compileall: passed
- unit/security: 10 passed
- atomic apply: 2 passed
- signed-backfill: 178 passed
- RuleSpec/registry: 1,466 passed, 31 skipped
- version provenance: 9 passed
- full local suite: 11,591 passed, 119 skipped
- hosted lint, Python 3.13, Ubuntu and macOS signing supervisors: passed
