### PR TITLE
Recognize CFR source citation aliases

### DIFF
--- a/changelog.d/recognize-cfr-source-citations.fixed.md
+++ b/changelog.d/recognize-cfr-source-citations.fixed.md
@@ -1,0 +1,1 @@
+Recognize conventional CFR citations as aliases of canonical regulation corpus paths during complete-source validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1666"
+version = "0.2.1667"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1666"
+__version__ = "0.2.1667"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -4911,29 +4911,34 @@ def _paths_from_source_reference(
     ):
         return set()
     paths: set[tuple[str, ...]] = set()
-    escaped_path = re.escape(corpus_citation_path.rstrip("/"))
-    for match in re.finditer(
-        rf"(?<![A-Za-z0-9_]){escaped_path}"
-        r"(?P<suffix>(?:/[A-Za-z0-9-]+)+|(?:\([A-Za-z0-9-]+\))+)",
-        value,
-        flags=re.IGNORECASE,
-    ):
-        suffix = match.group("suffix")
-        components = (
-            [part for part in suffix.split("/") if part]
-            if suffix.startswith("/")
-            else re.findall(r"\(([A-Za-z0-9-]+)\)", suffix)
-        )
-        if components:
-            base_components = tuple(component.lower() for component in components)
-            trailing = _reference_qualifier_tail(
-                value,
-                start=match.end(),
-                next_reference=corpus_citation_path,
+    reference_aliases = _authoritative_source_unit_aliases(corpus_citation_path)
+    for reference in reference_aliases:
+        escaped_reference = re.escape(reference)
+        for match in re.finditer(
+            rf"(?<![A-Za-z0-9_]){escaped_reference}"
+            r"(?P<suffix>(?:/[A-Za-z0-9-]+)+|(?:\([A-Za-z0-9-]+\))+)",
+            value,
+            flags=re.IGNORECASE,
+        ):
+            suffix = match.group("suffix")
+            components = (
+                [part for part in suffix.split("/") if part]
+                if suffix.startswith("/")
+                else re.findall(r"\(([A-Za-z0-9-]+)\)", suffix)
             )
-            paths.add(
-                (*base_components, *_keyword_path_components(trailing, base_components))
-            )
+            if components:
+                base_components = tuple(component.lower() for component in components)
+                trailing = _reference_qualifier_tail(
+                    value,
+                    start=match.end(),
+                    next_reference=reference,
+                )
+                paths.add(
+                    (
+                        *base_components,
+                        *_keyword_path_components(trailing, base_components),
+                    )
+                )
 
     keyword_components = _keyword_path_components(value)
     if keyword_components:
@@ -5005,10 +5010,7 @@ def _source_reference_targets_authoritative_unit(
 ) -> bool:
     """Require branch claims to identify this unit, not merely a branch label."""
 
-    candidates = {
-        corpus_citation_path.rstrip("/"),
-        _rulespec_target_base(corpus_citation_path),
-    }
+    candidates = _authoritative_source_unit_aliases(corpus_citation_path)
     if any(
         re.search(
             rf"(?<![A-Za-z0-9_]){re.escape(candidate)}(?![A-Za-z0-9_.-])",
@@ -5028,6 +5030,24 @@ def _source_reference_targets_authoritative_unit(
             flags=re.IGNORECASE,
         )
     )
+
+
+def _authoritative_source_unit_aliases(
+    corpus_citation_path: str,
+) -> tuple[str, ...]:
+    """Return canonical and conventional citations for one source unit."""
+
+    canonical = corpus_citation_path.rstrip("/")
+    aliases = [canonical, _rulespec_target_base(canonical)]
+    parts = canonical.split("/")
+    if (
+        len(parts) == 5
+        and parts[:2] == ["us", "regulation"]
+        and all(re.fullmatch(r"[A-Za-z0-9-]+", part) for part in parts[2:])
+    ):
+        title, part, section = parts[2:]
+        aliases.append(f"{title} CFR {part}.{section}")
+    return tuple(dict.fromkeys(alias for alias in aliases if alias))
 
 
 def _deferred_coverage(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1666"
+ENCODER_VERSION = "0.2.1667"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1666"
+ENCODER_VERSION = "0.2.1667"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1666"
+ENCODER_VERSION = "0.2.1667"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1666"
+ENCODER_VERSION = "0.2.1667"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1666"
+ENCODER_VERSION = "0.2.1667"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1666"
+ENCODER_VERSION = "0.2.1667"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1666"
+ENCODER_VERSION = "0.2.1667"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6216,7 +6216,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1666"')
+        .startswith('__version__ = "0.2.1667"')
     )
 
 
@@ -6448,13 +6448,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1666"
+    assert encoder_package["version"] == "0.2.1667"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1666"
+    assert project["project"]["version"] == "0.2.1667"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1666"')
+        .startswith('__version__ = "0.2.1667"')
     )
 
 
@@ -6716,13 +6716,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1666"
+    assert encoder_package["version"] == "0.2.1667"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1666"
+    assert project["project"]["version"] == "0.2.1667"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1666"')
+        .startswith('__version__ = "0.2.1667"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1666"
+ENCODER_VERSION = "0.2.1667"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2757,6 +2757,65 @@ def test_dotted_subsection_children_match_canonical_source_paths():
     ) == {("a", "2")}
 
 
+def test_cfr_source_reference_alias_matches_canonical_source_paths():
+    assert completeness_module._paths_from_source_reference(
+        "7 CFR 273.4(a)(3)",
+        corpus_citation_path="us/regulation/7/273/4",
+    ) == {("a", "3")}
+
+
+def test_cfr_parent_and_child_source_aliases_cover_complete_structure():
+    source = """\
+(a) A person is eligible only if one of the following applies:
+(1) A U.S. citizen.
+(2) A U.S. non-citizen national.
+(3) An individual who is:
+(i) An American Indian born in Canada; or
+(ii) A member of an Indian tribe.
+(b) Reporting requirements.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/4
+rules:
+  - name: american_indian_status_eligible
+    kind: derived
+    dtype: Judgment
+    source: 7 CFR 273.4(a)(3)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: canada_born_status_eligible or tribe_status_eligible
+  - name: canada_born_status_eligible
+    kind: derived
+    dtype: Judgment
+    source: 7 CFR 273.4(a)(3)(i)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: member_is_american_indian_born_in_canada
+  - name: tribe_status_eligible
+    kind: derived
+    dtype: Judgment
+    source: 7 CFR 273.4(a)(3)(ii)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: member_is_member_of_indian_tribe
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us/regulation/7/273/4",
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert not _has_issue(result, "Source branch (3)", "neither encoded")
+    assert not _has_issue(result, "Source branch (i)", "neither encoded")
+    assert not _has_issue(result, "Source branch (ii)", "neither encoded")
+
+
 def test_dotted_subsections_preserve_parenthesized_preamble():
     source = "(9) Preamble rule.\nA. First.\n(1) Nested.\nB. Second."
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1666"
+version = "0.2.1667"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- recognize conventional CFR references such as `7 CFR 273.4(a)(3)` as aliases of canonical corpus citations
- apply the alias consistently when checking whether a reference targets the authoritative unit and when extracting structural paths
- add direct parser and source-completeness regression coverage
- bump the encoder version to `0.2.1667`

## Motivation
The protected §273.4 canonicalization for rulespec-us #1248 correctly emitted source references for `7 CFR 273.4(a)(3)`, `(i)`, and `(ii)`, but the completeness validator ignored that citation form and falsely reported the parent branch as uncovered. This keeps the strict structural check while accepting the conventional legal citation spelling.

## Checks
- `uv run pytest tests/test_source_completeness.py -q` (5,367 passed)
- focused version/provenance and state-oracle registry tests
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `git diff main...HEAD --check`

## Review cycle
Independent review requested below. Actionable findings will be fixed and focused checks rerun before merge.

Related to TheAxiomFoundation/rulespec-us#1248.