### PR TITLE
Fix state PIT validation normalization

### DIFF
--- a/changelog.d/state-pit-validation-normalization.fixed.md
+++ b/changelog.d/state-pit-validation-normalization.fixed.md
@@ -1,0 +1,1 @@
+Preserve exact generated decimal test literals, recognize numeric-root U.S. statutory outlines with spaced nested markers, and exclude fully validated terminal Alabama Act/Code history from substantive numeric recall.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1653"
+version = "0.2.1654"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1653"
+__version__ = "0.2.1654"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -236,6 +236,7 @@ SUPPORTED_EVAL_DTYPES = (
     "Float",
 )
 _PURE_NUMERIC_EXPRESSION_PATTERN = re.compile(r"^[\d\s()+\-*/.,]+$")
+_PLAIN_SIGNED_NUMERIC_LITERAL_PATTERN = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$")
 _ISO_WEEK_PERIOD_PATTERN = re.compile(r"^\d{4}-W\d{2}(?:-\d)?$")
 _ADMIN_AGENCY_AGGREGATE_SUBJECT_PATTERN = re.compile(
     r"\b(?:FNS|State\s+agenc(?:y|ies)|State(?:'s)?\s+administration|"
@@ -15651,6 +15652,13 @@ def _normalize_test_case_value(value: object) -> object:
     if isinstance(value, str):
         expression = value.strip()
         if _PURE_NUMERIC_EXPRESSION_PATTERN.fullmatch(expression):
+            if _PLAIN_SIGNED_NUMERIC_LITERAL_PATTERN.fullmatch(expression):
+                if "." in expression:
+                    return expression
+                try:
+                    return int(expression)
+                except ValueError:
+                    return value
             try:
                 formatted = _format_safe_numeric_expression(expression)
                 if formatted is None:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -241,12 +241,16 @@ _LETTER_MARKER = re.compile(
 )
 _PARENTHESIZED_OUTLINE_MARKER = re.compile(
     r"(?m)^[ \t]*(?:[A-Z]\.)?"
-    r"(?P<marker>(?:\((?:\d+[a-z]?|[a-z]|[ivxlcdm]{2,15})\))+)(?=\s|bis\b)",
+    r"(?P<marker>\((?:\d+[a-z]?|[a-z]|[ivxlcdm]{2,15})\)"
+    r"(?:[ \t]*\((?:\d+[a-z]?|[a-z]|[ivxlcdm]{2,15})\))*)"
+    r"(?=\s|bis\b)",
     flags=re.IGNORECASE,
 )
 _INLINE_PARENTHESIZED_OUTLINE_MARKER = re.compile(
     r"(?:(?<=[.!?;:])[ \t]+|(?<=—)[ \t]*)"
-    r"(?P<marker>(?:\((?:\d+[a-z]?|[a-z]|[ivxlcdm]{2,15})\))+)(?=\s|bis\b)",
+    r"(?P<marker>\((?:\d+[a-z]?|[a-z]|[ivxlcdm]{2,15})\)"
+    r"(?:[ \t]*\((?:\d+[a-z]?|[a-z]|[ivxlcdm]{2,15})\))*)"
+    r"(?=\s|bis\b)",
     flags=re.IGNORECASE,
 )
 _INLINE_OUTLINE_REFERENCE_CONTEXT = re.compile(
@@ -2045,6 +2049,30 @@ _SESSION_LAW_YEAR_CHAPTER = re.compile(
     r"(?:(?:P\.?\s*L\.?|L\.)\s*)?\d{4}\s*,\s*c\.\s*\d+",
     flags=re.IGNORECASE,
 )
+_ALABAMA_TERMINAL_ACT_HISTORY_ENTRY = re.compile(
+    r"\s*Acts?\s+"
+    r"(?:"
+    r"\d{4}\s*,\s*"
+    r"(?:"
+    r"(?:(?:\d+\s*(?:st|nd|rd|th|d)|"
+    r"[A-Za-z]+(?:[-\s]+[A-Za-z]+){0,3})\s+)?"
+    r"(?:E\.?\s*S\.?|Ex\.?|Extra\.?|Extraordinary)\s*"
+    r"(?:Sess\.?|Session)\s*,\s*"
+    r")?"
+    r"Nos?\.?\s*\d+(?:-\d+)?"
+    r"|\d{2}-\d+"
+    r")"
+    r"\s*,\s*p\.?\s*\d+"
+    r"(?:\s*,\s*§{1,2}\s*\d+(?:\s*(?:,|and|through|to|[-–—])\s*\d+)*)?"
+    r"\s*\.?\s*",
+    flags=re.IGNORECASE,
+)
+_ALABAMA_TERMINAL_CODE_HISTORY_ENTRY = re.compile(
+    r"\s*Code\s+\d{4}\s*,\s*T\.?\s*\d+\s*,\s*"
+    r"§{1,2}\s*\d+(?:\s*(?:,|and|through|to|[-–—])\s*\d+)*"
+    r"\s*\.?\s*",
+    flags=re.IGNORECASE,
+)
 _FORMULA_IDENTIFIER = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
 
 
@@ -2471,6 +2499,17 @@ _PARENTHESIZED_LEGAL_OUTLINE_LEVELS = (
     "numeric",
     "roman",
 )
+_NUMERIC_ROOT_PARENTHESIZED_LEGAL_OUTLINE_LEVELS = (
+    "numeric",
+    "lower-alpha",
+    "roman",
+    "upper-alpha",
+    "numeric",
+    "roman",
+    "upper-alpha",
+    "numeric",
+    "roman",
+)
 
 
 def _qualified_parenthesized_legal_outline_markers(
@@ -2501,6 +2540,13 @@ def _qualified_parenthesized_legal_outline_markers(
     if not matches:
         return ()
 
+    first_labels = tuple(re.findall(r"\(([A-Za-z0-9]+)\)", matches[0].group("marker")))
+    outline_levels = (
+        _NUMERIC_ROOT_PARENTHESIZED_LEGAL_OUTLINE_LEVELS
+        if first_labels and first_labels[0][0].isdigit()
+        else _PARENTHESIZED_LEGAL_OUTLINE_LEVELS
+    )
+
     markers: list[_OutlineMarker] = []
     emitted_paths: set[tuple[str, ...]] = set()
     active: list[tuple[int, str, str, str]] = []
@@ -2517,6 +2563,7 @@ def _qualified_parenthesized_legal_outline_markers(
                 raw_label,
                 active=active,
                 attached_parent_level=attached_parent_level,
+                outline_levels=outline_levels,
             )
             if marker_start in inline_marker_starts and label_index == 0 and level == 0:
                 break
@@ -2545,13 +2592,11 @@ def _qualified_parenthesized_legal_outline_markers(
                 emitted_paths.add(path)
             attached_parent_level = level
 
-    root_labels = [
-        marker.path[0]
-        for marker in markers
-        if len(marker.path) == 1 and marker.label[1:-1].islower()
-    ]
+    root_category = outline_levels[0]
+    root_labels = [marker.label[1:-1] for marker in markers if len(marker.path) == 1]
     has_sequential_roots = any(
-        first == "a" and second == "b"
+        _parenthesized_outline_label_is_first(first, root_category)
+        and _parenthesized_outline_label_follows(first, second, root_category)
         for first, second in itertools.pairwise(root_labels)
     )
     return tuple(markers) if has_sequential_roots else ()
@@ -2577,12 +2622,11 @@ def _parenthesized_legal_outline_level(
     *,
     active: Sequence[tuple[int, str, str, str]],
     attached_parent_level: int | None,
+    outline_levels: Sequence[str],
 ) -> tuple[int, str]:
     categories = _parenthesized_legal_outline_categories(raw_label)
     candidate_levels = tuple(
-        level
-        for level, category in enumerate(_PARENTHESIZED_LEGAL_OUTLINE_LEVELS)
-        if category in categories
+        level for level, category in enumerate(outline_levels) if category in categories
     )
     if not candidate_levels:
         return 0, categories[0]
@@ -2592,7 +2636,7 @@ def _parenthesized_legal_outline_level(
             (level for level in candidate_levels if level > attached_parent_level),
             candidate_levels[-1],
         )
-        return level, _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level]
+        return level, outline_levels[level]
 
     continuing = [
         (level, category)
@@ -2610,12 +2654,12 @@ def _parenthesized_legal_outline_level(
         if level > parent_level
         and _parenthesized_outline_label_is_first(
             raw_label,
-            _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level],
+            outline_levels[level],
         )
     ]
     if first_descending:
         level = first_descending[0]
-        return level, _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level]
+        return level, outline_levels[level]
 
     same_category = [
         (level, category)
@@ -2628,10 +2672,10 @@ def _parenthesized_legal_outline_level(
     descending = [level for level in candidate_levels if level > parent_level]
     if descending:
         level = descending[0]
-        return level, _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level]
+        return level, outline_levels[level]
 
     level = min(candidate_levels, key=lambda item: abs(item - parent_level))
-    return level, _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level]
+    return level, outline_levels[level]
 
 
 def _parenthesized_legal_outline_categories(raw_label: str) -> tuple[str, ...]:
@@ -10893,6 +10937,22 @@ def _branch_citation(
 
 def _strip_terminal_session_law_history(source_text: str) -> str:
     """Remove only a fully validated terminal session-law history chain."""
+
+    terminal_parenthetical = re.search(
+        r"\s+\((?P<history>[^()]*)\)\s*$",
+        source_text,
+    )
+    if terminal_parenthetical is not None:
+        history_entries = tuple(
+            entry.strip()
+            for entry in terminal_parenthetical.group("history").split(";")
+        )
+        if history_entries and all(
+            _ALABAMA_TERMINAL_ACT_HISTORY_ENTRY.fullmatch(entry)
+            or _ALABAMA_TERMINAL_CODE_HISTORY_ENTRY.fullmatch(entry)
+            for entry in history_entries
+        ):
+            return source_text[: terminal_parenthetical.start()].rstrip()
 
     blank_lines = tuple(re.finditer(r"\n[ \t]*\n", source_text))
     if blank_lines:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1653"
+ENCODER_VERSION = "0.2.1654"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -11859,6 +11859,70 @@ rules:
     def test_normalize_test_case_value_preserves_invalid_numeric_expression(self):
         assert _normalize_test_case_value("30 / 0") == "30 / 0"
 
+    @pytest.mark.parametrize(
+        "literal",
+        (
+            "432.09845",
+            "117.60035",
+            "12345.67",
+            "+0.00035",
+            "-0.00035",
+        ),
+    )
+    def test_normalize_test_case_value_preserves_decimal_literal_precision(
+        self,
+        literal,
+    ):
+        assert _normalize_test_case_value(literal) == literal
+
+    def test_normalize_test_case_value_converts_plain_integer_literal(self):
+        assert _normalize_test_case_value("350") == 350
+
+    def test_materialize_eval_artifact_preserves_decimal_literal_precision(
+        self,
+        tmp_path,
+    ):
+        output_file = tmp_path / "source" / "kentucky_rate.yaml"
+        response = """=== FILE: kentucky_rate.yaml ===
+format: rulespec/v1
+module:
+  summary: Kentucky tax before credits is 3.5 percent of net income.
+rules:
+  - name: normal_tax_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: net_income * 0.035
+inputs:
+  - name: net_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+=== FILE: kentucky_rate.test.yaml ===
+- name: fractional_net_income_before_credits
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    '#input.net_income': '12345.67'
+  output:
+    '#normal_tax_before_credits': '432.09845'
+"""
+
+        wrote = _materialize_eval_artifact(response, output_file)
+
+        assert wrote is True
+        cases = yaml.safe_load(output_file.with_suffix(".test.yaml").read_text())
+        assert cases[0]["input"]["#input.net_income"] == "12345.67"
+        assert cases[0]["output"]["#normal_tax_before_credits"] == "432.09845"
+
     def test_materialize_eval_artifact_adds_missing_oracle_hint_output_from_rulespec(
         self, tmp_path
     ):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1653"
+ENCODER_VERSION = "0.2.1654"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1653"
+ENCODER_VERSION = "0.2.1654"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1653"
+ENCODER_VERSION = "0.2.1654"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1653"
+ENCODER_VERSION = "0.2.1654"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1653"
+ENCODER_VERSION = "0.2.1654"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1653"
+ENCODER_VERSION = "0.2.1654"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1653"')
+        .startswith('__version__ = "0.2.1654"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1653"
+    assert encoder_package["version"] == "0.2.1654"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1653"
+    assert project["project"]["version"] == "0.2.1654"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1653"')
+        .startswith('__version__ = "0.2.1654"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1653"
+    assert encoder_package["version"] == "0.2.1654"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1653"
+    assert project["project"]["version"] == "0.2.1654"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1653"')
+        .startswith('__version__ = "0.2.1654"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1653"
+ENCODER_VERSION = "0.2.1654"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1606,6 +1606,58 @@ def test_parenthesized_cfr_outline_keeps_colliding_branch_text_separate():
     assert "Canadian-born member" not in by_path[("c", "3")].text
 
 
+def test_numeric_root_parenthesized_outline_preserves_spaced_nested_markers():
+    source = """\
+(1) (a) Resident schedule.
+(i) 1. First band.
+2. Second band.
+3. Third band.
+(ii) Fourth-percent band.
+(iii) Fifth-percent band.
+(b) (i) Calendar-year exclusion.
+(ii) Scheduled later-year rates:
+1. First year.
+2. Second year.
+3. Third year.
+(2) S corporation exclusion.
+(3) Nonresident schedule.
+(4) Fiscal-year proration:
+(a) Earlier-year tax.
+(b) Later-year tax.
+"""
+
+    branches = recognize_source_structure(source)
+    assert [branch.path for branch in branches] == [
+        ("1",),
+        ("1", "a"),
+        ("1", "a", "i"),
+        ("1", "a", "i", "2"),
+        ("1", "a", "i", "3"),
+        ("1", "a", "ii"),
+        ("1", "a", "iii"),
+        ("1", "b"),
+        ("1", "b", "i"),
+        ("1", "b", "ii"),
+        ("1", "b", "ii", "1"),
+        ("1", "b", "ii", "2"),
+        ("1", "b", "ii", "3"),
+        ("2",),
+        ("3",),
+        ("4",),
+        ("4", "a"),
+        ("4", "b"),
+    ]
+    by_path = {branch.path: branch for branch in branches}
+    assert "Third band" in by_path[("1", "a", "i", "3")].text
+    assert "Third year" in by_path[("1", "b", "ii", "3")].text
+    assert "Nonresident schedule" in by_path[("3",)].text
+    assert "Fiscal-year proration" not in by_path[("3",)].text
+    assert ("ii",) not in by_path
+    assert by_path[("1",)].end == by_path[("2",)].start
+    assert by_path[("1", "a")].end == by_path[("1", "b")].start
+    assert by_path[("4", "a")].end == by_path[("4", "b")].start
+
+
 def test_parenthesized_cfr_outline_keeps_suffixed_numeric_siblings():
     source = """\
 (a) Status requirements.
@@ -13661,6 +13713,51 @@ def test_terminal_session_law_history_is_not_numeric_recall(history_tail):
     cleaned = authoritative_numeric_recall_text(f"{operative} {history_tail}")
 
     assert cleaned == operative
+
+
+def test_terminal_alabama_act_and_code_history_is_not_numeric_recall():
+    operative = (
+        "The tax is two percent of taxable income not in excess of five hundred "
+        "dollars ($500), four percent above $500 through $3,000, and five percent "
+        "above $3,000."
+    )
+    history = (
+        "(Acts 1935, No. 194, p. 256; Code 1940, T. 51, §377; Acts 1982, "
+        "No. 82-465, p. 759, §1; Acts 1982, 1st Ex. Sess., No. 82-667, "
+        "p. 85, §1; Act 98-502, p. 1083, §1.)"
+    )
+
+    cleaned = authoritative_numeric_recall_text(f"{operative} {history}")
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        cleaned,
+        profile="en-US",
+    )
+
+    assert cleaned == operative
+    assert [(item.value, item.raw) for item in inventory] == [
+        (500.0, "500"),
+        (500.0, "500"),
+        (3000.0, "3,000"),
+        (3000.0, "3,000"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The credit is 40%. (Acts 1935, No. 194, p. 256; operative amount $51.)",
+        "The credit is 40%. (Acts 1935, No. 194, p. 256.) Operative amount $51.",
+    ),
+)
+def test_alabama_shaped_history_does_not_hide_operative_amount(source):
+    cleaned = authoritative_numeric_recall_text(source)
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        cleaned,
+        profile="en-US",
+    )
+
+    assert "amount $51." in cleaned
+    assert any(item.value == 51.0 for item in inventory)
 
 
 def test_louisiana_session_law_citations_are_not_numeric_recall_values():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1653"
+version = "0.2.1654"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- preserve exact generated decimal test literals without routing plain decimals through binary-float formatting
- recognize numeric-root statutory outlines and spaced compound markers used by Mississippi
- exclude only fully validated terminal Alabama Act/Code history from substantive numeric recall
- bump the package to 0.2.1654 and add regression coverage

This changes validation/normalization ownership only. It does not redesign dispatch, retry, signing, or session behavior. No executable concept names or acronym registries change.

## Cycle

Independent exact-head review of `1803e525f` found no actionable issues. The reviewer separately ran all 5,318 source-completeness tests and confirmed the three fixes are fail-closed and preserve existing alpha-root behavior.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/axiom_encode/harness/evals.py src/axiom_encode/harness/source_completeness.py`
- `python -m compileall -q src/axiom_encode scripts`
- focused regression tests: 113 passed
- `uv run pytest`: 12,461 passed, 123 skipped
- `git diff --check`