### PR TITLE
Fix currency thresholds near percentage text

### DIFF
--- a/changelog.d/us-canonical-numeric-profile.fixed.md
+++ b/changelog.d/us-canonical-numeric-profile.fixed.md
@@ -1,0 +1,3 @@
+Keep explicit currency thresholds from being reinterpreted as rates merely
+because percentage language appears nearby, preserving exact progressive-tax
+formula witnesses without changing the mature US numeric profile.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1656"
+version = "0.2.1657"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1656"
+__version__ = "0.2.1657"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1290,7 +1290,7 @@ _SOURCE_REFERENCE_PATTERNS = (
         # Rwanda excise schedule, "RWF 3,000", "GHS 100") - the amount
         # must survive for numeric grounding, so currency codes are
         # excluded from the reference pattern.
-        r"\b(?!(?:FRW|RWF|GHS|GHP|NGN|UGX|ZMW|ETB|USD|EUR|GBP|CAD|AUD|"
+        r"\b(?!(?:FRW|RWF|GHS|GHP|NGN|UGX|ZMW|ETB|USD|EUR|GBP|CAD|AUD|CHF|"
         r"KES|TZS|XAF|XOF|ZAR)\b)[A-Z]{2,6}[ \t]+\d+(?:\.\d+)*(?:\([^)]+\))*",
     ),
     re.compile(r"\b(?:Act|Order|Regulations?)\s+\d{4}\b"),
