### PR TITLE
Keep targeted receipt packaging schema-compatible

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1749,6 +1749,11 @@ jobs:
               UnsafeCorpusPathError,
               read_bounded_regular_file,
           )
+          from axiom_encode.legacy_replacement import (
+              RECEIPT_SCHEMA_V1,
+              RECEIPT_SCHEMAS,
+              RECEIPT_SCHEMAS_WITH_RETAINED_SUCCESSORS,
+          )
           from axiom_encode.rulespec_path_migration import (
               canonical_destination,
               rewrite_exact_references,
@@ -2254,14 +2259,12 @@ jobs:
                   receipt = json.loads(receipt_bytes)
                   receipt_replacement = receipt.get("replacement")
                   receipt_schema = receipt.get("schema_version")
+                  if receipt_schema not in RECEIPT_SCHEMAS:
+                      raise SystemExit(
+                          "legacy replacement receipt schema is unsupported"
+                      )
                   if (
-                      receipt_schema not in {
-                          "axiom-encode/legacy-fresh-reencode-receipt/v1",
-                          "axiom-encode/legacy-fresh-reencode-receipt/v2",
-                          "axiom-encode/legacy-fresh-reencode-receipt/v3",
-                          "axiom-encode/legacy-fresh-reencode-receipt/v4",
-                      }
-                      or not isinstance(receipt_replacement, dict)
+                      not isinstance(receipt_replacement, dict)
                       or receipt_replacement.get("source")
                       != legacy_source_path
                       or receipt_replacement.get("destination")
@@ -2283,7 +2286,7 @@ jobs:
                       or (
                           exact_dependent_paths
                           and receipt_schema
-                          == "axiom-encode/legacy-fresh-reencode-receipt/v1"
+                          == RECEIPT_SCHEMA_V1
                       )
                   ):
                       raise SystemExit(
@@ -2293,9 +2296,7 @@ jobs:
                   retained_successors = receipt_replacement.get(
                       "retained_successors"
                   )
-                  if receipt_schema == (
-                      "axiom-encode/legacy-fresh-reencode-receipt/v4"
-                  ):
+                  if receipt_schema in RECEIPT_SCHEMAS_WITH_RETAINED_SUCCESSORS:
                       if (
                           not isinstance(retained_successors, list)
                           or not isinstance(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1646"
+version = "0.2.1647"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1646"
+__version__ = "0.2.1647"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -36,6 +36,25 @@ RECEIPT_SCHEMA_V4: Final = "axiom-encode/legacy-fresh-reencode-receipt/v4"
 RECEIPT_SCHEMA_V5: Final = "axiom-encode/legacy-fresh-reencode-receipt/v5"
 RECEIPT_SCHEMA_V6: Final = "axiom-encode/legacy-fresh-reencode-receipt/v6"
 RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v7"
+RECEIPT_SCHEMAS: Final = frozenset(
+    {
+        RECEIPT_SCHEMA_V1,
+        RECEIPT_SCHEMA_V2,
+        RECEIPT_SCHEMA_V3,
+        RECEIPT_SCHEMA_V4,
+        RECEIPT_SCHEMA_V5,
+        RECEIPT_SCHEMA_V6,
+        RECEIPT_SCHEMA,
+    }
+)
+RECEIPT_SCHEMAS_WITH_RETAINED_SUCCESSORS: Final = frozenset(
+    {
+        RECEIPT_SCHEMA_V4,
+        RECEIPT_SCHEMA_V5,
+        RECEIPT_SCHEMA_V6,
+        RECEIPT_SCHEMA,
+    }
+)
 RECEIPT_DIR: Final = ".axiom/legacy-replacements"
 DESTINATION_PREDECESSOR_ABSENT: Final = "absent"
 DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE: Final = (

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1646"
+ENCODER_VERSION = "0.2.1647"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1646"
+ENCODER_VERSION = "0.2.1647"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1646"
+ENCODER_VERSION = "0.2.1647"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1646"
+ENCODER_VERSION = "0.2.1647"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1646"
+ENCODER_VERSION = "0.2.1647"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1646"
+ENCODER_VERSION = "0.2.1647"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1646"
+ENCODER_VERSION = "0.2.1647"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1646"')
+        .startswith('__version__ = "0.2.1647"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1646"
+    assert encoder_package["version"] == "0.2.1647"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1646"
+    assert project["project"]["version"] == "0.2.1647"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1646"')
+        .startswith('__version__ = "0.2.1647"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1646"
+    assert encoder_package["version"] == "0.2.1647"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1646"
+    assert project["project"]["version"] == "0.2.1647"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1646"')
+        .startswith('__version__ = "0.2.1647"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1646"
+ENCODER_VERSION = "0.2.1647"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -5221,6 +5221,7 @@ def test_targeted_metadata_uses_consumed_repair_identity_after_evidence_mutation
     }
 
 
+@pytest.mark.parametrize("receipt_version", [4, 5, 6, 7])
 @pytest.mark.parametrize(
     ("mutation", "error"),
     [
@@ -5231,13 +5232,17 @@ def test_targeted_metadata_uses_consumed_repair_identity_after_evidence_mutation
         ("tampered-evidence", "retained predecessor file digest differs"),
         ("missing-deleted-manifest", "deleted manifest inventory differs"),
         ("extra-deleted-manifest", "deleted manifest inventory differs"),
+        ("tampered-exact-binding", "exact dependent manifest binding differs"),
     ],
 )
-def test_targeted_artifact_packages_v4_retained_successor_closure(
+def test_targeted_artifact_packages_replacement_closure(
     tmp_path: Path,
+    receipt_version: int,
     mutation: str,
     error: str | None,
 ) -> None:
+    if mutation == "tampered-exact-binding" and receipt_version != 7:
+        pytest.skip("exact-dependent v7 binding case")
     script = _targeted_package_script()
     rulespec = tmp_path / "rulespec-us"
     rulespec.mkdir()
@@ -5313,6 +5318,19 @@ def test_targeted_artifact_packages_v4_retained_successor_closure(
                 "successor_files": successor_files,
             }
         )
+    exact_primary_path = "us/policies/income_tax/2026_resident_core.yaml"
+    exact_manifest_path = (
+        ".axiom/encoding-manifests/us/policies/income_tax/2026_resident_core.json"
+    )
+    exact_legacy_file: dict[str, str] | None = None
+    exact_legacy_manifest: dict[str, str] | None = None
+    if receipt_version == 7:
+        exact_legacy_file = evidence(
+            write(exact_primary_path, b"old exact dependent\n")
+        )
+        exact_legacy_manifest = evidence(
+            write(exact_manifest_path, b"old exact dependent manifest\n")
+        )
     subprocess.run(["git", "add", "."], cwd=rulespec, check=True)
     subprocess.run(["git", "commit", "-qm", "base"], cwd=rulespec, check=True)
     rulespec_ref = subprocess.check_output(
@@ -5326,6 +5344,32 @@ def test_targeted_artifact_packages_v4_retained_successor_closure(
             (rulespec / item["path"]).unlink()
         (rulespec / row["legacy_manifest"]["path"]).unlink()
     main_live = write("us/statutes/47/32.yaml", b"new main\n")
+    exact_dependents: list[dict[str, object]] = []
+    if receipt_version == 7:
+        assert exact_legacy_file is not None
+        assert exact_legacy_manifest is not None
+        exact_live = write(exact_primary_path, b"new exact dependent\n")
+        exact_live_file = evidence(exact_live)
+        exact_dependents.append(
+            {
+                "primary": exact_primary_path,
+                "legacy_manifest": exact_legacy_manifest,
+                "legacy_files": [exact_legacy_file],
+                "live_files": [exact_live_file],
+                "rewrites": [
+                    {
+                        "path": exact_primary_path,
+                        "before_sha256": exact_legacy_file["sha256"],
+                        "after_sha256": exact_live_file["sha256"],
+                        "replacements": [],
+                        "proof_import_repairs": 0,
+                        "proof_excerpt_reanchors": [],
+                    }
+                ],
+                "source_verification_migration": None,
+                "concept_replacements": [],
+            }
+        )
     citation = "us/statute/47:32"
     review_content = "Retain the canonical successors.\n"
     context_payload = {
@@ -5351,12 +5395,14 @@ def test_targeted_artifact_packages_v4_retained_successor_closure(
         "applied_files": [evidence(main_live)],
     }
     receipt_payload = {
-        "schema_version": "axiom-encode/legacy-fresh-reencode-receipt/v4",
+        "schema_version": (
+            f"axiom-encode/legacy-fresh-reencode-receipt/v{receipt_version}"
+        ),
         "replacement": {
             "source": "us/statutes/47:32.yaml",
             "destination": "us/statutes/47/32.yaml",
             "scheduled_dependents": [],
-            "exact_dependents": [],
+            "exact_dependents": exact_dependents,
             "retained_successors": retained_rows,
             "metadata_reconciliations": [],
         },
@@ -5394,6 +5440,33 @@ def test_targeted_artifact_packages_v4_retained_successor_closure(
         }
         (rulespec / row["successor_manifest"]["path"]).write_text(
             json.dumps(refreshed, sort_keys=True) + "\n"
+        )
+    exact_manifest: Path | None = None
+    if receipt_version == 7:
+        exact_migration = {
+            "receipt_path": receipt_path.relative_to(rulespec).as_posix(),
+            "receipt_sha256": receipt_digest,
+            "primary": exact_primary_path,
+        }
+        if mutation == "tampered-exact-binding":
+            exact_migration["receipt_sha256"] = "0" * 64
+        exact_manifest = write(
+            exact_manifest_path,
+            (
+                json.dumps(
+                    {
+                        "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                        "tool": (
+                            "axiom-encode encode --apply "
+                            "--legacy-exact-dependent-rulespec-path"
+                        ),
+                        "applied_files": exact_dependents[0]["live_files"],
+                        "legacy_migration": exact_migration,
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            ).encode(),
         )
     outer = {
         "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
@@ -5441,6 +5514,9 @@ def test_targeted_artifact_packages_v4_retained_successor_closure(
             "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON": json.dumps(
                 selected_inputs
             ),
+            "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": (
+                exact_primary_path if receipt_version == 7 else ""
+            ),
         },
     )
 
@@ -5456,6 +5532,8 @@ def test_targeted_artifact_packages_v4_retained_successor_closure(
     assert {str(row["successor_manifest"]["path"]) for row in retained_rows}.issubset(
         inventory_paths
     )
+    if exact_manifest is not None:
+        assert exact_manifest.relative_to(rulespec).as_posix() in inventory_paths
 
 
 @pytest.mark.parametrize("receipt_version", [1, 2, 3])

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1646"
+version = "0.2.1647"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- centralize admitted legacy replacement receipt schema sets in the encoder contract
- make targeted artifact packaging consume those sets and report unsupported schemas distinctly from path mismatches
- exercise packaging compatibility for receipt v1-v7, including a non-empty v7 exact-dependent manifest and fail-closed tamper rejection
- bump the encoder version to 0.2.1647 and propagate the pin through every packaged registry assertion

## Why
Fresh Louisiana run 31301427028 completed exact encoding, authenticated migration, apply, and provenance verification, then failed only because the artifact packager retained a stale v1-v4 receipt allowlist. This removes that duplicate allowlist; it does not change dispatch inputs or reuse the failed candidate.

## Review cycle
An independent reviewer found that the initial v7 test had an empty exact-dependent list. The fixture now includes the full v7-era exact-dependent evidence surface, verifies its linked manifest enters the inventory, and rejects a tampered receipt binding. A second review found no actionable findings. After hosted CI exposed stale 0.2.1646 expectations in newer state registries, every applicable assertion was propagated to 0.2.1647; the final independent review of commit `c1ffd034d` found no actionable findings and confirmed the packaging contract remains fail closed.

## Checks
- focused packaging compatibility: 32 passed, 3 intentional non-v7 skips
- workflow/receipt/publisher slice: 387 passed, 51 skipped
- affected version provenance/oracle registries: 27 passed
- final independent review slice: 60 passed, 3 intentional non-v7 skips
- Ruff check, Ruff format check, compileall, and git diff --check: passed
- full local suite: 12,444 passed, 122 skipped
- hosted Python 3.13: 12,492 passed, 74 skipped
- hosted lint and signing supervisors (Ubuntu and macOS): passed
- contributor-race check: branch is based on current `origin/main` at `19dfdf2ee`
