### PR TITLE
Allow current reviewed US RuleSpec hard-cut tip

### DIFF
--- a/changelog.d/admit-post-louisiana-rulespec-root.changed.md
+++ b/changelog.d/admit-post-louisiana-rulespec-root.changed.md
@@ -1,0 +1,1 @@
+Admit the exact independently reviewed post-Louisiana US RuleSpec hard-cut root for protected signed re-encoding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1652"
+version = "0.2.1653"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1652"
+__version__ = "0.2.1653"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -105,6 +105,10 @@ REVIEWED_RULESPEC_REFS = frozenset(
         ),
         (
             "us",
+            "2a503a5c9a2227c363aceaece6c547429c3c0878",
+        ),
+        (
+            "us",
             "6535019ce780d9e78f10509f2fe7a2607fb2bdc4",
         ),
         (

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1652"
+ENCODER_VERSION = "0.2.1653"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1652"
+ENCODER_VERSION = "0.2.1653"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1652"
+ENCODER_VERSION = "0.2.1653"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1652"
+ENCODER_VERSION = "0.2.1653"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1652"
+ENCODER_VERSION = "0.2.1653"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1652"
+ENCODER_VERSION = "0.2.1653"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1652"
+ENCODER_VERSION = "0.2.1653"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -3360,6 +3360,7 @@ def test_validate_rulespec_base_rejects_stale_main_pr_base(
         ("us", "f4fd3203db560c0d4661542388b6ae2f353e0bd3"),
         ("us", "e942ce50546b1c3a1c0c8f3f0404a217eddbe071"),
         ("us", "dc87ef6212accbc4ff67b81f97b6ddf0cf3b5a5c"),
+        ("us", "2a503a5c9a2227c363aceaece6c547429c3c0878"),
         ("us", "6535019ce780d9e78f10509f2fe7a2607fb2bdc4"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
@@ -3383,6 +3384,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
             ("us", "f4fd3203db560c0d4661542388b6ae2f353e0bd3"),
             ("us", "e942ce50546b1c3a1c0c8f3f0404a217eddbe071"),
             ("us", "dc87ef6212accbc4ff67b81f97b6ddf0cf3b5a5c"),
+            ("us", "2a503a5c9a2227c363aceaece6c547429c3c0878"),
             ("us", "6535019ce780d9e78f10509f2fe7a2607fb2bdc4"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -3415,7 +3415,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_protected_branch_tip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = tmp_path / "rulespec-us"
-    reviewed_ref = "dc87ef6212accbc4ff67b81f97b6ddf0cf3b5a5c"
+    reviewed_ref = "2a503a5c9a2227c363aceaece6c547429c3c0878"
     git_calls: list[tuple[str, ...]] = []
 
     def fake_git(_repo: Path, *args: str) -> bytes:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1652"')
+        .startswith('__version__ = "0.2.1653"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1652"
+    assert encoder_package["version"] == "0.2.1653"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1652"
+    assert project["project"]["version"] == "0.2.1653"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1652"')
+        .startswith('__version__ = "0.2.1653"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1652"
+    assert encoder_package["version"] == "0.2.1653"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1652"
+    assert project["project"]["version"] == "0.2.1653"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1652"')
+        .startswith('__version__ = "0.2.1653"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1652"
+ENCODER_VERSION = "0.2.1653"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1652"
+version = "0.2.1653"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- admit only the exact independently reviewed post-Louisiana `rulespec-us` hard-cut tip `2a503a5c9a2227c363aceaece6c547429c3c0878` for protected signed runs
- retain exact protected-branch-tip enforcement; historical allowlisted roots remain artifact-only for PR publication
- advance the protected-tip regression, version-coupled package assertions, and changelog consistently to encoder `0.2.1653`

The admitted commit is the reviewed and merged RuleSpec PR #1266 root. This is the owner-layer continuation authorization needed before the next state-income-tax signed-v5 targets. It also unblocks the isolated signed §273.4 canonicalization prerequisite for RuleSpec issue #1248 without coupling the two sessions.

No workflow input, dispatch logic, queue behavior, or signing boundary changes. No concept/acronym change is introduced.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` — 12,450 passed, 123 skipped
- focused RuleSpec-base authorization selection — 25 passed
- full `test_prepare_signed_backfill.py` plus all touched oracle-registry files — 195 passed
- `uv lock --check --python 3.13`
- `git diff --check`

## Review cycle

- Independent exact-tree review: CLEAN; no actionable findings.
- Verified exact-SHA-only admission, stale protected-tip rejection, version/lock/test consistency, changelog, and absence of unintended behavior.
- After integrating the completion into the existing contributor branch, a second independent exact-head review confirmed `cc1cc90e649ece695879f70f407226ff58e0bda5` is byte-identical to the previously reviewed candidate tree `bd4b975a5de8aa8f45d60fef7384f0bc08f521df` and preserves both contributor commits as linear ancestors.