@@ -1888,12 +1888,18 @@ _STRUCTURAL_LINE_MARKER_PATTERN = re.compile(
 _STRUCTURAL_GLUED_SENTENCE_MARKER_PATTERN = re.compile(
     r"(?<![\w])(?:[1-9]\d?)(?=[A-ZÄÖÜ])"
 )
+_CURRENCY_MARKER_FRAGMENT = (
+    r"(?:[$£€¥₹]|"
+    r"(?:euros?|eur|dollars?|usd|pounds?|gbp|cad|aud|chf)\b|"
+    r"(?:(?:u\.?\s*s\.?|united\s+states|canadian|australian)\s+dollars?|"
+    r"swiss\s+francs?)\b)"
+)
 _CURRENCY_MARKER_BEFORE_NUMBER_PATTERN = re.compile(
-    r"(?:[$£€¥₹]|(?:euros?|eur|usd|gbp|cad|aud|chf)\b)\s*$",
+    rf"{_CURRENCY_MARKER_FRAGMENT}\s*$",
     re.IGNORECASE,
 )
 _CURRENCY_MARKER_AFTER_NUMBER_PATTERN = re.compile(
-    r"^\s*(?:[$£€¥₹]|(?:euros?|eur|dollars?|usd|pounds?|gbp)\b)",
+    rf"^\s*{_CURRENCY_MARKER_FRAGMENT}",
     re.IGNORECASE,
 )
 _DANISH_CURRENCY_MARKER_PATTERN = re.compile(
@@ -1901,7 +1907,7 @@ _DANISH_CURRENCY_MARKER_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _GENERIC_CURRENCY_MARKER_PATTERN = re.compile(
-    r"(?:[$£€¥₹]|(?:euros?|eur|dollars?|usd|pounds?|gbp|cad|aud|chf)\b)",
+    _CURRENCY_MARKER_FRAGMENT,
     re.IGNORECASE,
 )
 _VEHICLE_TAX_FISCAL_POWER_TABLE_CELL_PATTERN = re.compile(
@@ -8468,6 +8474,26 @@ def _tokenize_numeric_occurrences_from_text(
         with contextlib.suppress(ValueError):
             source_value = float(raw)
             if source_value <= 1:
+                continue
+            source_span = cleaned_view.source_span(match.span(1))
+            if (
+                any(
+                    money_start <= source_span[0] and source_span[1] <= money_end
+                    for money_start, money_end in collector.money_spans
+                )
+                or _currency_marker_before_number(
+                    cleaned,
+                    match.start(1),
+                    profile=profile,
+                    boundaries=collector.context_boundaries,
+                )
+                or _currency_marker_after_number(
+                    cleaned,
+                    match.end(1),
+                    profile=profile,
+                    boundaries=collector.context_boundaries,
+                )
+            ):
                 continue
             context = cleaned[max(0, match.start() - 500) : match.end() + 80].lower()
             if not re.search(r"\bpercent(?:age|ages)?\b", context):

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1656"
+ENCODER_VERSION = "0.2.1657"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1656"
+ENCODER_VERSION = "0.2.1657"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1656"
+ENCODER_VERSION = "0.2.1657"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1656"
+ENCODER_VERSION = "0.2.1657"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1656"
+ENCODER_VERSION = "0.2.1657"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1656"
+ENCODER_VERSION = "0.2.1657"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1656"
+ENCODER_VERSION = "0.2.1657"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1656"')
+        .startswith('__version__ = "0.2.1657"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1656"
+    assert encoder_package["version"] == "0.2.1657"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1656"
+    assert project["project"]["version"] == "0.2.1657"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1656"')
+        .startswith('__version__ = "0.2.1657"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1656"
+    assert encoder_package["version"] == "0.2.1657"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1656"
+    assert project["project"]["version"] == "0.2.1657"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1656"')
+        .startswith('__version__ = "0.2.1657"')
     )
 
 
@@ -12956,6 +12956,7 @@ def test_da_numeric_profile_terminates_at_glued_juris_sentence_marker():
         ),
         ("de/statute/estg/32a", "de-DE"),
         ("us/statute/example/1", "legacy"),
+        ("us-al/statute/40-18-5", "legacy"),
         (None, "legacy"),
     ),
 )
@@ -12965,6 +12966,158 @@ def test_numeric_profile_selection_uses_canonical_citation_country(
 ):
     assert (
         validator_pipeline._numeric_profile_for_citation_path(citation_path) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "threshold",
+    (
+        "$500",
+        "500 dollars",
+        "500 U.S. dollars",
+        "CAD 500",
+        "500 CAD",
+        "CHF 500",
+        "500 CHF",
+        "AUD 500",
+        "500 AUD",
+    ),
+)
+def test_legacy_percentage_context_does_not_scale_currency_threshold(threshold):
+    grounding = extract_typed_numeric_occurrences_from_text(
+        f"A threshold of {threshold} applies; the rate is 2 percent.",
+        profile="legacy",
+    )
+
+    assert [item.value for item in grounding if item.raw == "500"] == [500.0]
+    assert any(item.value == 0.02 and item.has_rate_context for item in grounding)
+
+
+def test_legacy_percentage_context_keeps_real_scaled_rate():
+    grounding = extract_typed_numeric_occurrences_from_text(
+        "The applicable rate is 500 percent.",
+        profile="legacy",
+    )
+
+    assert any(
+        item.value == 5.0 and item.raw == "500" and item.has_rate_context
+        for item in grounding
+    )
+
+
+def test_us_pipeline_does_not_reinterpret_money_as_nearby_percentage():
+    citation_path = "us-al/statute/40-18-5"
+    source_text = (
+        "Two percent of taxable income not in excess of five hundred dollars ($500)."
+    )
+    grounding = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="legacy",
+    )
+    assert [(item.value, item.raw) for item in grounding] == [
+        (0.02, "Two percent"),
+        (500.0, "five hundred"),
+        (500.0, "500"),
+    ]
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-al/statute/40-18-5
+rules:
+  - name: first_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '0.02'
+  - name: first_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '500'
+  - name: first_bracket_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: Two percent of taxable income not in excess of five hundred dollars ($500).
+    versions:
+      - effective_from: '2026-01-01'
+        formula: first_bracket_rate * min(max(0, taxable_income), first_bracket_ceiling)
+inputs:
+  - name: taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+"""
+    test_cases = [
+        {
+            "name": "inside_first_bracket",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "input": {
+                "us-al:policies/income_tax/example#input.taxable_income": 499,
+            },
+            "output": {
+                "us-al:policies/income_tax/example#first_bracket_tax": 9.98,
+            },
+        },
+        {
+            "name": "at_first_bracket_ceiling",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "input": {
+                "us-al:policies/income_tax/example#input.taxable_income": 500,
+            },
+            "output": {
+                "us-al:policies/income_tax/example#first_bracket_tax": 10,
+            },
+        },
+    ]
+    pipeline = ValidatorPipeline(
+        policy_repo_path=Path("/tmp/rulespec-us/us-al"),
+        axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+        local_corpus_release=None,
+        enable_oracles=False,
+        require_complete_source_unit=True,
+        source_citation_path=citation_path,
+    )
+
+    assert (
+        find_ungrounded_numeric_issues(
+            content,
+            source_text=source_text,
+            source_citation_path=citation_path,
+        )
+        == []
+    )
+    assert (
+        pipeline._complete_source_unit_issues(
+            content,
+            validation_source_texts={citation_path: source_text},
+            test_cases=test_cases,
+        )
+        == []
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1656"
+ENCODER_VERSION = "0.2.1657"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1656"
+version = "0.2.1657"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- preserve explicit money thresholds when legacy numeric grounding sees nearby percentage language
- use symmetric prefix/suffix currency marker vocabulary, including named US/Canadian/Australian/Swiss forms
- keep CHF-prefixed amounts out of the all-caps document-reference mask
- retain genuine scaled-rate extraction and the mature US numeric profile
- bump the encoder and affected oracle registry pins to 0.2.1657

## Validation

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run ruff format --check src/ tests/`
- `uv run pytest -q` — 12,532 passed, 123 skipped
- focused numeric/profile regression set — 16 passed
- pinned AL replacement overlay against RuleSpec `2a503a5`, corpus `e79781b`, and rules engine `e5e40d4` with dependents and complete-source enforcement — pass, zero issues, zero supplemental repairs

## Review cycle

Independent review found asymmetric postfix currency coverage. The implementation and regressions were expanded, including the CHF document-reference interaction, and the amended commit was independently re-reviewed. Final cycle result: no actionable findings.