### PR TITLE
Fix authoritative root formula proof binding

### DIFF
--- a/changelog.d/pit-root-formula-proof.fixed.md
+++ b/changelog.d/pit-root-formula-proof.fixed.md
@@ -1,0 +1,4 @@
+Bind a correctly cited proof excerpt to the authoritative source root when the
+excerpt is source-verbatim but lies outside later recognized structural
+branches. Fabricated or off-source excerpts remain unbound, and excerpts inside
+recognized branches retain their most-specific paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1657"
+version = "0.2.1658"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1657"
+__version__ = "0.2.1658"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -4325,7 +4325,7 @@ def _rule_coverage(
             excerpt_branch = _most_specific_excerpt_branch(excerpt, branches)
             if excerpt_branch is not None:
                 paths.add(excerpt_branch.path)
-            elif not branches:
+            elif _collapse_text(excerpt) in _collapse_text(source_text):
                 paths.add(())
         for path in paths:
             all_paths.add(path)

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1657"
+ENCODER_VERSION = "0.2.1658"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1657"
+ENCODER_VERSION = "0.2.1658"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1657"
+ENCODER_VERSION = "0.2.1658"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1657"
+ENCODER_VERSION = "0.2.1658"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1657"
+ENCODER_VERSION = "0.2.1658"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1657"
+ENCODER_VERSION = "0.2.1658"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1657"
+ENCODER_VERSION = "0.2.1658"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1657"')
+        .startswith('__version__ = "0.2.1658"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1657"
+    assert encoder_package["version"] == "0.2.1658"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1657"
+    assert project["project"]["version"] == "0.2.1658"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1657"')
+        .startswith('__version__ = "0.2.1658"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1657"
+    assert encoder_package["version"] == "0.2.1658"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1657"
+    assert project["project"]["version"] == "0.2.1658"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1657"')
+        .startswith('__version__ = "0.2.1658"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1657"
+ENCODER_VERSION = "0.2.1658"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -15295,6 +15295,123 @@ rules:
     assert _has_issue(result, "(1)", "source branch")
 
 
+def test_authoritative_root_formula_proof_binds_before_later_source_branch():
+    formula_clause = (
+        "The tax shall be determined by applying the rates in subsection (2) "
+        "to net income and subtracting allowable tax credits."
+    )
+    source = f"{formula_clause}\n(2) A later source branch applies."
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+  - name: annual_tax
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: >-
+                {formula_clause}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: schedule_before_credits - allowable_credits
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-ky/statute/krs/141.020/document-1",
+        test_cases=[],
+    )
+
+    assert recognize_source_structure(source)
+    assert not _has_issue(result, "formula-output")
+
+
+def test_unmatched_formula_proof_cannot_gain_root_coverage_from_later_branch():
+    source = (
+        "The tax shall be determined by multiplying net income by the rate. "
+        "\n(2) A later source branch applies."
+    )
+    payload = yaml.safe_load(
+        """\
+format: rulespec/v1
+rules:
+  - name: annual_tax
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: The tax shall be determined by dividing income by a fabricated amount.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: net_income * rate
+"""
+    )
+    branches = recognize_source_structure(source)
+
+    _, principal_paths, _, principal_rule_paths = completeness_module._rule_coverage(
+        payload,
+        source_text=source,
+        branches=branches,
+        corpus_citation_path="us-ky/statute/krs/141.020/document-1",
+    )
+
+    assert branches
+    assert () not in principal_paths
+    assert principal_rule_paths["annual_tax"] == set()
+
+
+def test_formula_proof_inside_branch_keeps_most_specific_coverage():
+    formula_clause = (
+        "The tax shall be determined by multiplying net income by the rate."
+    )
+    source = f"(2) {formula_clause}"
+    payload = yaml.safe_load(
+        f"""\
+format: rulespec/v1
+rules:
+  - name: annual_tax
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: {formula_clause}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: net_income * rate
+"""
+    )
+    branches = recognize_source_structure(source)
+
+    _, principal_paths, _, principal_rule_paths = completeness_module._rule_coverage(
+        payload,
+        source_text=source,
+        branches=branches,
+        corpus_citation_path="us-ky/statute/krs/141.020/document-1",
+    )
+
+    assert principal_paths == {("2",)}
+    assert principal_rule_paths["annual_tax"] == {("2",)}
+
+
 def test_unstructured_formula_requires_principal_output_bound_to_source_unit():
     source = "Die Steuer ergibt sich aus dem Einkommen geteilt durch den Grundwert."
     content = """\

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1657"
+version = "0.2.1658"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- bind correctly cited, source-verbatim proof excerpts to the authoritative root when they lie before or outside later recognized branches
- keep fabricated excerpts unbound and preserve most-specific branch coverage
- bump axiom-encode to 0.2.1658

## Batch 004 evidence
Run 31356586839 produced a principal Kentucky annual-tax rule with the exact chars 339:518 proof, but unrelated later recognized branches made that proof path-invisible. Both retained final candidates bind the required clause under this fix. No failed candidate was replayed into a workflow, adopted, signed, reapproved, or dispatched.

## Review cycle
Independent review completed with no actionable findings. The reviewer also replayed both retained Kentucky finals and confirmed the target formula-output issue clears while citation, source-verbatim, anti-fabrication, and most-specific-path protections remain fail-closed.

## Checks
- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- uv run ruff format --check src/ tests/
- uv run pytest -q tests/test_source_completeness.py --no-cov (5368 passed)
- uv run pytest (12535 passed, 123 skipped)
- retained Batch 004 Kentucky final replay for both model lanes