### PR TITLE
Harden residual state PIT validation

### DIFF
--- a/changelog.d/state-pit-residual-validation.fixed.md
+++ b/changelog.d/state-pit-residual-validation.fixed.md
@@ -1,0 +1,3 @@
+Prevent legal citations from becoming false source branches, recognize progressive
+tax clamps as boundary witnesses, and preserve pre-deferral tax-band rules during
+purpose-specific repair.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1654"
+version = "0.2.1655"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1655"
+version = "0.2.1656"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1654"
+__version__ = "0.2.1655"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1655"
+__version__ = "0.2.1656"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -291,7 +291,8 @@ _INLINE_OUTLINE_CHAPEAU_REFERENCE_LEAD = re.compile(
 _GLUED_SENTENCE_MARKER = re.compile(
     r"(?<![\w])(?P<label>[1-9]\d?)"
     r"(?!(?i:st|nd|rd|th)\b)"
-    r"(?=[A-ZÄÖÜ](?!:)(?![./-]\d))"
+    r"(?=[A-ZÄÖÜ](?!:)(?![ \t]*[.:/\-\u2010-\u2015\u2212\ufe58\ufe63\uff0d]"
+    r"[ \t]*\d))"
 )
 _EXPLICIT_SENTENCE_MARKER = re.compile(
     r"(?:(?<=^)|(?<=[.;])|(?<=\)))[ \t]*Satz[ \t]+"
@@ -7257,12 +7258,10 @@ def _reason_names_missing_same_act_dependency(
         )
     if not exact_current_branch:
         return False
-    reason_sections = {
-        (match.group("section").lower(), match.group("act").lower())
-        for match in _SAME_ACT_SECTION_DEPENDENCY.finditer(reason)
-    }
+    reason_matches = tuple(_SAME_ACT_SECTION_DEPENDENCY.finditer(reason))
+    reason_sections = {match.group("section").lower() for match in reason_matches}
     source_sections = {
-        (match.group("section").lower(), match.group("act").lower())
+        match.group("section").lower()
         for match in _SAME_ACT_SECTION_DEPENDENCY.finditer(source_scope_text)
         if re.search(
             r"\b(?:except|unless|subject\s+to)\b",
@@ -7270,15 +7269,121 @@ def _reason_names_missing_same_act_dependency(
             flags=re.IGNORECASE,
         )
     }
-    if not reason_sections.intersection(source_sections):
+    matching_sections = reason_sections.intersection(source_sections)
+    if not matching_sections:
         return False
+    clauses = tuple(re.finditer(r"[^.;\n]+", reason))
+    for dependency_match in reason_matches:
+        identity = dependency_match.group("section").lower()
+        if identity not in matching_sections:
+            continue
+        clause_index = next(
+            (
+                index
+                for index, clause in enumerate(clauses)
+                if clause.start() <= dependency_match.start() < clause.end()
+            ),
+            None,
+        )
+        if clause_index is None:
+            continue
+        section = re.escape(dependency_match.group("section"))
+        for clause in clauses[clause_index : clause_index + 2]:
+            clause_text = clause.group(0)
+            if not re.search(rf"\bsection\s+{section}\b", clause_text, re.IGNORECASE):
+                continue
+            if _same_act_clause_names_missing_dependency(
+                clause_text,
+                section=section,
+            ):
+                return True
+    return False
+
+
+def _same_act_clause_names_missing_dependency(
+    clause_text: str, *, section: str
+) -> bool:
+    reference = rf"\bsection\s+{section}(?:\s+of\s+(?:this|the)\s+act)?\b"
+    direct_state = (
+        r"\s*(?:,\s*)?(?:(?:which|that)\s+)?(?:is|remains)\s+"
+        r"(?:missing|unavailable|not\s+(?:available|encoded|implemented|supplied))\b"
+    )
+    direct_match = re.search(reference + direct_state, clause_text, flags=re.IGNORECASE)
+    if direct_match and not _same_act_dependency_state_is_reversed(
+        clause_text,
+        direct_match,
+        section=section,
+    ):
+        return True
+    no_executable_for_section = (
+        r"\bno\s+executable\b[^,;]{0,100}\b(?:for|from|under)\s+(?:the\s+)?" + reference
+    )
+    no_executable_match = re.search(
+        no_executable_for_section,
+        clause_text,
+        flags=re.IGNORECASE,
+    )
+    if no_executable_match and not _same_act_dependency_state_is_reversed(
+        clause_text,
+        no_executable_match,
+        section=section,
+    ):
+        return True
+    dependency_bridge = (
+        r"\b(?:requires?|depends?\s+on|until|without)\s+"
+        r"(?:an?\s+|the\s+)?(?:executable\s+)?" + reference
+    )
+    bridge_match = re.search(dependency_bridge, clause_text, flags=re.IGNORECASE)
     return bool(
-        _MISSING_DEPENDENCY_LANGUAGE.search(reason)
-        or re.search(
-            r"\b(?:no\s+executable|not\s+(?:available|encoded|implemented)|"
-            r"(?:is|are)\s+(?:not\s+)?(?:available|missing|unencoded|unsupplied)|"
-            r"(?:is|are)\s+not\s+supplied)\b",
-            reason,
+        bridge_match
+        and not _ADVERSATIVE_LANGUAGE.search(bridge_match.group(0))
+        and not _same_act_dependency_state_is_reversed(
+            clause_text,
+            bridge_match,
+            section=section,
+        )
+    )
+
+
+def _same_act_dependency_state_is_reversed(
+    clause_text: str,
+    dependency_match: re.Match[str],
+    *,
+    section: str,
+) -> bool:
+    """Reject bounded negation or a coordinated reversal of this dependency."""
+
+    prefix = clause_text[
+        max(0, dependency_match.start() - 80) : dependency_match.start()
+    ]
+    if re.search(
+        r"\b(?:"
+        r"(?:it\s+is\s+)?(?:false|untrue|not\s+true)\s+that"
+        r"(?:\s+there\s+is)?|"
+        r"no\s+(?:basis|evidence|indication|support)\s+that|"
+        r"not\s+(?:because|due\s+to)"
+        r")\s*$",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    suffix = clause_text[dependency_match.end() :]
+    reversal_subject = (
+        rf"(?:it|that\s+section|the\s+section|"
+        rf"section\s+{section}(?:\s+of\s+(?:this|the)\s+act)?|"
+        r"an?\s+executable\s+(?:output|rule))"
+    )
+    reversal_state = (
+        r"(?:is|remains)\s+(?:(?:actually|fully|in\s+fact)\s+)?"
+        r"(?:available|encoded|implemented|"
+        r"supplied|not\s+(?:missing|required|unavailable))|"
+        r"(?:is\s+)?not\s+required|(?:does\s+)?exists?"
+    )
+    return bool(
+        re.search(
+            rf"\b(?:although|but|however|nevertheless|nonetheless|though|yet)\b"
+            rf"[^.;\n]{{0,100}}?\b{reversal_subject}\s+{reversal_state}\b",
+            suffix,
             flags=re.IGNORECASE,
         )
     )
@@ -12705,11 +12810,11 @@ def _formula_execution_is_source_branch_witness(
         selector_values = _reached_formula_interval_selector_values(
             execution,
             case,
-            rule=rule,
             principal_rules=principal_rules,
             formula_environment=formula_environment,
             dependency_environment=dependency_environment,
             interval=interval,
+            source_text=branch.text,
         )
     else:
         selector_names = _rule_numeric_selector_names(rule)
@@ -13036,11 +13141,11 @@ def _reached_formula_interval_selector_values(
     execution: _FormulaExecution,
     case: dict[str, Any],
     *,
-    rule: dict[str, Any],
     principal_rules: dict[str, dict[str, Any]],
     formula_environment: dict[str, Any],
     dependency_environment: dict[str, Any],
     interval: _NumericInterval,
+    source_text: str,
 ) -> tuple[float, ...]:
     """Trace values paired with the source bound through derived selectors."""
 
@@ -13117,33 +13222,27 @@ def _reached_formula_interval_selector_values(
     )
     if values:
         return values
-    clamp_subject_names = _formula_progressive_clamp_subject_names(execution.leaf)
-    if not clamp_subject_names:
-        return ()
-    reached_names = set().union(
-        *(
-            set(_FORMULA_IDENTIFIER.findall(expression))
-            for expression in (
-                execution.leaf,
-                *(selector for step in execution.trace for selector in step.selectors),
-            )
-        ),
-        set(),
-    )
-    return _case_numeric_selector_values(
-        case,
-        _rule_numeric_selector_names(rule) & reached_names & clamp_subject_names,
-        dependency_environment=dependency_environment,
+    return _formula_progressive_clamp_subject_values(
+        execution.leaf,
+        environment=environment,
+        evidence_names=evidence_names,
+        source_text=source_text,
     )
 
 
-def _formula_progressive_clamp_subject_names(formula_text: str) -> set[str]:
-    """Return identifiers in a ``min(max(...), cap)`` progressive subject."""
+def _formula_progressive_clamp_subject_values(
+    formula_text: str,
+    *,
+    environment: dict[str, Any],
+    evidence_names: set[str],
+    source_text: str,
+) -> tuple[float, ...]:
+    """Evaluate the minuend subject in a reached ``min(max(...), cap)`` clamp."""
 
     expression = _parse_formula_expression(formula_text)
     if expression is None:
-        return set()
-    names: set[str] = set()
+        return ()
+    values: list[float] = []
     for node in ast.walk(expression):
         if not (
             isinstance(node, ast.Call)
@@ -13153,19 +13252,130 @@ def _formula_progressive_clamp_subject_names(formula_text: str) -> set[str]:
             and not node.keywords
         ):
             continue
-        for argument in node.args:
+        for argument, cap in (
+            (node.args[0], node.args[1]),
+            (node.args[1], node.args[0]),
+        ):
             if not (
                 isinstance(argument, ast.Call)
                 and isinstance(argument.func, ast.Name)
                 and argument.func.id == "max"
+                and len(argument.args) == 2
+                and not argument.keywords
             ):
                 continue
-            names.update(
-                candidate.id
-                for candidate in ast.walk(argument)
-                if isinstance(candidate, ast.Name) and candidate.id != "max"
+            zero_operands = [
+                operand
+                for operand in argument.args
+                if isinstance(operand, ast.Constant) and operand.value == 0
+            ]
+            if len(zero_operands) != 1:
+                continue
+            positive_operand = next(
+                operand for operand in argument.args if operand is not zero_operands[0]
             )
-    return names
+            if isinstance(positive_operand, ast.Name):
+                subject = positive_operand
+            elif (
+                isinstance(positive_operand, ast.BinOp)
+                and isinstance(positive_operand.op, ast.Sub)
+                and isinstance(positive_operand.left, ast.Name)
+                and isinstance(cap, ast.BinOp)
+                and isinstance(cap.op, ast.Sub)
+                and ast.dump(positive_operand.right) == ast.dump(cap.right)
+            ):
+                subject = positive_operand.left
+            else:
+                continue
+            if subject.id not in evidence_names or not _formula_subject_matches_source(
+                subject.id,
+                source_text,
+            ):
+                continue
+            value = _evaluate_condition_expression(subject, environment)
+            if _rulespec_runtime_decimal(value) is not None:
+                values.append(float(value))
+    return tuple(values)
+
+
+def _formula_progressive_clamp_subject_names(formula_text: str) -> tuple[str, ...]:
+    """Return structurally valid subject names from progressive clamps."""
+
+    expression = _parse_formula_expression(formula_text)
+    if expression is None:
+        return ()
+    names: list[str] = []
+    for node in ast.walk(expression):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "min"
+            and len(node.args) == 2
+            and not node.keywords
+        ):
+            continue
+        for argument, cap in (
+            (node.args[0], node.args[1]),
+            (node.args[1], node.args[0]),
+        ):
+            if not (
+                isinstance(argument, ast.Call)
+                and isinstance(argument.func, ast.Name)
+                and argument.func.id == "max"
+                and len(argument.args) == 2
+                and not argument.keywords
+            ):
+                continue
+            zero_operands = [
+                operand
+                for operand in argument.args
+                if isinstance(operand, ast.Constant) and operand.value == 0
+            ]
+            if len(zero_operands) != 1:
+                continue
+            positive_operand = next(
+                operand for operand in argument.args if operand is not zero_operands[0]
+            )
+            if isinstance(positive_operand, ast.Name):
+                names.append(positive_operand.id)
+            elif (
+                isinstance(positive_operand, ast.BinOp)
+                and isinstance(positive_operand.op, ast.Sub)
+                and isinstance(positive_operand.left, ast.Name)
+                and isinstance(cap, ast.BinOp)
+                and isinstance(cap.op, ast.Sub)
+                and ast.dump(positive_operand.right) == ast.dump(cap.right)
+            ):
+                names.append(positive_operand.left.id)
+    return tuple(names)
+
+
+def _formula_subject_matches_source(name: str, source_text: str) -> bool:
+    """Bind an inferred clamp minuend to the source's named subject."""
+
+    generic_tokens = {"amount", "base", "input", "subject", "total", "value"}
+    name_tokens = tuple(
+        token
+        for token in re.findall(r"[a-z0-9]+", name.lower().replace("_", " "))
+        if token not in generic_tokens
+    )
+    if not name_tokens:
+        return False
+    subject_phrase = r"\s+".join(re.escape(token) for token in name_tokens)
+    interval_comparison = (
+        r"(?:above|at\s+(?:least|most)|below|between|exceeds?|exceeding|from|"
+        r"greater\s+than|in\s+excess\s+of|less\s+than|more\s+than|"
+        r"no\s+(?:less|more|greater)\s+than|not\s+(?:in\s+excess\s+of|"
+        r"less\s+than|more\s+than|over)|over|through|under|up\s+to)"
+    )
+    return bool(
+        re.search(
+            rf"\b{subject_phrase}\b\s+"
+            rf"(?:(?:is|are|shall\s+be)\s+)?{interval_comparison}\b",
+            source_text,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _formula_interval_subject_values(
@@ -13459,6 +13669,13 @@ def _formula_execution_matches_source_branch(
         execution.leaf,
         environment=binding_environment,
     )
+    clamp_subject_names = _formula_progressive_clamp_subject_names(operative_leaf)
+    if interval is not None and clamp_subject_names:
+        if len(clamp_subject_names) != 1 or not _formula_subject_matches_source(
+            clamp_subject_names[0],
+            branch.text,
+        ):
+            return False
     source_topology = _explicit_source_arithmetic_topology(
         authoritative_numeric_recall_text(branch.text)
     )
@@ -16883,21 +17100,74 @@ def _formula_expression_has_boundary_clamp(
                 and not _formula_node_references_names(cap, input_names)
             ):
                 continue
-            if any(
-                _formula_node_boundary_value(
-                    candidate,
-                    boundary_names=boundary_names,
-                    boundary=boundary,
-                    formula_environment=formula_environment,
-                    extract_numeric_occurrences=extract_numeric_occurrences,
-                    numeric_value_is_grounded=numeric_value_is_grounded,
-                )
-                is not None
+            cap_names = {
+                candidate.id
                 for candidate in ast.walk(cap)
-                if isinstance(candidate, ast.expr)
+                if isinstance(candidate, ast.Name)
+            }
+            if not cap_names or cap_names.issubset(boundary_names):
+                cap_value = _evaluate_condition_expression(cap, formula_environment)
+                if _rulespec_runtime_decimal(
+                    cap_value
+                ) is not None and numeric_value_is_grounded(
+                    float(cap_value), (boundary,)
+                ):
+                    return True
+            if _formula_clamp_preserves_boundary_offset(
+                subject,
+                cap,
+                boundary_names=boundary_names,
+                boundary=boundary,
+                formula_environment=formula_environment,
+                numeric_value_is_grounded=numeric_value_is_grounded,
             ):
                 return True
     return False
+
+
+def _formula_clamp_preserves_boundary_offset(
+    subject: ast.expr,
+    cap: ast.expr,
+    *,
+    boundary_names: set[str],
+    boundary: NumericOccurrenceLike,
+    formula_environment: dict[str, Any],
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    """Accept ``min(max(0, x - a), ceiling - a)`` as an exact ceiling clamp."""
+
+    if not (isinstance(cap, ast.BinOp) and isinstance(cap.op, ast.Sub)):
+        return False
+    ceiling_names = {
+        candidate.id
+        for candidate in ast.walk(cap.left)
+        if isinstance(candidate, ast.Name)
+    }
+    if ceiling_names and not ceiling_names.issubset(boundary_names):
+        return False
+    positive_subject = next(
+        (
+            operand
+            for node in ast.walk(subject)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "max"
+            for operand in node.args
+            if not (isinstance(operand, ast.Constant) and operand.value == 0)
+        ),
+        None,
+    )
+    if not (
+        isinstance(positive_subject, ast.BinOp)
+        and isinstance(positive_subject.op, ast.Sub)
+        and ast.dump(positive_subject.right) == ast.dump(cap.right)
+    ):
+        return False
+    ceiling_value = _evaluate_condition_expression(cap.left, formula_environment)
+    return bool(
+        _rulespec_runtime_decimal(ceiling_value) is not None
+        and numeric_value_is_grounded(float(ceiling_value), (boundary,))
+    )
 
 
 def _parse_formula_expression(text: str) -> ast.expr | None:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -291,7 +291,7 @@ _INLINE_OUTLINE_CHAPEAU_REFERENCE_LEAD = re.compile(
 _GLUED_SENTENCE_MARKER = re.compile(
     r"(?<![\w])(?P<label>[1-9]\d?)"
     r"(?!(?i:st|nd|rd|th)\b)"
-    r"(?=[A-ZÄÖÜ](?!:))"
+    r"(?=[A-ZÄÖÜ](?!:)(?![./-]\d))"
 )
 _EXPLICIT_SENTENCE_MARKER = re.compile(
     r"(?:(?<=^)|(?<=[.;])|(?<=\)))[ \t]*Satz[ \t]+"
@@ -1193,6 +1193,10 @@ _PRECISE_DEFERRAL_DEPENDENCY = re.compile(
     r"\b[a-z]{2}(?:-[a-z0-9-]+)?:"
     r"(?:statutes|regulations|guidance|manuals)/[A-Za-z0-9_./-]+#[A-Za-z0-9_]+"
     r")",
+    flags=re.IGNORECASE,
+)
+_SAME_ACT_SECTION_DEPENDENCY = re.compile(
+    r"\bsection\s+(?P<section>\d+[a-z]?)\s+of\s+(?P<act>this|the)\s+act\b",
     flags=re.IGNORECASE,
 )
 _USC_DEFERRAL_DEPENDENCY = re.compile(
@@ -4714,6 +4718,40 @@ def _deferred_coverage(
             )
             path = tuple(part.lower() for part in display_path)
         if path is None:
+            fragment = output.partition("#")[2]
+            jurisdiction = base_target.partition(":")[0].lower()
+            uses_local_policy_root = output_path.lower().startswith(
+                f"{jurisdiction}:policies/"
+            )
+            output_parts = tuple(
+                part.lower() for part in output_path.rstrip("/").split("/") if part
+            )
+            matching_branches = [
+                branch
+                for branch in branches
+                if branch.path
+                and len(output_parts) >= len(branch.path)
+                and output_parts[-len(branch.path) :] == branch.path
+            ]
+            if fragment and uses_local_policy_root and matching_branches:
+                matching_branch = max(
+                    matching_branches, key=lambda branch: len(branch.path)
+                )
+                display_branch = _deferred_branch_display_path(
+                    matching_branch.path,
+                    corpus_citation_path=corpus_citation_path,
+                    branches=branches,
+                )
+                corrected_output = (
+                    f"{base_target}/{'/'.join(display_branch)}#{fragment}"
+                )
+                issues.append(
+                    "[complete-source-unit:deferral] "
+                    f"`module.deferred_outputs[{index}].output` uses non-source "
+                    f"root `{output_path}` for source branch "
+                    f"(`{'/'.join(display_branch)}`). Use the canonical source "
+                    f"anchor, for example `{corrected_output}`."
+                )
             continue
         reason = str(record.get("reason") or "").strip()
         blocked_by = record.get("blocked_by")
@@ -4779,6 +4817,7 @@ def _deferred_coverage(
                     reason,
                     candidate_scope_text,
                     corpus_citation_path=corpus_citation_path,
+                    path=candidate_path,
                 )
                 or _reason_names_source_bound_runtime_gap(
                     reason,
@@ -4845,6 +4884,7 @@ def _deferred_coverage(
                     reason,
                     candidate_scope_text,
                     corpus_citation_path=corpus_citation_path,
+                    path=candidate,
                 )
                 for candidate, candidate_scope_text in most_specific_source_scopes.items()
             )
@@ -7058,8 +7098,17 @@ def _reason_dependency_is_source_bound(
     source_scope_text: str,
     *,
     corpus_citation_path: str,
+    path: tuple[str, ...] | None = None,
 ) -> bool:
     """Require one external dependency citation to bind to the deferred source."""
+
+    if _reason_names_missing_same_act_dependency(
+        reason,
+        source_scope_text,
+        corpus_citation_path=corpus_citation_path,
+        path=path,
+    ):
+        return True
 
     louisiana_dependencies = _qualified_louisiana_rs_dependencies(reason)
     if not _MISSING_DEPENDENCY_LANGUAGE.search(reason) and not any(
@@ -7172,6 +7221,67 @@ def _reason_dependency_is_source_bound(
         if normalized_dependency and normalized_dependency in normalized_source:
             return True
     return False
+
+
+def _reason_names_missing_same_act_dependency(
+    reason: str,
+    source_scope_text: str,
+    *,
+    corpus_citation_path: str,
+    path: tuple[str, ...] | None,
+) -> bool:
+    """Recognize an exact missing session-law section named by one source branch."""
+
+    if not path:
+        return False
+    exact_current_branch = _reason_cites_exact_current_statute_branch(
+        reason,
+        corpus_citation_path=corpus_citation_path,
+        path=path,
+        strict_terminal=True,
+    )
+    if not exact_current_branch:
+        current_section = corpus_citation_path.rstrip("/").rsplit("/", 1)[-1]
+        branch_pattern = r"\s*".join(
+            rf"\(\s*{re.escape(normalize_rulespec_path_segment(part))}\s*\)"
+            for part in path
+        )
+        exact_current_branch = bool(
+            current_section
+            and re.search(
+                rf"\bsection\s+{re.escape(current_section)}\s*{branch_pattern}"
+                r"(?!\s*\()(?![A-Za-z0-9_])",
+                reason,
+                flags=re.IGNORECASE,
+            )
+        )
+    if not exact_current_branch:
+        return False
+    reason_sections = {
+        (match.group("section").lower(), match.group("act").lower())
+        for match in _SAME_ACT_SECTION_DEPENDENCY.finditer(reason)
+    }
+    source_sections = {
+        (match.group("section").lower(), match.group("act").lower())
+        for match in _SAME_ACT_SECTION_DEPENDENCY.finditer(source_scope_text)
+        if re.search(
+            r"\b(?:except|unless|subject\s+to)\b",
+            source_scope_text[max(0, match.start() - 80) : match.start()],
+            flags=re.IGNORECASE,
+        )
+    }
+    if not reason_sections.intersection(source_sections):
+        return False
+    return bool(
+        _MISSING_DEPENDENCY_LANGUAGE.search(reason)
+        or re.search(
+            r"\b(?:no\s+executable|not\s+(?:available|encoded|implemented)|"
+            r"(?:is|are)\s+(?:not\s+)?(?:available|missing|unencoded|unsupplied)|"
+            r"(?:is|are)\s+not\s+supplied)\b",
+            reason,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _reason_match_names_missing_dependency(
@@ -12595,6 +12705,7 @@ def _formula_execution_is_source_branch_witness(
         selector_values = _reached_formula_interval_selector_values(
             execution,
             case,
+            rule=rule,
             principal_rules=principal_rules,
             formula_environment=formula_environment,
             dependency_environment=dependency_environment,
@@ -12925,6 +13036,7 @@ def _reached_formula_interval_selector_values(
     execution: _FormulaExecution,
     case: dict[str, Any],
     *,
+    rule: dict[str, Any],
     principal_rules: dict[str, dict[str, Any]],
     formula_environment: dict[str, Any],
     dependency_environment: dict[str, Any],
@@ -12993,7 +13105,7 @@ def _reached_formula_interval_selector_values(
             for dependency_name in reached
             if dependency_name in principal_rules and dependency_name not in visited
         )
-    return tuple(
+    values = tuple(
         value
         for selector in selectors
         for value in _formula_interval_subject_values(
@@ -13003,6 +13115,57 @@ def _reached_formula_interval_selector_values(
             interval=interval,
         )
     )
+    if values:
+        return values
+    clamp_subject_names = _formula_progressive_clamp_subject_names(execution.leaf)
+    if not clamp_subject_names:
+        return ()
+    reached_names = set().union(
+        *(
+            set(_FORMULA_IDENTIFIER.findall(expression))
+            for expression in (
+                execution.leaf,
+                *(selector for step in execution.trace for selector in step.selectors),
+            )
+        ),
+        set(),
+    )
+    return _case_numeric_selector_values(
+        case,
+        _rule_numeric_selector_names(rule) & reached_names & clamp_subject_names,
+        dependency_environment=dependency_environment,
+    )
+
+
+def _formula_progressive_clamp_subject_names(formula_text: str) -> set[str]:
+    """Return identifiers in a ``min(max(...), cap)`` progressive subject."""
+
+    expression = _parse_formula_expression(formula_text)
+    if expression is None:
+        return set()
+    names: set[str] = set()
+    for node in ast.walk(expression):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "min"
+            and len(node.args) == 2
+            and not node.keywords
+        ):
+            continue
+        for argument in node.args:
+            if not (
+                isinstance(argument, ast.Call)
+                and isinstance(argument.func, ast.Name)
+                and argument.func.id == "max"
+            ):
+                continue
+            names.update(
+                candidate.id
+                for candidate in ast.walk(argument)
+                if isinstance(candidate, ast.Name) and candidate.id != "max"
+            )
+    return names
 
 
 def _formula_interval_subject_values(
@@ -13296,7 +13459,9 @@ def _formula_execution_matches_source_branch(
         execution.leaf,
         environment=binding_environment,
     )
-    source_topology = _explicit_source_arithmetic_topology(branch.text)
+    source_topology = _explicit_source_arithmetic_topology(
+        authoritative_numeric_recall_text(branch.text)
+    )
     if source_topology is not None and source_topology != _formula_arithmetic_topology(
         operative_leaf,
         environment=binding_environment,
@@ -16675,6 +16840,63 @@ def _formula_text_has_boundary_comparison(
                     )
                 ):
                     return True
+        if source_interval is not None and _formula_expression_has_boundary_clamp(
+            expression,
+            input_names=input_names,
+            boundary_names=boundary_names,
+            boundary=boundary,
+            formula_environment=formula_environment,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+        ):
+            return True
+    return False
+
+
+def _formula_expression_has_boundary_clamp(
+    expression: ast.expr,
+    *,
+    input_names: set[str],
+    boundary_names: set[str],
+    boundary: NumericOccurrenceLike,
+    formula_environment: dict[str, Any],
+    extract_numeric_occurrences: NumericOccurrenceExtractor | None,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    """Recognize a reached progressive ``min(subject, cap)`` boundary."""
+
+    for node in ast.walk(expression):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "min"
+            and len(node.args) == 2
+            and not node.keywords
+        ):
+            continue
+        for subject, cap in (
+            (node.args[0], node.args[1]),
+            (node.args[1], node.args[0]),
+        ):
+            if not (
+                _formula_node_references_names(subject, input_names)
+                and not _formula_node_references_names(cap, input_names)
+            ):
+                continue
+            if any(
+                _formula_node_boundary_value(
+                    candidate,
+                    boundary_names=boundary_names,
+                    boundary=boundary,
+                    formula_environment=formula_environment,
+                    extract_numeric_occurrences=extract_numeric_occurrences,
+                    numeric_value_is_grounded=numeric_value_is_grounded,
+                )
+                is not None
+                for candidate in ast.walk(cap)
+                if isinstance(candidate, ast.expr)
+            ):
+                return True
     return False
 
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -19657,10 +19657,35 @@ _PURPOSE_AMOUNT_TOKENS = {
     "wage",
     "wages",
 }
-_PURPOSE_BRANCH_QUALIFIER_GROUPS = (
-    frozenset({"lower", "middle", "upper"}),
-    frozenset({"first", "second", "third", "fourth"}),
-)
+_PURPOSE_BRANCH_QUALIFIER_GROUPS = (frozenset({"lower", "middle", "upper"}),)
+_PURPOSE_ORDINAL_VALUES = {
+    name: index
+    for index, name in enumerate(
+        (
+            "first",
+            "second",
+            "third",
+            "fourth",
+            "fifth",
+            "sixth",
+            "seventh",
+            "eighth",
+            "ninth",
+            "tenth",
+            "eleventh",
+            "twelfth",
+            "thirteenth",
+            "fourteenth",
+            "fifteenth",
+            "sixteenth",
+            "seventeenth",
+            "eighteenth",
+            "nineteenth",
+            "twentieth",
+        ),
+        start=1,
+    )
+}
 _DEFERRED_OUTPUT_YEAR_PATTERN = re.compile(
     r"(?:^|_)(?:for|from|beginning|effective)(?:_in|_with|_calendar|_taxable|_year)*_"
     r"(?P<year>(?:19|20)\d{2})(?:_|$)",
@@ -19690,7 +19715,12 @@ def find_current_purpose_placeholder_issues(content: str) -> list[str]:
     return issues
 
 
-def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
+def find_deferred_purpose_specific_limitation_issues(
+    content: str,
+    *,
+    rules_file: Path | None = None,
+    policy_repo_path: Path | None = None,
+) -> list[str]:
     """Reject generic executable outputs when purpose-specific limitations defer."""
     payload = _rulespec_payload(content)
     if payload is None:
@@ -19703,6 +19733,20 @@ def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
     )
     if not isinstance(deferred_outputs, list):
         return []
+    rules_by_name = {
+        str(rule.get("name") or "").strip(): rule
+        for rule in payload.get("rules", [])
+        if isinstance(rule, dict) and str(rule.get("name") or "").strip()
+    }
+    current_module_target = None
+    if rules_file is not None:
+        canonical_target = _canonical_rulespec_file_target(
+            policy_repo_path=policy_repo_path,
+            rules_file=rules_file,
+            symbol="__module__",
+        )
+        if canonical_target is not None:
+            current_module_target = canonical_target.rsplit("#", 1)[0]
     for record in deferred_outputs:
         if not isinstance(record, dict):
             continue
@@ -19723,7 +19767,17 @@ def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
         if len(tokens) < 2:
             continue
         deferred_prefix_tokens.append(
-            (symbol, tokens, _deferred_output_effective_start(symbol))
+            (
+                symbol,
+                tokens,
+                _deferred_output_effective_start(
+                    symbol,
+                    reason=reason,
+                    source_values=record.get("source_values"),
+                    rules_by_name=rules_by_name,
+                    current_module_target=current_module_target,
+                ),
+            )
         )
     if not deferred_prefix_tokens:
         return []
@@ -19743,7 +19797,10 @@ def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
         if not rule_tokens or not rule_tokens.intersection(_PURPOSE_AMOUNT_TOKENS):
             continue
         for deferred_symbol, deferred_tokens, deferred_start in deferred_prefix_tokens:
-            if not _purpose_branch_core_matches(rule_tokens, deferred_tokens):
+            if not _purpose_branch_core_matches(
+                name,
+                _purpose_specific_prefix(deferred_symbol),
+            ):
                 continue
             if _rule_ends_before_deferred_period(rule, deferred_start=deferred_start):
                 continue
@@ -19765,10 +19822,15 @@ def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
 
 
 def _purpose_branch_core_matches(
-    rule_tokens: set[str], deferred_tokens: set[str]
+    rule_name: str,
+    deferred_name: str,
 ) -> bool:
     """Keep mutually exclusive named branches from colliding on generic tokens."""
 
+    rule_sequence = _purpose_surface_token_sequence(rule_name)
+    deferred_sequence = _purpose_surface_token_sequence(deferred_name)
+    rule_tokens = set(rule_sequence)
+    deferred_tokens = set(deferred_sequence)
     for qualifier_group in _PURPOSE_BRANCH_QUALIFIER_GROUPS:
         rule_qualifiers = rule_tokens & qualifier_group
         deferred_qualifiers = deferred_tokens & qualifier_group
@@ -19778,14 +19840,174 @@ def _purpose_branch_core_matches(
             and rule_qualifiers.isdisjoint(deferred_qualifiers)
         ):
             return False
+    rule_ordinals = _purpose_branch_ordinal_values(rule_sequence)
+    deferred_ordinals = _purpose_branch_ordinal_values(deferred_sequence)
+    if (
+        rule_ordinals
+        and deferred_ordinals
+        and rule_ordinals.isdisjoint(deferred_ordinals)
+    ):
+        return False
     return True
 
 
-def _deferred_output_effective_start(symbol: str) -> date | None:
+def _purpose_branch_ordinal_values(tokens: Sequence[str]) -> set[int]:
+    tens = {
+        "twenty": 20,
+        "thirty": 30,
+        "forty": 40,
+        "fifty": 50,
+        "sixty": 60,
+        "seventy": 70,
+        "eighty": 80,
+        "ninety": 90,
+    }
+    values: set[int] = set()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if (
+            token in tens
+            and index + 1 < len(tokens)
+            and tokens[index + 1] in _PURPOSE_ORDINAL_VALUES
+            and _PURPOSE_ORDINAL_VALUES[tokens[index + 1]] < 10
+        ):
+            values.add(tens[token] + _PURPOSE_ORDINAL_VALUES[tokens[index + 1]])
+            index += 2
+            continue
+        if token in _PURPOSE_ORDINAL_VALUES:
+            values.add(_PURPOSE_ORDINAL_VALUES[token])
+        elif match := re.fullmatch(r"(?P<number>\d+)(?:st|nd|rd|th)?", token):
+            values.add(int(match.group("number")))
+        index += 1
+    return values
+
+
+def _deferred_output_effective_start(
+    symbol: str,
+    *,
+    reason: str,
+    source_values: object,
+    rules_by_name: dict[str, dict[str, Any]],
+    current_module_target: str | None,
+) -> date | None:
     match = _DEFERRED_OUTPUT_YEAR_PATTERN.search(_normalize_identifier(symbol))
     if match is None:
         return None
-    return date(int(match.group("year")), 1, 1)
+    year = match.group("year")
+    if not re.search(
+        rf"\b(?:calendar|taxable|fiscal)?\s*year\s+{year}\b|"
+        rf"\b{year}\s+(?:and\s+later|and\s+thereafter|or\s+later)\b",
+        reason,
+        flags=re.IGNORECASE,
+    ):
+        return None
+    if not isinstance(source_values, list):
+        return None
+    typed_temporal_value = False
+    for item in source_values:
+        item_text = str(item or "").strip()
+        if not _deferred_temporal_reference_is_current_module(
+            item_text,
+            current_module_target=current_module_target,
+        ):
+            continue
+        source_symbol = item_text.rsplit("#", 1)[-1] if "#" in item_text else ""
+        if not _deferred_temporal_parameter_matches_branch(
+            source_symbol,
+            deferred_symbol=symbol,
+        ):
+            continue
+        source_rule = rules_by_name.get(source_symbol)
+        if not isinstance(source_rule, dict) or source_rule.get("kind") != "parameter":
+            continue
+        versions = source_rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        if any(
+            isinstance(version, dict)
+            and str(version.get("effective_from") or "").strip() == f"{year}-01-01"
+            for version in versions
+        ):
+            typed_temporal_value = True
+            break
+    if not typed_temporal_value:
+        return None
+    return date(int(year), 1, 1)
+
+
+def _deferred_temporal_reference_is_current_module(
+    reference: str,
+    *,
+    current_module_target: str | None,
+) -> bool:
+    """Require an exact absolute target to the file currently under validation."""
+
+    if current_module_target is None or "#" not in reference:
+        return False
+    reference_path, source_symbol = reference.rsplit("#", 1)
+    if not reference_path or not source_symbol:
+        return False
+    return reference_path == current_module_target
+
+
+def _deferred_temporal_parameter_matches_branch(
+    source_symbol: str,
+    *,
+    deferred_symbol: str,
+) -> bool:
+    """Bind temporal evidence to the deferred branch, not generic tax words."""
+
+    deferred_tokens = _purpose_surface_tokens(_purpose_specific_prefix(deferred_symbol))
+    source_tokens = _purpose_surface_tokens(source_symbol)
+    deferred_prefix = _purpose_specific_prefix(deferred_symbol)
+    if not _purpose_branch_core_matches(source_symbol, deferred_prefix):
+        return False
+    for qualifier_group in _PURPOSE_BRANCH_QUALIFIER_GROUPS:
+        deferred_qualifiers = deferred_tokens & qualifier_group
+        if deferred_qualifiers and not deferred_qualifiers.issubset(source_tokens):
+            return False
+    deferred_ordinals = {
+        value
+        for value in _purpose_branch_ordinal_values(
+            _purpose_surface_token_sequence(deferred_prefix)
+        )
+        if value < 1900
+    }
+    if deferred_ordinals and not deferred_ordinals.intersection(
+        {
+            value
+            for value in _purpose_branch_ordinal_values(
+                _purpose_surface_token_sequence(source_symbol)
+            )
+            if value < 1900
+        }
+    ):
+        return False
+    generic_tokens = (
+        _PURPOSE_AMOUNT_TOKENS
+        | _PURPOSE_TOKEN_STOPWORDS
+        | {
+            "calendar",
+            "computed",
+            "gross",
+            "household",
+            "individual",
+            "later",
+            "net",
+            "person",
+            "persons",
+            "taxpayer",
+            "total",
+            "year",
+        }
+    )
+    discriminators = {
+        token
+        for token in deferred_tokens - generic_tokens
+        if not re.fullmatch(r"(?:19|20)\d{2}", token)
+    }
+    return len(discriminators & source_tokens) >= 2
 
 
 def _rule_ends_before_deferred_period(
@@ -19927,12 +20149,16 @@ def _purpose_specific_prefix(symbol: str) -> str:
 
 
 def _purpose_surface_tokens(name: str) -> set[str]:
-    tokens = {
+    return set(_purpose_surface_token_sequence(name))
+
+
+def _purpose_surface_token_sequence(name: str) -> tuple[str, ...]:
+    tokens = (
         _normalize_purpose_token(token)
         for token in _normalize_identifier(name).split("_")
         if token and token not in _PURPOSE_TOKEN_STOPWORDS
-    }
-    return {token for token in tokens if token}
+    )
+    return tuple(token for token in tokens if token)
 
 
 def _normalize_purpose_token(token: str) -> str:
@@ -27881,7 +28107,13 @@ class ValidatorPipeline:
         issues.extend(find_partial_extent_zeroing_issues(content))
         issues.extend(find_scoped_exception_category_gate_issues(content))
         issues.extend(find_current_purpose_placeholder_issues(content))
-        issues.extend(find_deferred_purpose_specific_limitation_issues(content))
+        issues.extend(
+            find_deferred_purpose_specific_limitation_issues(
+                content,
+                rules_file=rules_file,
+                policy_repo_path=self.policy_repo_path,
+            )
+        )
         issues.extend(
             find_imported_deferred_branch_composition_issues(
                 content,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -19657,6 +19657,15 @@ _PURPOSE_AMOUNT_TOKENS = {
     "wage",
     "wages",
 }
+_PURPOSE_BRANCH_QUALIFIER_GROUPS = (
+    frozenset({"lower", "middle", "upper"}),
+    frozenset({"first", "second", "third", "fourth"}),
+)
+_DEFERRED_OUTPUT_YEAR_PATTERN = re.compile(
+    r"(?:^|_)(?:for|from|beginning|effective)(?:_in|_with|_calendar|_taxable|_year)*_"
+    r"(?P<year>(?:19|20)\d{2})(?:_|$)",
+    flags=re.IGNORECASE,
+)
 
 
 def find_current_purpose_placeholder_issues(content: str) -> list[str]:
@@ -19687,7 +19696,7 @@ def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
     if payload is None:
         return []
 
-    deferred_prefix_tokens: list[tuple[str, set[str]]] = []
+    deferred_prefix_tokens: list[tuple[str, set[str], date | None]] = []
     module = payload.get("module")
     deferred_outputs = (
         module.get("deferred_outputs") if isinstance(module, dict) else None
@@ -19713,7 +19722,9 @@ def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
         tokens = _purpose_surface_tokens(prefix)
         if len(tokens) < 2:
             continue
-        deferred_prefix_tokens.append((symbol, tokens))
+        deferred_prefix_tokens.append(
+            (symbol, tokens, _deferred_output_effective_start(symbol))
+        )
     if not deferred_prefix_tokens:
         return []
 
@@ -19731,7 +19742,11 @@ def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
         rule_tokens = _purpose_surface_tokens(name)
         if not rule_tokens or not rule_tokens.intersection(_PURPOSE_AMOUNT_TOKENS):
             continue
-        for deferred_symbol, deferred_tokens in deferred_prefix_tokens:
+        for deferred_symbol, deferred_tokens, deferred_start in deferred_prefix_tokens:
+            if not _purpose_branch_core_matches(rule_tokens, deferred_tokens):
+                continue
+            if _rule_ends_before_deferred_period(rule, deferred_start=deferred_start):
+                continue
             overlap = rule_tokens & deferred_tokens
             if len(overlap) < 3:
                 continue
@@ -19747,6 +19762,51 @@ def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
             )
             break
     return issues
+
+
+def _purpose_branch_core_matches(
+    rule_tokens: set[str], deferred_tokens: set[str]
+) -> bool:
+    """Keep mutually exclusive named branches from colliding on generic tokens."""
+
+    for qualifier_group in _PURPOSE_BRANCH_QUALIFIER_GROUPS:
+        rule_qualifiers = rule_tokens & qualifier_group
+        deferred_qualifiers = deferred_tokens & qualifier_group
+        if (
+            rule_qualifiers
+            and deferred_qualifiers
+            and rule_qualifiers.isdisjoint(deferred_qualifiers)
+        ):
+            return False
+    return True
+
+
+def _deferred_output_effective_start(symbol: str) -> date | None:
+    match = _DEFERRED_OUTPUT_YEAR_PATTERN.search(_normalize_identifier(symbol))
+    if match is None:
+        return None
+    return date(int(match.group("year")), 1, 1)
+
+
+def _rule_ends_before_deferred_period(
+    rule: dict[str, Any], *, deferred_start: date | None
+) -> bool:
+    """Return true only when every executable version ends before a deferral."""
+
+    if deferred_start is None:
+        return False
+    versions = rule.get("versions")
+    if not isinstance(versions, list) or not versions:
+        return False
+    effective_ends: list[date] = []
+    for version in versions:
+        if not isinstance(version, dict) or not version.get("effective_to"):
+            return False
+        try:
+            effective_ends.append(date.fromisoformat(str(version["effective_to"])))
+        except ValueError:
+            return False
+    return bool(effective_ends) and max(effective_ends) < deferred_start
 
 
 def find_imported_deferred_branch_composition_issues(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1654"
+ENCODER_VERSION = "0.2.1655"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1655"
+ENCODER_VERSION = "0.2.1656"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1655"
+ENCODER_VERSION = "0.2.1656"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1654"
+ENCODER_VERSION = "0.2.1655"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1654"
+ENCODER_VERSION = "0.2.1655"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1655"
+ENCODER_VERSION = "0.2.1656"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1654"
+ENCODER_VERSION = "0.2.1655"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1655"
+ENCODER_VERSION = "0.2.1656"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1654"
+ENCODER_VERSION = "0.2.1655"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1655"
+ENCODER_VERSION = "0.2.1656"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1655"
+ENCODER_VERSION = "0.2.1656"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1654"
+ENCODER_VERSION = "0.2.1655"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1655"
+ENCODER_VERSION = "0.2.1656"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1654"
+ENCODER_VERSION = "0.2.1655"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1655"')
+        .startswith('__version__ = "0.2.1656"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1655"
+    assert encoder_package["version"] == "0.2.1656"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1655"
+    assert project["project"]["version"] == "0.2.1656"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1655"')
+        .startswith('__version__ = "0.2.1656"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1655"
+    assert encoder_package["version"] == "0.2.1656"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1655"
+    assert project["project"]["version"] == "0.2.1656"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1655"')
+        .startswith('__version__ = "0.2.1656"')
     )
 
 
@@ -37178,14 +37178,18 @@ rules:
     assert find_deferred_purpose_specific_limitation_issues(content) == []
 
 
-def test_deferred_future_upper_band_does_not_remove_prior_or_sibling_bands():
+def test_deferred_future_upper_band_does_not_remove_prior_or_sibling_bands(
+    tmp_path,
+):
     content = """format: rulespec/v1
 module:
   source_verification:
     corpus_citation_path: us-ms/statute/27-7-5
   deferred_outputs:
     - output: us-ms:statutes/27-7-5/1/b/ii/7#individual_upper_band_tax_for_2030_and_later
-      reason: Paragraph (7) has an exception for the 2030 upper-band tax that cannot be encoded until Section 2 of the act is available.
+      reason: Paragraph (7) has an exception for the calendar year 2030 upper-band tax that cannot be encoded until Section 2 of the act is available.
+      source_values:
+        - us-ms:policies/income_tax/2026_section_27_7_5_schedule#upper_band_rate
 rules:
   - name: individual_lower_band_tax
     kind: derived
@@ -37213,9 +37217,29 @@ rules:
       - effective_from: '2024-01-01'
         effective_to: '2029-12-31'
         formula: individual_lower_band_tax + individual_middle_band_tax + individual_upper_band_tax
+  - name: upper_band_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2030-01-01'
+        formula: 0.03
 """
 
-    assert find_deferred_purpose_specific_limitation_issues(content) == []
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us-ms")
+    rules_file = (
+        policy_repo / "policies" / "income_tax" / "2026_section_27_7_5_schedule.yaml"
+    )
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(content)
+
+    assert (
+        find_deferred_purpose_specific_limitation_issues(
+            content,
+            rules_file=rules_file,
+            policy_repo_path=policy_repo,
+        )
+        == []
+    )
 
 
 def test_deferred_future_upper_band_rejects_upper_band_extending_into_period():
@@ -37225,7 +37249,9 @@ module:
     corpus_citation_path: us-ms/statute/27-7-5
   deferred_outputs:
     - output: us-ms:statutes/27-7-5/1/b/ii/7#individual_upper_band_tax_for_2030_and_later
-      reason: Paragraph (7) has an exception for the 2030 upper-band tax that cannot be encoded until Section 2 of the act is available.
+      reason: Paragraph (7) has an exception for the calendar year 2030 upper-band tax that cannot be encoded until Section 2 of the act is available.
+      source_values:
+        - us-ms:policies/income_tax/2026_section_27_7_5_schedule#upper_band_rate
 rules:
   - name: individual_upper_band_tax
     kind: derived
@@ -37236,6 +37262,158 @@ rules:
 """
 
     issues = find_deferred_purpose_specific_limitation_issues(content)
+
+    assert len(issues) == 1
+    assert "individual_upper_band_tax" in issues[0]
+
+
+def test_deferred_period_requires_matching_structured_source_evidence():
+    content = """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us-ms:statutes/27-7-5/1/b/ii/7#individual_upper_band_tax_for_2030_and_later
+      reason: The exception applies for calendar year 2031 and later.
+      source_values:
+        - us-ms:policies/income_tax/2026_section_27_7_5_schedule#upper_band_rate
+rules:
+  - name: individual_upper_band_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2024-01-01'
+        effective_to: '2029-12-31'
+        formula: upper_band_income * upper_band_rate
+"""
+
+    issues = find_deferred_purpose_specific_limitation_issues(content)
+
+    assert len(issues) == 1
+    assert "individual_upper_band_tax" in issues[0]
+
+
+def test_deferred_fifth_band_does_not_collide_with_sixth_band():
+    content = """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us-zz:statutes/1/1/5#individual_fifth_band_tax_for_section_2
+      reason: The fifth-band exception shall not apply until section 2 is available.
+rules:
+  - name: individual_sixth_band_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sixth_band_income * sixth_band_rate
+"""
+
+    assert find_deferred_purpose_specific_limitation_issues(content) == []
+
+
+def test_deferred_twenty_first_band_does_not_collide_with_first_band():
+    content = """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us-zz:statutes/1/1/21#individual_twenty_first_band_tax_for_section_2
+      reason: The twenty-first-band exception shall not apply until section 2 is available.
+rules:
+  - name: individual_first_band_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: first_band_income * first_band_rate
+"""
+
+    assert find_deferred_purpose_specific_limitation_issues(content) == []
+
+
+def test_deferred_temporal_parameter_requires_adjacent_compound_ordinal():
+    deferred_symbol = "individual_twenty_first_band_tax_for_2030_and_later"
+
+    assert validator_pipeline._deferred_temporal_parameter_matches_branch(
+        "twenty_first_band_rate",
+        deferred_symbol=deferred_symbol,
+    )
+    assert not validator_pipeline._deferred_temporal_parameter_matches_branch(
+        "first_band_rate_for_twenty_year_period",
+        deferred_symbol=deferred_symbol,
+    )
+    assert not validator_pipeline._purpose_branch_core_matches(
+        "first_band_rate_for_twenty_year_period",
+        "individual_twenty_first_band_tax",
+    )
+
+
+@pytest.mark.parametrize(
+    ("source_reference", "parameter_name"),
+    (
+        (
+            "us-ms:policies/income_tax/2026_section_27_7_5_schedule#unrelated_future_parameter",
+            "unrelated_future_parameter",
+        ),
+        (
+            "us-ms:policies/income_tax/2026_section_27_7_5_schedule#individual_tax_rate",
+            "individual_tax_rate",
+        ),
+        (
+            "us-ms:policies/income_tax/2026_section_27_7_5_schedule#lower_band_rate",
+            "lower_band_rate",
+        ),
+        (
+            "us-ms:policies/income_tax/other_schedule_27_7_5#upper_band_rate",
+            "upper_band_rate",
+        ),
+        (
+            "us-ms:policies/income_tax/27-7-5/other_schedule#upper_band_rate",
+            "upper_band_rate",
+        ),
+        (
+            "us-ms:policies/income_tax/section_27_7_5_unrelated#upper_band_rate",
+            "upper_band_rate",
+        ),
+    ),
+)
+def test_deferred_period_rejects_unbound_same_year_source_value(
+    source_reference: str,
+    parameter_name: str,
+    tmp_path,
+):
+    content = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ms/statute/27-7-5
+  deferred_outputs:
+    - output: us-ms:statutes/27-7-5/1/b/ii/7#individual_upper_band_tax_for_2030_and_later
+      reason: The exception applies for calendar year 2030 and later.
+      source_values:
+        - {source_reference}
+rules:
+  - name: individual_upper_band_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2024-01-01'
+        effective_to: '2029-12-31'
+        formula: upper_band_income * upper_band_rate
+  - name: {parameter_name}
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2030-01-01'
+        formula: 0.01
+"""
+
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us-ms")
+    rules_file = (
+        policy_repo / "policies" / "income_tax" / "2026_section_27_7_5_schedule.yaml"
+    )
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(content)
+    issues = find_deferred_purpose_specific_limitation_issues(
+        content,
+        rules_file=rules_file,
+        policy_repo_path=policy_repo,
+    )
 
     assert len(issues) == 1
     assert "individual_upper_band_tax" in issues[0]

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1654"')
+        .startswith('__version__ = "0.2.1655"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1654"
+    assert encoder_package["version"] == "0.2.1655"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1654"
+    assert project["project"]["version"] == "0.2.1655"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1654"')
+        .startswith('__version__ = "0.2.1655"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1654"
+    assert encoder_package["version"] == "0.2.1655"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1654"
+    assert project["project"]["version"] == "0.2.1655"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1654"')
+        .startswith('__version__ = "0.2.1655"')
     )
 
 
@@ -37176,6 +37176,69 @@ rules:
 """
 
     assert find_deferred_purpose_specific_limitation_issues(content) == []
+
+
+def test_deferred_future_upper_band_does_not_remove_prior_or_sibling_bands():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ms/statute/27-7-5
+  deferred_outputs:
+    - output: us-ms:statutes/27-7-5/1/b/ii/7#individual_upper_band_tax_for_2030_and_later
+      reason: Paragraph (7) has an exception for the 2030 upper-band tax that cannot be encoded until Section 2 of the act is available.
+rules:
+  - name: individual_lower_band_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2024-01-01'
+        formula: lower_band_income * lower_band_rate
+  - name: individual_middle_band_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2024-01-01'
+        formula: middle_band_income * middle_band_rate
+  - name: individual_upper_band_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2024-01-01'
+        effective_to: '2029-12-31'
+        formula: upper_band_income * upper_band_rate
+  - name: individual_income_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2024-01-01'
+        effective_to: '2029-12-31'
+        formula: individual_lower_band_tax + individual_middle_band_tax + individual_upper_band_tax
+"""
+
+    assert find_deferred_purpose_specific_limitation_issues(content) == []
+
+
+def test_deferred_future_upper_band_rejects_upper_band_extending_into_period():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ms/statute/27-7-5
+  deferred_outputs:
+    - output: us-ms:statutes/27-7-5/1/b/ii/7#individual_upper_band_tax_for_2030_and_later
+      reason: Paragraph (7) has an exception for the 2030 upper-band tax that cannot be encoded until Section 2 of the act is available.
+rules:
+  - name: individual_upper_band_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2024-01-01'
+        formula: upper_band_income * upper_band_rate
+"""
+
+    issues = find_deferred_purpose_specific_limitation_issues(content)
+
+    assert len(issues) == 1
+    assert "individual_upper_band_tax" in issues[0]
 
 
 def test_imported_deferred_branch_composition_rejects_generic_output(tmp_path):

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1654"
+ENCODER_VERSION = "0.2.1655"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1655"
+ENCODER_VERSION = "0.2.1656"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1158,7 +1158,13 @@ def test_nj_title_54a_citations_are_not_glued_german_sentence_markers():
         "KRS 7A.210",
         "KRS 26A.015",
         "section 12B/4",
+        "section 12B / 4",
         "section 9C-2",
+        "section 9C - 2",
+        "KRS 7A. 210",
+        "section 7A–210",
+        "N.J.S. 54A : 4-7",
+        "section 7A : 210",
     ),
 )
 def test_alphanumeric_legal_citations_are_not_glued_german_sentence_markers(
@@ -1219,6 +1225,28 @@ def test_progressive_min_clamp_binds_exact_source_boundary():
     )
 
 
+def test_progressive_min_clamp_binds_matching_subtracted_offset():
+    source = "Taxable income not in excess of $500 is taxed at two percent."
+    boundary = EN_NUMERIC_OCCURRENCE_EXTRACTOR(source)[0]
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert completeness_module._formula_text_has_boundary_comparison(
+        "rate * min(max(0, taxable_income - lower_bound), ceiling - lower_bound)",
+        allow_complement_relation=False,
+        input_names={"taxable_income"},
+        boundary_names={"lower_bound", "ceiling"},
+        boundary=boundary,
+        formula_environment={"rate": 0.02, "lower_bound": 100, "ceiling": 500},
+        source_interval=interval,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
 def test_progressive_min_clamp_rejects_unrelated_cap():
     source = "Taxable income not in excess of $500 is taxed at two percent."
     boundary = EN_NUMERIC_OCCURRENCE_EXTRACTOR(source)[0]
@@ -1243,6 +1271,219 @@ def test_progressive_min_clamp_rejects_unrelated_cap():
         extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
+
+
+@pytest.mark.parametrize(
+    "cap_expression",
+    ("bracket_ceiling + 100", "bracket_ceiling * 2"),
+)
+def test_progressive_min_clamp_rejects_shifted_or_scaled_boundary(
+    cap_expression: str,
+):
+    source = "Taxable income not in excess of $500 is taxed at two percent."
+    boundary = EN_NUMERIC_OCCURRENCE_EXTRACTOR(source)[0]
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        f"rate * min(max(0, taxable_income), {cap_expression})",
+        allow_complement_relation=False,
+        input_names={"taxable_income"},
+        boundary_names={"bracket_ceiling"},
+        boundary=boundary,
+        formula_environment={"rate": 0.02, "bracket_ceiling": 500},
+        source_interval=interval,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
+def test_progressive_min_clamp_shift_fails_full_formula_witness():
+    source = "Taxable income not in excess of 500 dollars is taxed at two percent."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-zz/statute/2
+rules:
+  - name: bracket_ceiling
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 500
+  - name: rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.02
+  - name: tax
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-zz/statute/2
+              excerpt: Taxable income not in excess of 500 dollars is taxed at two percent.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: rate * min(max(0, taxable_income), bracket_ceiling + 100)
+"""
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-zz/statute/2",
+        test_cases=[
+            {
+                "name": "shifted cap",
+                "period": "2026-01-01",
+                "input": {"taxable_income": 499},
+                "output": {"tax": 9.98},
+            }
+        ],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "formula", "500")
+
+
+@pytest.mark.parametrize("reversed_subject", ("threshold", "percent", "taxed"))
+def test_progressive_min_clamp_paired_reversal_fails_full_formula_witness(
+    reversed_subject: str,
+):
+    source = "Taxable income not in excess of 500 dollars is taxed at two percent."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-zz/statute/2
+rules:
+  - name: bracket_ceiling
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 500
+  - name: rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.02
+  - name: tax
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-zz/statute/2
+              excerpt: Taxable income not in excess of 500 dollars is taxed at two percent.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: rate * min(max(0, threshold - taxable_income), bracket_ceiling - taxable_income)
+""".replace("threshold", reversed_subject)
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-zz/statute/2",
+        test_cases=[
+            {
+                "name": "paired reversed clamp",
+                "period": "2026-01-01",
+                "input": {"taxable_income": 1000, reversed_subject: 100},
+                "output": {"tax": -10},
+            }
+        ],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "formula", "500")
+
+
+def test_progressive_min_clamp_rejects_nested_decoy_full_formula_witness():
+    source = "Taxable income not in excess of 500 dollars is taxed at two percent."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-zz/statute/2
+rules:
+  - name: bracket_ceiling
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 500
+  - name: rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.02
+  - name: tax
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-zz/statute/2
+              excerpt: Taxable income not in excess of 500 dollars is taxed at two percent.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: rate * min(min(max(0, threshold - real_income), bracket_ceiling - real_income), min(max(0, taxable_income), bracket_ceiling))
+"""
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-zz/statute/2",
+        test_cases=[
+            {
+                "name": "operative reversed clamp",
+                "period": "2026-01-01",
+                "input": {
+                    "taxable_income": 100,
+                    "real_income": 1000,
+                    "threshold": 100,
+                },
+                "output": {"tax": -10},
+            },
+            {
+                "name": "decoy boundary clamp",
+                "period": "2026-01-01",
+                "input": {
+                    "taxable_income": 500,
+                    "real_income": 0,
+                    "threshold": 500,
+                },
+                "output": {"tax": 10},
+            },
+        ],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "formula", "500")
 
 
 def test_interval_selector_falls_back_to_reached_clamp_leaf():
@@ -1288,12 +1529,105 @@ def test_interval_selector_falls_back_to_reached_clamp_leaf():
     assert completeness_module._reached_formula_interval_selector_values(
         execution,
         case,
-        rule=rule,
         principal_rules={"tax": rule},
         formula_environment={"rate": 0.02, "bracket_ceiling": 500},
         dependency_environment={},
         interval=interval,
+        source_text=source,
     ) == (499.0,)
+
+
+def test_interval_selector_fallback_does_not_use_clamp_subtractor():
+    source = "Taxable income from $500 through $1000 is taxed at two percent."
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+    rule = {
+        "versions": [
+            {
+                "effective_from": "2026-01-01",
+                "formula": (
+                    "if return_was_made then rate * min(max(0, taxable_income - "
+                    "exemption), ceiling - exemption) else 0"
+                ),
+            }
+        ]
+    }
+    execution = completeness_module._FormulaExecution(
+        trace=(
+            completeness_module._FormulaTraceStep(
+                kind="if",
+                selectors=("return_was_made",),
+                choice=0,
+            ),
+        ),
+        leaf=("rate * min(max(0, taxable_income - exemption), ceiling - exemption)"),
+        evaluated_value=None,
+        evaluates_to_zero=False,
+        constant_environment={"rate": 0.02, "ceiling": 1000},
+    )
+    case = {
+        "input": {
+            "return_was_made": True,
+            "taxable_income": 1500,
+            "exemption": 600,
+        }
+    }
+
+    assert interval is not None
+    assert completeness_module._reached_formula_interval_selector_values(
+        execution,
+        case,
+        principal_rules={"tax": rule},
+        formula_environment={"rate": 0.02, "ceiling": 1000},
+        dependency_environment={},
+        interval=interval,
+        source_text=source,
+    ) == (1500.0,)
+
+
+@pytest.mark.parametrize(
+    ("leaf", "case_input"),
+    (
+        (
+            "rate * min(max(0, threshold - taxable_income), ceiling)",
+            {"taxable_income": 1000, "threshold": 100},
+        ),
+        (
+            "rate * min(max(taxable_income, unrelated_income), ceiling)",
+            {"taxable_income": 1000, "unrelated_income": 100},
+        ),
+    ),
+)
+def test_interval_selector_fallback_rejects_reversed_or_multi_operand_clamp(
+    leaf: str, case_input: dict[str, int]
+):
+    execution = completeness_module._FormulaExecution(
+        trace=(),
+        leaf=leaf,
+        evaluated_value=None,
+        evaluates_to_zero=False,
+        constant_environment={"rate": 0.02, "ceiling": 500},
+    )
+    interval = completeness_module._formula_interval_from_text(
+        "Taxable income not in excess of $500 is taxed at two percent.",
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert (
+        completeness_module._reached_formula_interval_selector_values(
+            execution,
+            {"input": case_input},
+            principal_rules={},
+            formula_environment={"rate": 0.02, "ceiling": 500},
+            dependency_environment={},
+            interval=interval,
+            source_text="Taxable income not in excess of $500 is taxed at two percent.",
+        )
+        == ()
+    )
 
 
 @pytest.mark.parametrize("ordinal", ["1ST", "2ND", "3RD", "4TH", "21st"])
@@ -7073,6 +7407,153 @@ def test_same_act_section_dependency_is_bound_to_exact_source_branch():
     )
 
     assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+def test_same_act_section_dependency_rejects_unrelated_missing_input():
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) is operative except as "
+        "otherwise provided in Section 2 of this act. The taxpayer income input "
+        "is unavailable."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) is operative except as "
+            "provided in Section 2 of this act, which is available, but the "
+            "taxpayer income input is unavailable."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) requires household income "
+            "that is unavailable, except as otherwise provided in Section 2 of "
+            "this act."
+        ),
+    ),
+)
+def test_same_act_section_dependency_rejects_same_clause_unrelated_gap(reason: str):
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+def test_same_act_section_dependency_normalizes_act_determiner():
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) applies except as otherwise "
+        "provided in Section 2 of the act, which is unavailable."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) cannot be encoded without "
+            "Section 2 of the act, but the 2029 rule remains executable."
+        ),
+        (
+            "The 2029 rule remains executable, but Miss. Code section "
+            "27-7-5(1)(b)(ii)(7) cannot be encoded without Section 2 of this act."
+        ),
+    ),
+)
+def test_same_act_section_dependency_scopes_adversative_to_bridge(reason: str):
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+@pytest.mark.parametrize(
+    "dependency_state",
+    (
+        "cannot be encoded, but not because Section 2 of this act is unavailable",
+        "is deferred because it is false that Section 2 of the act is unavailable",
+        (
+            "is deferred because Section 2 of this act is unavailable, but it is "
+            "actually available"
+        ),
+        (
+            "cannot be encoded without Section 2 of this act, but Section 2 is "
+            "available and not required"
+        ),
+        "is deferred because there is no evidence that Section 2 is unavailable",
+        (
+            "is deferred because it is false that there is no executable rule for "
+            "Section 2 of the act"
+        ),
+        (
+            "is deferred because there is no executable rule for Section 2 of this "
+            "act, but an executable rule is available"
+        ),
+        (
+            "is deferred because there is no executable rule for Section 2 of this "
+            "act, although Section 2 is fully implemented"
+        ),
+        "is deferred because it is not true that Section 2 is unavailable",
+        (
+            "is deferred because Section 2 of this act is unavailable, but it is "
+            "in fact available"
+        ),
+        (
+            "is deferred because there is no executable rule for Section 2 of this "
+            "act, but an executable rule exists"
+        ),
+    ),
+)
+def test_same_act_section_dependency_rejects_reversed_missing_state(
+    dependency_state: str,
+):
+    reason = f"Miss. Code section 27-7-5(1)(b)(ii)(7) {dependency_state}."
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert not completeness_module._reason_dependency_is_source_bound(
         reason,
         source,
         corpus_citation_path="us-ms/statute/27-7-5",

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1152,6 +1152,150 @@ def test_nj_title_54a_citations_are_not_glued_german_sentence_markers():
     ]
 
 
+@pytest.mark.parametrize(
+    "legal_citation",
+    (
+        "KRS 7A.210",
+        "KRS 26A.015",
+        "section 12B/4",
+        "section 9C-2",
+    ),
+)
+def test_alphanumeric_legal_citations_are_not_glued_german_sentence_markers(
+    legal_citation: str,
+):
+    branches = recognize_source_structure(
+        f"The cross-reference is {legal_citation}. 1Das ist Satz eins."
+    )
+
+    assert [branch.label for branch in branches if branch.kind == "sentence"] == [
+        "Satz 1"
+    ]
+
+
+def test_legal_section_citation_does_not_invent_arithmetic_topology():
+    topology = completeness_module._explicit_source_arithmetic_topology(
+        authoritative_numeric_recall_text(
+            "The tax imposed by Section 40-18-2 shall be computed as follows."
+        )
+    )
+
+    assert topology is None
+
+
+def test_legal_section_citation_does_not_hide_real_arithmetic_topology():
+    with_citation = completeness_module._explicit_source_arithmetic_topology(
+        authoritative_numeric_recall_text(
+            "Under Section 40-18-2, tax is (income - 500) * 0.04."
+        )
+    )
+    without_citation = completeness_module._explicit_source_arithmetic_topology(
+        "tax is (income - 500) * 0.04."
+    )
+
+    assert with_citation is not None
+    assert with_citation == without_citation
+
+
+def test_progressive_min_clamp_binds_exact_source_boundary():
+    source = "Taxable income not in excess of $500 is taxed at two percent."
+    boundary = EN_NUMERIC_OCCURRENCE_EXTRACTOR(source)[0]
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert completeness_module._formula_text_has_boundary_comparison(
+        "rate * min(max(0, taxable_income), bracket_ceiling)",
+        allow_complement_relation=False,
+        input_names={"taxable_income"},
+        boundary_names={"bracket_ceiling"},
+        boundary=boundary,
+        formula_environment={"rate": 0.02, "bracket_ceiling": 500},
+        source_interval=interval,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
+def test_progressive_min_clamp_rejects_unrelated_cap():
+    source = "Taxable income not in excess of $500 is taxed at two percent."
+    boundary = EN_NUMERIC_OCCURRENCE_EXTRACTOR(source)[0]
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "rate * min(max(0, taxable_income), unrelated_cap)",
+        allow_complement_relation=False,
+        input_names={"taxable_income"},
+        boundary_names={"bracket_ceiling"},
+        boundary=boundary,
+        formula_environment={
+            "rate": 0.02,
+            "bracket_ceiling": 500,
+            "unrelated_cap": 600,
+        },
+        source_interval=interval,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
+def test_interval_selector_falls_back_to_reached_clamp_leaf():
+    source = "Taxable income not in excess of $500 is taxed at two percent."
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+    rule = {
+        "versions": [
+            {
+                "effective_from": "2026-01-01",
+                "formula": (
+                    "if joint_return_was_made then "
+                    "rate * min(max(0, taxable_income), bracket_ceiling) "
+                    "else unrelated_income"
+                ),
+            }
+        ]
+    }
+    execution = completeness_module._FormulaExecution(
+        trace=(
+            completeness_module._FormulaTraceStep(
+                kind="if",
+                selectors=("joint_return_was_made",),
+                choice=0,
+            ),
+        ),
+        leaf="rate * min(max(0, taxable_income), bracket_ceiling)",
+        evaluated_value=None,
+        evaluates_to_zero=False,
+        constant_environment={"rate": 0.02, "bracket_ceiling": 500},
+    )
+    case = {
+        "input": {
+            "joint_return_was_made": True,
+            "taxable_income": 499,
+            "unrelated_income": 250,
+        }
+    }
+
+    assert interval is not None
+    assert completeness_module._reached_formula_interval_selector_values(
+        execution,
+        case,
+        rule=rule,
+        principal_rules={"tax": rule},
+        formula_environment={"rate": 0.02, "bracket_ceiling": 500},
+        dependency_environment={},
+        interval=interval,
+    ) == (499.0,)
+
+
 @pytest.mark.parametrize("ordinal", ["1ST", "2ND", "3RD", "4TH", "21st"])
 def test_english_ordinals_are_not_glued_german_sentence_markers(ordinal: str):
     branches = recognize_source_structure(
@@ -6868,6 +7012,103 @@ def test_precise_root_state_deferral_retry_preserves_branch_in_output_path():
     )
     assert "branch citation in `reason` is already recognized" in issue
     assert "literal canonical citation required" not in issue
+
+
+def test_policy_root_state_deferral_retry_names_canonical_source_branch():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ms/statute/27-7-5
+  deferred_outputs:
+    - output: us-ms:policies/income_tax/2026_section_27_7_5_schedule/1/b/ii/7#individual_upper_band_tax_for_2030_and_later
+      reason: >-
+        Miss. Code section 27-7-5(1)(b)(ii)(7) cannot be fully encoded because
+        Section 2 of this act is not available.
+rules: []
+"""
+    source = """\
+(1) Individual tax.
+(b) For later calendar years:
+(ii) The upper-band tax rate is as follows:
+7. For calendar year 2030 and later, except as otherwise provided in Section 2
+of this act, the rate shall be three percent (3%).
+"""
+
+    payload = yaml.safe_load(content)
+    branches = (
+        completeness_module.SourceStructureBranch(
+            path=("1", "b", "ii", "7"),
+            kind="outline",
+            label="7",
+            text=source,
+            start=0,
+            end=len(source),
+        ),
+    )
+
+    _covered, issues = completeness_module._deferred_coverage(
+        payload,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        source_text=source,
+        branches=branches,
+    )
+
+    issue = next(issue for issue in issues if "uses non-source root" in issue)
+    assert (
+        "`us-ms:statutes/27-7-5/1/b/ii/7#"
+        "individual_upper_band_tax_for_2030_and_later`" in issue
+    )
+
+
+def test_same_act_section_dependency_is_bound_to_exact_source_branch():
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) provides the 2030 rate except "
+        "as otherwise provided in Section 2 of this act; no executable RuleSpec "
+        "output for Section 2 of this act is supplied in the available context."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("reason", "path"),
+    (
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) cannot be encoded because "
+            "Section 3 of this act is unavailable.",
+            ("1", "b", "ii", "7"),
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(6) cannot be encoded because "
+            "Section 2 of this act is unavailable.",
+            ("1", "b", "ii", "7"),
+        ),
+    ),
+)
+def test_same_act_section_dependency_rejects_mismatched_binding(
+    reason: str, path: tuple[str, ...]
+):
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=path,
+    )
 
 
 def test_root_deferral_retry_preserves_uppercase_federal_subparagraph():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1655"
+version = "0.2.1656"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1654"
+version = "0.2.1655"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- harden source-structure parsing for legal citation separators and same-act dependencies
- recognize source-bound progressive tax clamps without accepting reversed, nested, or decoy formulas
- prevent deferred future-period repair from removing prior/sibling tax bands unless temporal evidence resolves to the exact current RuleSpec module
- parse compound ordinal branch identities from adjacent ordered tokens
- bump encoder version to 0.2.1656

## Campaign evidence

- exact Alabama failed-run candidate replay: 0 completeness issues
- exact raw Mississippi Sol candidate replay: 0 deferred-purpose issues
- prior failed AL/KY/MS batch remains terminal and was not replayed or re-approved

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 pytest --maxfail=1` — 12,520 passed, 123 skipped
- focused source/RuleSpec validators — 7,648 passed, 31 skipped
- unsafe formula output repair — 8 passed
- encoder-affecting version provenance check — passed

## Review cycle

Independent review/fix cycles were repeated through exact commit `ff73c9459ef0d4c51943816874d80d930ab65541`. Final cycle: no actionable findings. Review covered citation morphology, progressive clamp topology/subject binding, same-act dependency direction and reversals, temporal target resolution, branch qualifiers/compound ordinals, and real AL/MS artifact replays.
