### PR TITLE
Fix exact-dependent metadata reconciliation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1650"
+version = "0.2.1651"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1649"
+version = "0.2.1650"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1650"
+__version__ = "0.2.1651"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1649"
+__version__ = "0.2.1650"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -597,6 +597,7 @@ _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS = frozenset(
     {
         Path(".axiom/index/provisions_to_rules.json"),
         Path(".axiom/pending-validation-fingerprints.json"),
+        Path(".axiom/retired-schema-freeze.json"),
         Path(".axiom/toolchain.toml"),
         Path("known-validation-gaps.yaml"),
         Path("oracle-coverage-pending.yaml"),
@@ -23648,6 +23649,9 @@ def _legacy_replacement_manifest_issues(
             )
     seen_exact_primaries: set[str] = set()
     seen_exact_files: set[str] = set()
+    exact_metadata_manifest_paths: set[str] = set()
+    exact_metadata_retired_schema_modules: set[str] = set()
+    exact_metadata_reindexed_modules: dict[str, bytes] = {}
     for dependent in exact_dependents:
         expected_dependent_fields = {
             "primary",
@@ -23872,6 +23876,7 @@ def _legacy_replacement_manifest_issues(
             issues.append(f"{manifest_label} exact dependent rewrites are malformed")
             continue
         expected_rewrite_paths: set[Path] = set()
+        live_primary_raw: bytes | None = None
         for path in sorted(expected_group, key=Path.as_posix):
             try:
                 base_raw = _rulespec_migration_base_blob(repo_path, base_commit, path)
@@ -23882,6 +23887,8 @@ def _legacy_replacement_manifest_issues(
                     max_bytes=16 * 1024 * 1024,
                     required_mode=0o644,
                 )
+                if path == primary_path:
+                    live_primary_raw = live_raw
                 rewritten, counts = rewrite_exact_references(
                     base_raw, exact_authoritative_replacements
                 )
@@ -24160,6 +24167,11 @@ def _legacy_replacement_manifest_issues(
                 f"{manifest_label} exact dependent lacks its authenticated v5 "
                 f"migration manifest for {primary}"
             )
+        if live_primary_raw is not None:
+            exact_metadata_manifest_paths.add(dependent_manifest_path.as_posix())
+            exact_metadata_reindexed_modules[primary] = live_primary_raw
+            if receipt_source_verification_migration is not None:
+                exact_metadata_retired_schema_modules.add(primary)
 
     retained_successors = replacement.get("retained_successors", [])
     retained_deleted_entries: list[dict[str, object]] = []
@@ -24410,6 +24422,11 @@ def _legacy_replacement_manifest_issues(
                 base_raw,
                 moves=primary_moves,
                 validation_waiver_set_sha256=post_migration_waiver_sha256,
+                retired_manifest_paths=frozenset(exact_metadata_manifest_paths),
+                retired_schema_modules=frozenset(
+                    exact_metadata_retired_schema_modules
+                ),
+                reindexed_modules=exact_metadata_reindexed_modules,
             )
         except (OSError, RuntimeError, UnsafeCorpusPathError, ValueError) as exc:
             issues.append(
@@ -24439,6 +24456,11 @@ def _legacy_replacement_manifest_issues(
                 base_raw,
                 moves=primary_moves,
                 validation_waiver_set_sha256=post_migration_waiver_sha256,
+                retired_manifest_paths=frozenset(exact_metadata_manifest_paths),
+                retired_schema_modules=frozenset(
+                    exact_metadata_retired_schema_modules
+                ),
+                reindexed_modules=exact_metadata_reindexed_modules,
             )
         except (RuntimeError, ValueError):
             continue
@@ -26437,6 +26459,99 @@ def _index_module_record_counts(value: object) -> Counter[str]:
     return counts
 
 
+def _rulespec_index_references(raw: bytes) -> dict[str, set[str]]:
+    """Return the reverse-index references for one authenticated module postimage."""
+
+    try:
+        payload = yaml.safe_load(raw.decode("utf-8"))
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError("exact dependent postimage is not valid UTF-8 YAML") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("exact dependent postimage is not a RuleSpec mapping")
+    references: dict[str, set[str]] = {}
+    module = payload.get("module")
+    verification = (
+        module.get("source_verification") if isinstance(module, dict) else None
+    )
+    if isinstance(verification, dict):
+        citations: list[object] = [verification.get("corpus_citation_path")]
+        plural = verification.get("corpus_citation_paths")
+        if isinstance(plural, list):
+            citations.extend(plural)
+        for value in citations:
+            if isinstance(value, str) and value.strip():
+                references.setdefault(value.strip(), set()).add("module")
+    rules = payload.get("rules")
+    if isinstance(rules, list):
+        for rule in rules:
+            metadata = rule.get("metadata") if isinstance(rule, dict) else None
+            proof = metadata.get("proof") if isinstance(metadata, dict) else None
+            atoms = proof.get("atoms") if isinstance(proof, dict) else None
+            if not isinstance(atoms, list):
+                continue
+            for atom in atoms:
+                source = atom.get("source") if isinstance(atom, dict) else None
+                citation = (
+                    source.get("corpus_citation_path")
+                    if isinstance(source, dict)
+                    else None
+                )
+                if isinstance(citation, str) and citation.strip():
+                    references.setdefault(citation.strip(), set()).add("proof_atom")
+    return references
+
+
+def _reindex_exact_dependent_modules(
+    value: object,
+    *,
+    modules: Mapping[str, bytes],
+) -> tuple[object, int]:
+    """Replace reverse-index records for exact dependent module postimages."""
+
+    if not modules:
+        return value, 0
+    if not isinstance(value, dict) or not isinstance(value.get("provisions"), dict):
+        raise ValueError("legacy provision index has an unsupported schema")
+    before_counts = _index_module_record_counts(value)
+    missing = sorted(module for module in modules if before_counts[module] == 0)
+    if missing:
+        raise ValueError(
+            "legacy provision index lacks exact dependent module records: "
+            + ", ".join(missing)
+        )
+    rewritten, removed = _remove_index_module_records(
+        value,
+        old_modules=set(modules),
+    )
+    if removed != sum(before_counts[module] for module in modules):
+        raise ValueError("exact dependent provision index removal is inconsistent")
+    assert isinstance(rewritten, dict)
+    provisions = rewritten.get("provisions")
+    assert isinstance(provisions, dict)
+    for citation in list(provisions):
+        records = provisions[citation]
+        if not isinstance(records, list):
+            raise ValueError("legacy provision index records are malformed")
+        if not records:
+            del provisions[citation]
+    for module_path, module_raw in sorted(modules.items()):
+        for citation, kinds in sorted(_rulespec_index_references(module_raw).items()):
+            records = provisions.setdefault(citation, [])
+            if not isinstance(records, list):
+                raise ValueError("legacy provision index records are malformed")
+            records.append({"module": module_path, "via": sorted(kinds)})
+    rewritten["provisions"] = {
+        citation: sorted(
+            records,
+            key=lambda record: str(record.get("module", ""))
+            if isinstance(record, dict)
+            else "",
+        )
+        for citation, records in sorted(provisions.items())
+    }
+    return rewritten, len(modules)
+
+
 def _line_preserving_yaml_mapping_removal(
     raw: bytes,
     *,
@@ -26619,6 +26734,9 @@ def _legacy_metadata_reconciliation_bytes(
     *,
     moves: Sequence[PlannedMove],
     validation_waiver_set_sha256: str | None = None,
+    retired_manifest_paths: frozenset[str] = frozenset(),
+    retired_schema_modules: frozenset[str] = frozenset(),
+    reindexed_modules: Mapping[str, bytes] | None = None,
 ) -> tuple[bytes, tuple[dict[str, object], ...]]:
     """Apply one audited metadata cleanup from an explicit move set."""
 
@@ -26626,7 +26744,8 @@ def _legacy_metadata_reconciliation_bytes(
     old_identities = {rulespec_identity(move.source) for move in moves}
     old_manifests = {
         _applied_encoding_manifest_path(move.source).as_posix() for move in moves
-    }
+    } | set(retired_manifest_paths)
+    reindexed_modules = dict(reindexed_modules or {})
     if path == Path(".axiom/toolchain.toml"):
         if (
             validation_waiver_set_sha256 is None
@@ -26670,8 +26789,24 @@ def _legacy_metadata_reconciliation_bytes(
         after, count = _remove_index_module_records(before, old_modules=old_modules)
         if count != sum(module_counts[module] for module in old_modules):
             raise ValueError("legacy provision index removal count is inconsistent")
+        after, reindexed_count = _reindex_exact_dependent_modules(
+            after,
+            modules=reindexed_modules,
+        )
         rewritten = (json.dumps(after, indent=2, ensure_ascii=False) + "\n").encode()
-        operations = ({"operation": "remove_legacy_module_records", "count": count},)
+        operations = (
+            {"operation": "remove_legacy_module_records", "count": count},
+            *(
+                (
+                    {
+                        "operation": "reindex_exact_dependent_modules",
+                        "count": reindexed_count,
+                    },
+                )
+                if reindexed_modules
+                else ()
+            ),
+        )
     elif path == Path(".axiom/pending-validation-fingerprints.json"):
         try:
             before = json.loads(raw.decode("utf-8"))
@@ -26680,6 +26815,41 @@ def _legacy_metadata_reconciliation_bytes(
         after, count = _remove_nested_mapping_keys(before, old_modules)
         rewritten = (json.dumps(after, indent=2, ensure_ascii=True) + "\n").encode()
         operations = ({"operation": "remove_legacy_fingerprints", "count": count},)
+    elif path == Path(".axiom/retired-schema-freeze.json"):
+        try:
+            before = json.loads(raw.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise ValueError("retired-schema freeze is invalid JSON") from exc
+        if (
+            not isinstance(before, dict)
+            or set(before) != {"format", "artifacts"}
+            or before.get("format") != "axiom/retired-schema-freeze/v1"
+            or not isinstance(before.get("artifacts"), dict)
+        ):
+            raise ValueError("retired-schema freeze has an unsupported schema")
+        artifacts = before["artifacts"]
+        assert isinstance(artifacts, dict)
+        missing = sorted(set(retired_schema_modules) - set(artifacts))
+        if missing:
+            raise ValueError(
+                "retired-schema freeze lacks migrated exact dependents: "
+                + ", ".join(missing)
+            )
+        after = copy.deepcopy(before)
+        after_artifacts = after["artifacts"]
+        assert isinstance(after_artifacts, dict)
+        removed_modules = set(retired_schema_modules) | (old_modules & set(artifacts))
+        for module in removed_modules:
+            del after_artifacts[module]
+        rewritten = (
+            json.dumps(after, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+        ).encode()
+        operations = (
+            {
+                "operation": "remove_migrated_retired_schema_modules",
+                "count": len(removed_modules),
+            },
+        )
     elif path == Path("known-validation-gaps.yaml"):
         rewritten, count = _line_preserving_yaml_mapping_removal(raw, keys=old_modules)
         operations = ({"operation": "remove_legacy_validation_gaps", "count": count},)
@@ -26731,6 +26901,7 @@ def _legacy_metadata_reconciliations(
     base_commit: str,
     tracked: Mapping[Path, str],
     moves: Sequence[PlannedMove],
+    exact_dependents: Sequence[_LegacyReplacementExactDependent] = (),
 ) -> tuple[_LegacyReplacementRewrite, ...]:
     """Build audited path-move metadata and its derived toolchain binding."""
 
@@ -26738,12 +26909,29 @@ def _legacy_metadata_reconciliations(
         return ()
     old_modules = {move.source.as_posix() for move in moves}
     old_identities = {rulespec_identity(move.source) for move in moves}
+    retired_manifest_paths = frozenset(
+        dependent.legacy_manifest.path.as_posix() for dependent in exact_dependents
+    )
     old_manifests = {
         _applied_encoding_manifest_path(move.source).as_posix() for move in moves
+    } | set(retired_manifest_paths)
+    retired_schema_modules = frozenset(
+        dependent.primary.as_posix()
+        for dependent in exact_dependents
+        if dependent.source_verification_migration is not None
+    )
+    reindexed_modules = {
+        dependent.primary.as_posix(): next(
+            item.raw for item in dependent.live_files if item.path == dependent.primary
+        )
+        for dependent in exact_dependents
     }
     relevant_values = {
-        Path(".axiom/index/provisions_to_rules.json"): old_modules,
+        Path(".axiom/index/provisions_to_rules.json"): old_modules
+        | set(reindexed_modules),
         Path(".axiom/pending-validation-fingerprints.json"): old_modules,
+        Path(".axiom/retired-schema-freeze.json"): old_modules
+        | set(retired_schema_modules),
         Path("known-validation-gaps.yaml"): old_modules,
         Path("oracle-coverage-pending.yaml"): old_identities,
         Path("tests/test_encoding_manifests.py"): old_manifests,
@@ -26795,6 +26983,9 @@ def _legacy_metadata_reconciliations(
             raw,
             moves=moves,
             validation_waiver_set_sha256=post_migration_waiver_sha256,
+            retired_manifest_paths=retired_manifest_paths,
+            retired_schema_modules=retired_schema_modules,
+            reindexed_modules=reindexed_modules,
         )
         if rewritten == raw:
             continue
@@ -27614,14 +27805,23 @@ def _resolve_legacy_replacement_contract(
         ],
         *[item.successor_manifest.path for item in retained_successors],
     }
-    metadata_reconciliations = _legacy_metadata_reconciliations(
+    # Shared metadata affected by path moves is known now; exact-dependent
+    # metadata is completed after those authenticated postimages are built.
+    preliminary_metadata_reconciliations = _legacy_metadata_reconciliations(
         checkout_root=policy_checkout_path,
         base_commit=base_commit,
         tracked=tracked,
         moves=all_moves,
     )
-    metadata_reconciliation_paths = {item.path for item in metadata_reconciliations}
-    excluded.update(metadata_reconciliation_paths)
+    excluded.update(item.path for item in preliminary_metadata_reconciliations)
+    if exact_groups:
+        excluded.update(
+            {
+                Path(".axiom/index/provisions_to_rules.json"),
+                Path(".axiom/retired-schema-freeze.json"),
+                Path("tests/test_encoding_manifests.py"),
+            }
+        )
     for successor in retained_successors:
         for item in successor.successor_files:
             _unused, successor_counts = rewrite_exact_references(
@@ -27862,6 +28062,14 @@ def _resolve_legacy_replacement_contract(
                 source_verification_migration=primary_source_migration,
             )
         )
+
+    metadata_reconciliations = _legacy_metadata_reconciliations(
+        checkout_root=policy_checkout_path,
+        base_commit=base_commit,
+        tracked=tracked,
+        moves=all_moves,
+        exact_dependents=exact_dependents,
+    )
 
     return _LegacyReplacementContract(
         base_commit=base_commit,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -24423,9 +24423,7 @@ def _legacy_replacement_manifest_issues(
                 moves=primary_moves,
                 validation_waiver_set_sha256=post_migration_waiver_sha256,
                 retired_manifest_paths=frozenset(exact_metadata_manifest_paths),
-                retired_schema_modules=frozenset(
-                    exact_metadata_retired_schema_modules
-                ),
+                retired_schema_modules=frozenset(exact_metadata_retired_schema_modules),
                 reindexed_modules=exact_metadata_reindexed_modules,
             )
         except (OSError, RuntimeError, UnsafeCorpusPathError, ValueError) as exc:
@@ -24457,9 +24455,7 @@ def _legacy_replacement_manifest_issues(
                 moves=primary_moves,
                 validation_waiver_set_sha256=post_migration_waiver_sha256,
                 retired_manifest_paths=frozenset(exact_metadata_manifest_paths),
-                retired_schema_modules=frozenset(
-                    exact_metadata_retired_schema_modules
-                ),
+                retired_schema_modules=frozenset(exact_metadata_retired_schema_modules),
                 reindexed_modules=exact_metadata_reindexed_modules,
             )
         except (RuntimeError, ValueError):
@@ -26543,9 +26539,9 @@ def _reindex_exact_dependent_modules(
     rewritten["provisions"] = {
         citation: sorted(
             records,
-            key=lambda record: str(record.get("module", ""))
-            if isinstance(record, dict)
-            else "",
+            key=lambda record: (
+                str(record.get("module", "")) if isinstance(record, dict) else ""
+            ),
         )
         for citation, records in sorted(provisions.items())
     }

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -41,6 +41,7 @@ LEGACY_REPLACEMENT_METADATA_PATHS = frozenset(
     {
         PurePosixPath(".axiom/index/provisions_to_rules.json"),
         PurePosixPath(".axiom/pending-validation-fingerprints.json"),
+        PurePosixPath(".axiom/retired-schema-freeze.json"),
         PurePosixPath(".axiom/toolchain.toml"),
         PurePosixPath("known-validation-gaps.yaml"),
         PurePosixPath("oracle-coverage-pending.yaml"),
@@ -96,6 +97,10 @@ REVIEWED_RULESPEC_REFS = frozenset(
         (
             "us",
             "e942ce50546b1c3a1c0c8f3f0404a217eddbe071",
+        ),
+        (
+            "us",
+            "dc87ef6212accbc4ff67b81f97b6ddf0cf3b5a5c",
         ),
         (
             "us",

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -1530,6 +1530,15 @@ def _git(repo: Path, *args: str) -> bytes:
     return subprocess.check_output(["git", "-C", str(repo), *args])
 
 
+def _git_quiet(repo: Path, *args: str) -> bytes:
+    """Run a Git probe whose failure is handled without leaking diagnostics."""
+
+    return subprocess.check_output(
+        ["git", "-C", str(repo), *args],
+        stderr=subprocess.PIPE,
+    )
+
+
 def _changed_paths(repo: Path) -> set[PurePosixPath]:
     output = _git(repo, "status", "--porcelain=v1", "-z", "--untracked-files=all")
     paths: set[PurePosixPath] = set()
@@ -2826,7 +2835,7 @@ def authorized_changed_paths(
                         exact_metadata_retired_schema_modules.add(primary.as_posix())
             post_migration_waiver_sha256: str | None = None
             try:
-                base_waiver_raw = _git(
+                base_waiver_raw = _git_quiet(
                     repo,
                     "show",
                     "HEAD:known-validation-gaps.yaml",
@@ -2907,7 +2916,11 @@ def authorized_changed_paths(
             expected_metadata_paths: set[PurePosixPath] = set()
             for metadata_path in LEGACY_REPLACEMENT_METADATA_PATHS:
                 try:
-                    base_raw = _git(repo, "show", f"HEAD:{metadata_path.as_posix()}")
+                    base_raw = _git_quiet(
+                        repo,
+                        "show",
+                        f"HEAD:{metadata_path.as_posix()}",
+                    )
                 except subprocess.CalledProcessError:
                     continue
                 try:

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -2797,15 +2797,15 @@ def authorized_changed_paths(
                         or manifest.get("path") != expected_manifest.as_posix()
                     ):
                         raise ValueError(f"{label}.legacy_manifest is malformed")
-                    live_files = dependent.get("live_files")
+                    dependent_live_files = dependent.get("live_files")
                     primary_records = (
                         [
                             item
-                            for item in live_files
+                            for item in dependent_live_files
                             if isinstance(item, dict)
                             and item.get("path") == primary.as_posix()
                         ]
-                        if isinstance(live_files, list)
+                        if isinstance(dependent_live_files, list)
                         else []
                     )
                     live_primary = _read_bounded_regular(

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -2777,6 +2777,53 @@ def authorized_changed_paths(
                 for old, new in authoritative_replacements.items()
                 if old.endswith(".yaml") and not old.endswith(".test.yaml")
             ]
+            exact_metadata_manifest_paths: set[str] = set()
+            exact_metadata_retired_schema_modules: set[str] = set()
+            exact_metadata_reindexed_modules: dict[str, bytes] = {}
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7:
+                assert isinstance(exact_dependents, list)
+                for index, dependent in enumerate(exact_dependents):
+                    label = f"{relative} exact_dependents[{index}]"
+                    if not isinstance(dependent, dict):
+                        raise ValueError(f"{label} is malformed")
+                    primary = _safe_relative_path(
+                        dependent.get("primary"),
+                        label=f"{label}.primary",
+                    )
+                    manifest = dependent.get("legacy_manifest")
+                    expected_manifest = MANIFEST_ROOT / primary.with_suffix(".json")
+                    if (
+                        not isinstance(manifest, dict)
+                        or manifest.get("path") != expected_manifest.as_posix()
+                    ):
+                        raise ValueError(f"{label}.legacy_manifest is malformed")
+                    live_files = dependent.get("live_files")
+                    primary_records = (
+                        [
+                            item
+                            for item in live_files
+                            if isinstance(item, dict)
+                            and item.get("path") == primary.as_posix()
+                        ]
+                        if isinstance(live_files, list)
+                        else []
+                    )
+                    live_primary = _read_bounded_regular(
+                        repo,
+                        primary,
+                        label="legacy exact dependent primary",
+                        max_bytes=16 * 1024 * 1024,
+                    )
+                    if (
+                        len(primary_records) != 1
+                        or primary_records[0].get("sha256")
+                        != hashlib.sha256(live_primary).hexdigest()
+                    ):
+                        raise ValueError(f"{label}.live_files do not bind primary")
+                    exact_metadata_manifest_paths.add(expected_manifest.as_posix())
+                    exact_metadata_reindexed_modules[primary.as_posix()] = live_primary
+                    if dependent.get("source_verification_migration") is not None:
+                        exact_metadata_retired_schema_modules.add(primary.as_posix())
             post_migration_waiver_sha256: str | None = None
             try:
                 base_waiver_raw = _git(
@@ -2832,6 +2879,13 @@ def authorized_changed_paths(
                             base_raw,
                             moves=primary_moves,
                             validation_waiver_set_sha256=(post_migration_waiver_sha256),
+                            retired_manifest_paths=frozenset(
+                                exact_metadata_manifest_paths
+                            ),
+                            retired_schema_modules=frozenset(
+                                exact_metadata_retired_schema_modules
+                            ),
+                            reindexed_modules=exact_metadata_reindexed_modules,
                         )
                     )
                 except ValueError as exc:
@@ -2863,6 +2917,13 @@ def authorized_changed_paths(
                             base_raw,
                             moves=primary_moves,
                             validation_waiver_set_sha256=(post_migration_waiver_sha256),
+                            retired_manifest_paths=frozenset(
+                                exact_metadata_manifest_paths
+                            ),
+                            retired_schema_modules=frozenset(
+                                exact_metadata_retired_schema_modules
+                            ),
+                            reindexed_modules=exact_metadata_reindexed_modules,
                         )
                     )
                 except ValueError:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1650"
+ENCODER_VERSION = "0.2.1651"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1649"
+ENCODER_VERSION = "0.2.1650"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15112,10 +15112,28 @@ class TestCmdEncode:
         provision_index.write_text(
             json.dumps(
                 {
-                    "records": [
-                        *[{"module": module} for module in old_modules],
-                        *[{"module": module} for module in canonical_modules],
-                    ]
+                    "schema": "axiom.rulespec.provisions_to_rules/v1",
+                    "description": "exact dependent migration fixture",
+                    "provisions": {
+                        "us-la/statute/47/32": [
+                            *[
+                                {"module": module, "via": ["module"]}
+                                for module in old_modules
+                            ],
+                            *[
+                                {"module": module, "via": ["module"]}
+                                for module in canonical_modules
+                            ],
+                            {
+                                "module": dependent_relative.as_posix(),
+                                "via": ["module", "proof_atom"],
+                            },
+                            {
+                                "module": second_dependent_relative.as_posix(),
+                                "via": ["module", "proof_atom"],
+                            },
+                        ]
+                    },
                 },
                 indent=2,
             )

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1649"
+ENCODER_VERSION = "0.2.1650"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1650"
+ENCODER_VERSION = "0.2.1651"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1649"
+ENCODER_VERSION = "0.2.1650"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1650"
+ENCODER_VERSION = "0.2.1651"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -1940,8 +1940,7 @@ def test_exact_dependent_metadata_reconciliation_is_complete() -> None:
     new_module = moves[0].destination.as_posix()
     dependent = "us-la/policies/income_tax/2026_resident_core.yaml"
     dependent_manifest = (
-        ".axiom/encoding-manifests/us-la/policies/income_tax/"
-        "2026_resident_core.json"
+        ".axiom/encoding-manifests/us-la/policies/income_tax/2026_resident_core.json"
     )
     postimage = (
         "module:\n"

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -1929,6 +1929,93 @@ def test_five_inventory_reconciliation_is_exact_and_deterministic() -> None:
         assert old_manifest.encode() not in rewritten
 
 
+def test_exact_dependent_metadata_reconciliation_is_complete() -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:32.yaml"),
+            destination=Path("us-la/statutes/47/32.yaml"),
+        ),
+    )
+    old_module = moves[0].source.as_posix()
+    new_module = moves[0].destination.as_posix()
+    dependent = "us-la/policies/income_tax/2026_resident_core.yaml"
+    dependent_manifest = (
+        ".axiom/encoding-manifests/us-la/policies/income_tax/"
+        "2026_resident_core.json"
+    )
+    postimage = (
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_path: us-la/statute/47:32\n"
+        "rules:\n"
+        "  - name: amount\n"
+        "    metadata:\n"
+        "      proof:\n"
+        "        atoms:\n"
+        "          - source:\n"
+        "              corpus_citation_path: us-la/statute/47:44.1\n"
+    ).encode()
+    index = {
+        "schema": "axiom.rulespec.provisions_to_rules/v1",
+        "description": "test",
+        "provisions": {
+            "us-la/statute/47:32": [
+                {"module": old_module, "via": ["module"]},
+                {"module": new_module, "via": ["module"]},
+                {"module": dependent, "via": ["module", "proof_atom"]},
+            ],
+            "us-la/statute/47:44.1": [
+                {"module": dependent, "via": ["proof_atom"]},
+            ],
+        },
+    }
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path(".axiom/index/provisions_to_rules.json"),
+        (json.dumps(index, indent=2) + "\n").encode(),
+        moves=moves,
+        reindexed_modules={dependent: postimage},
+    )
+    payload = json.loads(rewritten)
+    assert operations == (
+        {"operation": "remove_legacy_module_records", "count": 1},
+        {"operation": "reindex_exact_dependent_modules", "count": 1},
+    )
+    assert payload["provisions"]["us-la/statute/47:32"] == [
+        {"module": dependent, "via": ["module"]},
+        {"module": new_module, "via": ["module"]},
+    ]
+    assert payload["provisions"]["us-la/statute/47:44.1"] == [
+        {"module": dependent, "via": ["proof_atom"]},
+    ]
+
+    allowlist = f"ALLOW = {{\n    '{dependent_manifest}',\n    'keep.json',\n}}\n"
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path("tests/test_encoding_manifests.py"),
+        allowlist.encode(),
+        moves=moves,
+        retired_manifest_paths=frozenset({dependent_manifest}),
+    )
+    assert dependent_manifest.encode() not in rewritten
+    assert operations == (
+        {"operation": "remove_retired_manifest_allowances", "count": 1},
+    )
+
+    freeze = {
+        "format": "axiom/retired-schema-freeze/v1",
+        "artifacts": {dependent: "a" * 64, "us-hi/policies/keep.yaml": "b" * 64},
+    }
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path(".axiom/retired-schema-freeze.json"),
+        (json.dumps(freeze, indent=2) + "\n").encode(),
+        moves=moves,
+        retired_schema_modules=frozenset({dependent}),
+    )
+    assert dependent not in json.loads(rewritten)["artifacts"]
+    assert operations == (
+        {"operation": "remove_migrated_retired_schema_modules", "count": 1},
+    )
+
+
 def test_toolchain_reconciliation_binds_exact_post_migration_waiver_digest() -> None:
     moves = (
         PlannedMove(

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1649"
+ENCODER_VERSION = "0.2.1650"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1650"
+ENCODER_VERSION = "0.2.1651"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1649"
+ENCODER_VERSION = "0.2.1650"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1650"
+ENCODER_VERSION = "0.2.1651"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1649"
+ENCODER_VERSION = "0.2.1650"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1650"
+ENCODER_VERSION = "0.2.1651"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1650"
+ENCODER_VERSION = "0.2.1651"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1649"
+ENCODER_VERSION = "0.2.1650"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -3357,6 +3357,7 @@ def test_validate_rulespec_base_rejects_stale_main_pr_base(
         ("us", "ef9dd5f72d529ebc70f539c42144361e536d7563"),
         ("us", "f4fd3203db560c0d4661542388b6ae2f353e0bd3"),
         ("us", "e942ce50546b1c3a1c0c8f3f0404a217eddbe071"),
+        ("us", "dc87ef6212accbc4ff67b81f97b6ddf0cf3b5a5c"),
         ("us", "6535019ce780d9e78f10509f2fe7a2607fb2bdc4"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
@@ -3379,6 +3380,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
             ("us", "ef9dd5f72d529ebc70f539c42144361e536d7563"),
             ("us", "f4fd3203db560c0d4661542388b6ae2f353e0bd3"),
             ("us", "e942ce50546b1c3a1c0c8f3f0404a217eddbe071"),
+            ("us", "dc87ef6212accbc4ff67b81f97b6ddf0cf3b5a5c"),
             ("us", "6535019ce780d9e78f10509f2fe7a2607fb2bdc4"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
@@ -3409,7 +3411,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_protected_branch_tip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = tmp_path / "rulespec-us"
-    reviewed_ref = "e942ce50546b1c3a1c0c8f3f0404a217eddbe071"
+    reviewed_ref = "dc87ef6212accbc4ff67b81f97b6ddf0cf3b5a5c"
     git_calls: list[tuple[str, ...]] = []
 
     def fake_git(_repo: Path, *args: str) -> bytes:

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -2466,6 +2466,7 @@ def _refresh_legacy_receipt_bindings(
 )
 def test_stage_accepts_v2_exact_dependent_with_unchanged_companion(
     tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
     legacy_owner_class: str,
     generated_exact_dependent: bool,
 ) -> None:
@@ -2485,6 +2486,7 @@ def test_stage_accepts_v2_exact_dependent_with_unchanged_companion(
         "us/policies/income_tax/composite.test.yaml"
         not in _git(repo, "diff", "--cached", "--name-only").splitlines()
     )
+    assert capfd.readouterr().err == ""
 
 
 def test_stage_accepts_v5_singular_exact_dependent_noop_migration(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1650"')
+        .startswith('__version__ = "0.2.1651"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1650"
+    assert encoder_package["version"] == "0.2.1651"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1650"
+    assert project["project"]["version"] == "0.2.1651"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1650"')
+        .startswith('__version__ = "0.2.1651"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1650"
+    assert encoder_package["version"] == "0.2.1651"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1650"
+    assert project["project"]["version"] == "0.2.1651"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1650"')
+        .startswith('__version__ = "0.2.1651"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1649"')
+        .startswith('__version__ = "0.2.1650"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1649"
+    assert encoder_package["version"] == "0.2.1650"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1649"
+    assert project["project"]["version"] == "0.2.1650"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1649"')
+        .startswith('__version__ = "0.2.1650"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1649"
+    assert encoder_package["version"] == "0.2.1650"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1649"
+    assert project["project"]["version"] == "0.2.1650"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1649"')
+        .startswith('__version__ = "0.2.1650"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1649"
+ENCODER_VERSION = "0.2.1650"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1650"
+ENCODER_VERSION = "0.2.1651"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1649"
+version = "0.2.1650"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1650"
+version = "0.2.1651"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- rebuild the RuleSpec reverse index from authenticated exact-dependent postimages during legacy path replacement
- retire replaced v1 manifest allowances and reconcile retired-schema freeze metadata
- verify the same metadata inputs in signed-backfill staging and receipt loading
- keep already-optional Git probes silent while required reconciliation reads remain strict
- bump axiom-encode to 0.2.1651

This fixes the owner-layer metadata model used by atomic legacy replacement; it does not change campaign dispatching or bypass validation.

## Validation

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `ruff format --check src/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` — 12,449 passed, 123 skipped on exact head `a8d38b01c`
- production-shaped exact-dependent apply cases pass for manual and generated legacy owners
- protected supervisor matrices pass on Ubuntu and macOS

## Review cycle

Independent review completed clean with no actionable findings at exact head `a8d38b01cb831f465df01528244a8b2d94acc7e1` against base `06c4ee533445a9810b2a392c16d18f1344e240cb`. Reviewer checked authenticated exact-dependent inputs, reverse-index/freeze/manifest reconciliation, signed-backfill authorization, receipt binding, version provenance, and the narrowly scoped quiet Git probes. No acronym registry update is required.

All required CI checks are green.