### PR TITLE
Reconcile retired schema inventory count

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1651"
+version = "0.2.1652"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1651"
+__version__ = "0.2.1652"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -593,6 +593,7 @@ _LEGACY_REPLACEMENT_RECEIPT_FIELDS = frozenset(
         "signature",
     }
 )
+_RETIRED_SCHEMA_COUNT_TEST_PATH = Path("tests/test_legacy_rulespec_freeze.py")
 _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS = frozenset(
     {
         Path(".axiom/index/provisions_to_rules.json"),
@@ -602,6 +603,7 @@ _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS = frozenset(
         Path("known-validation-gaps.yaml"),
         Path("oracle-coverage-pending.yaml"),
         Path("tests/test_encoding_manifests.py"),
+        _RETIRED_SCHEMA_COUNT_TEST_PATH,
     }
 )
 _MODEL_APPLIED_FILE_FIELDS = frozenset({"path", "sha256"})
@@ -24387,6 +24389,35 @@ def _legacy_replacement_manifest_issues(
         post_migration_waiver_sha256 = hashlib.sha256(rewritten_waiver_raw).hexdigest()
     except (RuntimeError, ValueError):
         pass
+    retired_schema_count_transition: tuple[int, int] | None = None
+    if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+        try:
+            base_retired_freeze_raw = _rulespec_migration_base_blob(
+                repo_path,
+                base_commit,
+                Path(".axiom/retired-schema-freeze.json"),
+            )
+            rewritten_retired_freeze_raw, _retired_freeze_operations = (
+                _legacy_metadata_reconciliation_bytes(
+                    Path(".axiom/retired-schema-freeze.json"),
+                    base_retired_freeze_raw,
+                    moves=primary_moves,
+                    retired_schema_modules=frozenset(
+                        exact_metadata_retired_schema_modules
+                    ),
+                )
+            )
+            before_retired_count = len(json.loads(base_retired_freeze_raw)["artifacts"])
+            after_retired_count = len(
+                json.loads(rewritten_retired_freeze_raw)["artifacts"]
+            )
+            if after_retired_count < before_retired_count:
+                retired_schema_count_transition = (
+                    before_retired_count,
+                    after_retired_count,
+                )
+        except (RuntimeError, ValueError):
+            pass
     listed_metadata_paths: set[Path] = set()
     for reconciliation in metadata_reconciliations:
         if not isinstance(reconciliation, dict) or set(reconciliation) != {
@@ -24424,6 +24455,7 @@ def _legacy_replacement_manifest_issues(
                 validation_waiver_set_sha256=post_migration_waiver_sha256,
                 retired_manifest_paths=frozenset(exact_metadata_manifest_paths),
                 retired_schema_modules=frozenset(exact_metadata_retired_schema_modules),
+                retired_schema_count_transition=retired_schema_count_transition,
                 reindexed_modules=exact_metadata_reindexed_modules,
             )
         except (OSError, RuntimeError, UnsafeCorpusPathError, ValueError) as exc:
@@ -24456,6 +24488,7 @@ def _legacy_replacement_manifest_issues(
                 validation_waiver_set_sha256=post_migration_waiver_sha256,
                 retired_manifest_paths=frozenset(exact_metadata_manifest_paths),
                 retired_schema_modules=frozenset(exact_metadata_retired_schema_modules),
+                retired_schema_count_transition=retired_schema_count_transition,
                 reindexed_modules=exact_metadata_reindexed_modules,
             )
         except (RuntimeError, ValueError):
@@ -26732,6 +26765,7 @@ def _legacy_metadata_reconciliation_bytes(
     validation_waiver_set_sha256: str | None = None,
     retired_manifest_paths: frozenset[str] = frozenset(),
     retired_schema_modules: frozenset[str] = frozenset(),
+    retired_schema_count_transition: tuple[int, int] | None = None,
     reindexed_modules: Mapping[str, bytes] | None = None,
 ) -> tuple[bytes, tuple[dict[str, object], ...]]:
     """Apply one audited metadata cleanup from an explicit move set."""
@@ -26846,6 +26880,50 @@ def _legacy_metadata_reconciliation_bytes(
                 "count": len(removed_modules),
             },
         )
+    elif path == _RETIRED_SCHEMA_COUNT_TEST_PATH:
+        if (
+            retired_schema_count_transition is None
+            or len(retired_schema_count_transition) != 2
+            or any(
+                not isinstance(value, int) or isinstance(value, bool) or value < 0
+                for value in retired_schema_count_transition
+            )
+        ):
+            raise ValueError(
+                "retired-schema count assertion lacks an exact count transition"
+            )
+        before_count, after_count = retired_schema_count_transition
+        if after_count >= before_count:
+            raise ValueError("retired-schema count transition is not decrement-only")
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeError as exc:
+            raise ValueError("retired-schema count test is not UTF-8") from exc
+        pattern = re.compile(
+            r'(?m)^(?P<indent>[ \t]*)assert len\(retired\["artifacts"\]\) == '
+            r"(?P<count>[0-9]+)(?P<trailing>[ \t]*)$"
+        )
+        matches = list(pattern.finditer(text))
+        if len(matches) != 1 or int(matches[0].group("count")) != before_count:
+            raise ValueError(
+                "retired-schema count test lacks one exact base-count assertion"
+            )
+        rewritten_text, count = pattern.subn(
+            lambda match: (
+                f'{match.group("indent")}assert len(retired["artifacts"]) == '
+                f"{after_count}{match.group('trailing')}"
+            ),
+            text,
+        )
+        if count != 1:
+            raise ValueError("retired-schema count assertion rewrite is not exact")
+        rewritten = rewritten_text.encode("utf-8")
+        operations = (
+            {
+                "operation": "decrement_retired_schema_artifact_count",
+                "count": before_count - after_count,
+            },
+        )
     elif path == Path("known-validation-gaps.yaml"):
         rewritten, count = _line_preserving_yaml_mapping_removal(raw, keys=old_modules)
         operations = ({"operation": "remove_legacy_validation_gaps", "count": count},)
@@ -26922,6 +27000,29 @@ def _legacy_metadata_reconciliations(
         )
         for dependent in exact_dependents
     }
+    retired_schema_count_transition: tuple[int, int] | None = None
+    retired_freeze_path = Path(".axiom/retired-schema-freeze.json")
+    if retired_freeze_path in tracked:
+        retired_freeze_raw = read_bounded_regular_file(
+            checkout_root,
+            checkout_root / retired_freeze_path,
+            label="legacy retired-schema count reconciliation",
+            max_bytes=16 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        rewritten_retired_freeze, _operations = _legacy_metadata_reconciliation_bytes(
+            retired_freeze_path,
+            retired_freeze_raw,
+            moves=moves,
+            retired_schema_modules=retired_schema_modules,
+        )
+        before_retired_count = len(json.loads(retired_freeze_raw)["artifacts"])
+        after_retired_count = len(json.loads(rewritten_retired_freeze)["artifacts"])
+        if after_retired_count < before_retired_count:
+            retired_schema_count_transition = (
+                before_retired_count,
+                after_retired_count,
+            )
     relevant_values = {
         Path(".axiom/index/provisions_to_rules.json"): old_modules
         | set(reindexed_modules),
@@ -26931,6 +27032,7 @@ def _legacy_metadata_reconciliations(
         Path("known-validation-gaps.yaml"): old_modules,
         Path("oracle-coverage-pending.yaml"): old_identities,
         Path("tests/test_encoding_manifests.py"): old_manifests,
+        _RETIRED_SCHEMA_COUNT_TEST_PATH: set(),
     }
     post_migration_waiver_sha256: str | None = None
     waiver_path = Path("known-validation-gaps.yaml")
@@ -26966,7 +27068,10 @@ def _legacy_metadata_reconciliations(
             max_bytes=16 * 1024 * 1024,
             required_mode=0o644,
         )
-        if path != Path(".axiom/toolchain.toml") and not any(
+        if path == _RETIRED_SCHEMA_COUNT_TEST_PATH:
+            if retired_schema_count_transition is None:
+                continue
+        elif path != Path(".axiom/toolchain.toml") and not any(
             value.encode() in raw for value in relevant_values[path]
         ):
             continue
@@ -26981,6 +27086,7 @@ def _legacy_metadata_reconciliations(
             validation_waiver_set_sha256=post_migration_waiver_sha256,
             retired_manifest_paths=retired_manifest_paths,
             retired_schema_modules=retired_schema_modules,
+            retired_schema_count_transition=retired_schema_count_transition,
             reindexed_modules=reindexed_modules,
         )
         if rewritten == raw:

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -46,6 +46,7 @@ LEGACY_REPLACEMENT_METADATA_PATHS = frozenset(
         PurePosixPath("known-validation-gaps.yaml"),
         PurePosixPath("oracle-coverage-pending.yaml"),
         PurePosixPath("tests/test_encoding_manifests.py"),
+        PurePosixPath("tests/test_legacy_rulespec_freeze.py"),
     }
 )
 RULESPEC_ATOMIC_ROOTS = frozenset(
@@ -2852,6 +2853,37 @@ def authorized_changed_paths(
                 ).hexdigest()
             except (subprocess.CalledProcessError, ValueError):
                 pass
+            retired_schema_count_transition: tuple[int, int] | None = None
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V7:
+                try:
+                    base_retired_freeze_raw = _git_quiet(
+                        repo,
+                        "show",
+                        "HEAD:.axiom/retired-schema-freeze.json",
+                    )
+                    rewritten_retired_freeze_raw, _retired_freeze_operations = (
+                        _legacy_metadata_reconciliation_bytes(
+                            Path(".axiom/retired-schema-freeze.json"),
+                            base_retired_freeze_raw,
+                            moves=primary_moves,
+                            retired_schema_modules=frozenset(
+                                exact_metadata_retired_schema_modules
+                            ),
+                        )
+                    )
+                    before_retired_count = len(
+                        json.loads(base_retired_freeze_raw)["artifacts"]
+                    )
+                    after_retired_count = len(
+                        json.loads(rewritten_retired_freeze_raw)["artifacts"]
+                    )
+                    if after_retired_count < before_retired_count:
+                        retired_schema_count_transition = (
+                            before_retired_count,
+                            after_retired_count,
+                        )
+                except (subprocess.CalledProcessError, ValueError):
+                    pass
             metadata_paths: set[PurePosixPath] = set()
             for index, reconciliation in enumerate(metadata_reconciliations):
                 if not isinstance(reconciliation, dict) or set(reconciliation) != {
@@ -2894,6 +2926,9 @@ def authorized_changed_paths(
                             retired_schema_modules=frozenset(
                                 exact_metadata_retired_schema_modules
                             ),
+                            retired_schema_count_transition=(
+                                retired_schema_count_transition
+                            ),
                             reindexed_modules=exact_metadata_reindexed_modules,
                         )
                     )
@@ -2935,6 +2970,9 @@ def authorized_changed_paths(
                             ),
                             retired_schema_modules=frozenset(
                                 exact_metadata_retired_schema_modules
+                            ),
+                            retired_schema_count_transition=(
+                                retired_schema_count_transition
                             ),
                             reindexed_modules=exact_metadata_reindexed_modules,
                         )

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1651"
+ENCODER_VERSION = "0.2.1652"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15215,6 +15215,30 @@ class TestCmdEncode:
             )
             + "    'keep.json',\n}\n"
         )
+        retired_freeze = checkout / ".axiom/retired-schema-freeze.json"
+        retired_freeze.write_text(
+            json.dumps(
+                {
+                    "format": "axiom/retired-schema-freeze/v1",
+                    "artifacts": {
+                        dependent_relative.as_posix(): _sha256_file(dependent),
+                        second_dependent_relative.as_posix(): _sha256_file(
+                            second_dependent
+                        ),
+                        "us-hi/policies/keep.yaml": "a" * 64,
+                    },
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        retired_freeze_test = checkout / "tests/test_legacy_rulespec_freeze.py"
+        retired_freeze_test.write_text(
+            "def test_frozen_legacy_inventory_matches_repository():\n"
+            "    retired = {'artifacts': {}}\n"
+            '    assert len(retired["artifacts"]) == 3\n'
+        )
         _git(checkout, "init", "-b", "main")
         _git(checkout, "config", "user.email", "test@example.com")
         _git(checkout, "config", "user.name", "Test User")
@@ -15569,10 +15593,12 @@ class TestCmdEncode:
         assert {item["path"] for item in metadata_reconciliations} == {
             ".axiom/index/provisions_to_rules.json",
             ".axiom/pending-validation-fingerprints.json",
+            ".axiom/retired-schema-freeze.json",
             ".axiom/toolchain.toml",
             "known-validation-gaps.yaml",
             "oracle-coverage-pending.yaml",
             "tests/test_encoding_manifests.py",
+            "tests/test_legacy_rulespec_freeze.py",
         }
         for reconciliation in metadata_reconciliations:
             metadata_path = checkout / reconciliation["path"]
@@ -15590,6 +15616,13 @@ class TestCmdEncode:
             )
         assert source_manifest.relative_to(checkout).as_posix().encode() not in (
             manifest_inventory.read_bytes()
+        )
+        retired_artifact_count = len(
+            json.loads(retired_freeze.read_text())["artifacts"]
+        )
+        assert (
+            f'assert len(retired["artifacts"]) == {retired_artifact_count}'
+            in retired_freeze_test.read_text()
         )
         assert receipt["legacy"]["owner_class"] == "v1-hmac-untrusted"
         assert receipt["replacement"]["destination_predecessor_class"] == (

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1651"
+ENCODER_VERSION = "0.2.1652"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1651"
+ENCODER_VERSION = "0.2.1652"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -2014,6 +2014,36 @@ def test_exact_dependent_metadata_reconciliation_is_complete() -> None:
         {"operation": "remove_migrated_retired_schema_modules", "count": 1},
     )
 
+    count_test = (
+        "def test_frozen_legacy_inventory_matches_repository():\n"
+        '    retired = {"artifacts": {}}\n'
+        '    assert len(retired["artifacts"]) == 2\n'
+    ).encode()
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path("tests/test_legacy_rulespec_freeze.py"),
+        count_test,
+        moves=moves,
+        retired_schema_count_transition=(2, 1),
+    )
+    assert b'assert len(retired["artifacts"]) == 1' in rewritten
+    assert operations == (
+        {"operation": "decrement_retired_schema_artifact_count", "count": 1},
+    )
+    with pytest.raises(ValueError, match="exact base-count assertion"):
+        _legacy_metadata_reconciliation_bytes(
+            Path("tests/test_legacy_rulespec_freeze.py"),
+            count_test,
+            moves=moves,
+            retired_schema_count_transition=(3, 1),
+        )
+    with pytest.raises(ValueError, match="not decrement-only"):
+        _legacy_metadata_reconciliation_bytes(
+            Path("tests/test_legacy_rulespec_freeze.py"),
+            count_test,
+            moves=moves,
+            retired_schema_count_transition=(2, 2),
+        )
+
 
 def test_toolchain_reconciliation_binds_exact_post_migration_waiver_digest() -> None:
     moves = (

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1651"
+ENCODER_VERSION = "0.2.1652"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1651"
+ENCODER_VERSION = "0.2.1652"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1651"
+ENCODER_VERSION = "0.2.1652"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1651"
+ENCODER_VERSION = "0.2.1652"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1651"')
+        .startswith('__version__ = "0.2.1652"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1651"
+    assert encoder_package["version"] == "0.2.1652"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1651"
+    assert project["project"]["version"] == "0.2.1652"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1651"')
+        .startswith('__version__ = "0.2.1652"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1651"
+    assert encoder_package["version"] == "0.2.1652"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1651"
+    assert project["project"]["version"] == "0.2.1652"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1651"')
+        .startswith('__version__ = "0.2.1652"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1651"
+ENCODER_VERSION = "0.2.1652"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -15,7 +15,7 @@ import tarfile
 import threading
 from base64 import b64decode, b64encode
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from unittest.mock import patch
 
 import _cffi_backend
@@ -1473,7 +1473,11 @@ def test_protected_supervisor_stages_authenticated_v7_exact_dependent_transactio
     assert isinstance(rulespec_root, Path)
     assert isinstance(corpus_root, Path)
     assert isinstance(expected_paths, tuple)
-    assert len(expected_paths) == 32
+    assert len(expected_paths) == 34
+    assert {
+        PurePosixPath(".axiom/retired-schema-freeze.json"),
+        PurePosixPath("tests/test_legacy_rulespec_freeze.py"),
+    } <= set(expected_paths)
 
     runtime = trusted_real_cli_runtime.__wrapped__(tmp_path_factory)
     interpreter, runtime_root, _package_root = runtime

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1651"
+version = "0.2.1652"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- authenticate and reconcile the RuleSpec retired-schema inventory count when exact legacy dependents are migrated
- require one exact base-count assertion and a decrement-only transition
- keep publisher and persisted/signed-backfill verification symmetric and receipt-v7 scoped
- bump the encoder and all current-package version invariants to 0.2.1652

This is the owner-layer fix for the sole failure discovered in the closed, unmerged generated RuleSpec PR #1265. It does not change targeted dispatch inputs or dispatch semantics.

## Validation

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused legacy replacement and signed-backfill suite: 263 passed
- production-shaped exact-dependent integration: 2 passed
- affected version/package invariants: 27 passed
- full suite: 12,449 passed, 123 skipped

## Review cycle

Independent review found one merge-blocking incomplete-version-bump issue. That was fixed, focused tests were rerun, and the exact amended SHA `91097d60c7a286d306204a286f178a10ca0f4398` received a clean independent re-review. No acronym flag is required.
