### PR TITLE
Fix progressive interval source binding

### DIFF
--- a/changelog.d/al-progressive-interval-source-binding.fixed.md
+++ b/changelog.d/al-progressive-interval-source-binding.fixed.md
@@ -1,0 +1,4 @@
+Recognize statutory `in excess of` progressive-tax brackets, collapse equal
+parenthetical currency restatements into one threshold, and bind established
+boundary helper names to their source-named tax base without accepting a
+different income or credit subject.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1658"
+version = "0.2.1659"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1658"
+__version__ = "0.2.1659"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -13353,29 +13353,39 @@ def _formula_progressive_clamp_subject_names(formula_text: str) -> tuple[str, ..
 def _formula_subject_matches_source(name: str, source_text: str) -> bool:
     """Bind an inferred clamp minuend to the source's named subject."""
 
-    generic_tokens = {"amount", "base", "input", "subject", "total", "value"}
-    name_tokens = tuple(
-        token
-        for token in re.findall(r"[a-z0-9]+", name.lower().replace("_", " "))
-        if token not in generic_tokens
-    )
-    if not name_tokens:
-        return False
-    subject_phrase = r"\s+".join(re.escape(token) for token in name_tokens)
+    generic_tokens = {
+        "amount",
+        "base",
+        "input",
+        "subject",
+        "total",
+        "value",
+    }
+    raw_name_tokens = tuple(re.findall(r"[a-z0-9]+", name.lower().replace("_", " ")))
+    candidate_name_tokens = [raw_name_tokens]
+    if raw_name_tokens and raw_name_tokens[-1] == "boundary":
+        candidate_name_tokens.append(raw_name_tokens[:-1])
     interval_comparison = (
         r"(?:above|at\s+(?:least|most)|below|between|exceeds?|exceeding|from|"
         r"greater\s+than|in\s+excess\s+of|less\s+than|more\s+than|"
         r"no\s+(?:less|more|greater)\s+than|not\s+(?:in\s+excess\s+of|"
         r"less\s+than|more\s+than|over)|over|through|under|up\s+to)"
     )
-    return bool(
-        re.search(
+    for candidate_tokens in candidate_name_tokens:
+        name_tokens = tuple(
+            token for token in candidate_tokens if token not in generic_tokens
+        )
+        if not name_tokens:
+            continue
+        subject_phrase = r"\s+".join(re.escape(token) for token in name_tokens)
+        if re.search(
             rf"\b{subject_phrase}\b\s+"
             rf"(?:(?:is|are|shall\s+be)\s+)?{interval_comparison}\b",
             source_text,
             flags=re.IGNORECASE,
-        )
-    )
+        ):
+            return True
+    return False
 
 
 def _formula_interval_subject_values(
@@ -17935,6 +17945,7 @@ def _formula_bound_from_comparison(
         "exceeding",
         "greater than",
         "higher than",
+        "in excess of",
         "larger than",
         "more than",
         "not equal or be less than",
@@ -18153,6 +18164,7 @@ def _formula_interval_from_text(
             r"less\s+than\s+or\s+equal\s+to|"
             r"equal\s+to\s+or\s+less\s+than|no\s+(?:greater|higher|larger|more)\s+than|"
             r"not\s+(?:greater|higher|larger|more)\s+than|not\s+(?:in\s+excess\s+of|over)|"
+            r"in\s+excess\s+of|"
             r"at\s+or\s+(?:below|under)|"
             r"no\s+less\s+than|not\s+less\s+than|less\s+than|below|"
             r"bis|up\s+to|höchstens|nicht\s+mehr\s+als|at\s+most|"
@@ -18170,16 +18182,47 @@ def _formula_interval_from_text(
     )
     extracted_occurrences = tuple(extract_numeric_occurrences(occurrence_text))
     numeric_occurrences_list: list[NumericOccurrenceLike] = []
+    parenthetical_restatement_spans: list[tuple[int, int]] = []
     # Stable source ordering retains the extractor's preferred interpretation
-    # when one numeric phrase emits multiple overlapping candidates.
+    # when one numeric phrase emits multiple overlapping candidates. A spelled
+    # amount followed by its equal parenthetical currency restatement is also
+    # one legal threshold, not two consecutive interval bounds.
     for occurrence in sorted(extracted_occurrences, key=lambda item: item.start):
         if (
             numeric_occurrences_list
             and occurrence.start < numeric_occurrences_list[-1].end
         ):
             continue
+        if numeric_occurrences_list:
+            previous = numeric_occurrences_list[-1]
+            restatement_gap = text[previous.end : occurrence.start]
+            restatement_suffix = text[occurrence.end :]
+            restatement_close = re.match(r"\s*\)", restatement_suffix)
+            strict_parenthetical_restatement = (
+                re.fullmatch(
+                    r"\s*(?:dollars?|usd|euros?|eur|pounds?|gbp)?\s*"
+                    r"\(\s*(?:\$|€|£|usd|eur|gbp)?\s*",
+                    restatement_gap,
+                    flags=re.IGNORECASE,
+                )
+                and restatement_close is not None
+            )
+            if strict_parenthetical_restatement:
+                if not _numeric_occurrences_are_equivalent(previous, occurrence):
+                    return None
+                parenthetical_restatement_spans.append(
+                    (
+                        previous.end,
+                        occurrence.end + restatement_close.end(),
+                    )
+                )
+                continue
         numeric_occurrences_list.append(occurrence)
     numeric_occurrences = tuple(numeric_occurrences_list)
+    comparison_characters = list(text)
+    for start, end in parenthetical_restatement_spans:
+        comparison_characters[start:end] = " " * (end - start)
+    comparison_text = "".join(comparison_characters)
     keyword = None
     occurrences: tuple[NumericOccurrenceLike, ...] = ()
     for candidate in sorted(
@@ -18273,14 +18316,14 @@ def _formula_interval_from_text(
         if float(occurrences[0].value) > float(occurrences[1].value):
             return None
         return _NumericInterval(occurrences[0], True, occurrences[1], True)
-    first_bound = _formula_first_bound(text, occurrences[0])
+    first_bound = _formula_first_bound(comparison_text, occurrences[0])
     if first_bound is not None:
         first, first_inclusive, first_kind = first_bound
         return _formula_interval_with_conjoined_bound(
             first,
             first_inclusive,
             first_kind,
-            _formula_conjoined_bound(text, occurrences),
+            _formula_conjoined_bound(comparison_text, occurrences),
         )
     clause_start = max(
         lowered.rfind(".", 0, keyword.start()),
@@ -18300,7 +18343,7 @@ def _formula_interval_from_text(
         unparsed_prefix,
         flags=re.IGNORECASE,
     ):
-        second_bound = _formula_conjoined_bound(text, occurrences)
+        second_bound = _formula_conjoined_bound(comparison_text, occurrences)
         if second_bound is None or second_bound[2] == "permissive":
             return None
         second, inclusive, kind = second_bound
@@ -18316,7 +18359,7 @@ def _formula_interval_from_text(
             occurrences[0],
             False,
             "upper",
-            _formula_conjoined_bound(text, occurrences),
+            _formula_conjoined_bound(comparison_text, occurrences),
         )
     if re.match(
         r"(?:bis|up\s+to|höchstens|nicht\s+mehr\s+als|at\s+most|"
@@ -18330,11 +18373,11 @@ def _formula_interval_from_text(
             occurrences[0],
             True,
             "upper",
-            _formula_conjoined_bound(text, occurrences),
+            _formula_conjoined_bound(comparison_text, occurrences),
         )
     if re.match(
         r"(?:(?:von\s+)?mehr\s+als|über|more\s+than|"
-        r"greater\s+than(?!\s+or\s+equal\s+to)|"
+        r"greater\s+than(?!\s+or\s+equal\s+to)|in\s+excess\s+of|"
         r"exceeds?|exceeding|above)\b",
         lowered_range,
     ):
@@ -18342,7 +18385,7 @@ def _formula_interval_from_text(
             occurrences[0],
             False,
             "lower",
-            _formula_conjoined_bound(text, occurrences),
+            _formula_conjoined_bound(comparison_text, occurrences),
         )
     if re.match(
         r"(?:von|ab|from|at\s+least|no\s+less\s+than|"
@@ -18355,7 +18398,7 @@ def _formula_interval_from_text(
             occurrences[0],
             True,
             "lower",
-            _formula_conjoined_bound(text, occurrences),
+            _formula_conjoined_bound(comparison_text, occurrences),
         )
     return None
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1658"
+ENCODER_VERSION = "0.2.1659"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1658"
+ENCODER_VERSION = "0.2.1659"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1658"
+ENCODER_VERSION = "0.2.1659"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1658"
+ENCODER_VERSION = "0.2.1659"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1658"
+ENCODER_VERSION = "0.2.1659"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1658"
+ENCODER_VERSION = "0.2.1659"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1658"
+ENCODER_VERSION = "0.2.1659"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1658"')
+        .startswith('__version__ = "0.2.1659"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1658"
+    assert encoder_package["version"] == "0.2.1659"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1658"
+    assert project["project"]["version"] == "0.2.1659"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1658"')
+        .startswith('__version__ = "0.2.1659"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1658"
+    assert encoder_package["version"] == "0.2.1659"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1658"
+    assert project["project"]["version"] == "0.2.1659"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1658"')
+        .startswith('__version__ = "0.2.1659"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1658"
+ENCODER_VERSION = "0.2.1659"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2798,6 +2798,133 @@ def test_formula_interval_recognizes_conjoined_upper_bound(
 
 
 @pytest.mark.parametrize(
+    ("source", "lower", "upper"),
+    (
+        (
+            "Four percent of taxable income in excess of five hundred dollars "
+            "($500) and not in excess of three thousand dollars ($3,000).",
+            500,
+            3000,
+        ),
+        (
+            "Four percent of taxable income in excess of one thousand dollars "
+            "($1,000) and not in excess of six thousand dollars ($6,000).",
+            1000,
+            6000,
+        ),
+    ),
+)
+def test_formula_interval_recognizes_alabama_in_excess_brackets(
+    source: str,
+    lower: int,
+    upper: int,
+):
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=LEGACY_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert interval.lower is not None and interval.lower.value == lower
+    assert not interval.lower_inclusive
+    assert interval.upper is not None and interval.upper.value == upper
+    assert interval.upper_inclusive
+
+
+def test_formula_subject_matches_established_boundary_helper_suffix():
+    source = (
+        "Four percent of taxable income in excess of five hundred dollars "
+        "and not in excess of three thousand dollars."
+    )
+
+    assert completeness_module._formula_subject_matches_source(
+        "taxable_income_boundary",
+        source,
+    )
+    assert not completeness_module._formula_subject_matches_source(
+        "gross_income_boundary",
+        source,
+    )
+    assert not completeness_module._formula_subject_matches_source(
+        "taxable_credit_boundary",
+        source,
+    )
+
+
+def test_formula_subject_preserves_literal_boundary_subject():
+    assert completeness_module._formula_subject_matches_source(
+        "benefit_boundary",
+        "The benefit boundary above five hundred dollars applies.",
+    )
+
+
+def test_alabama_middle_bracket_execution_accepts_taxable_income_boundary():
+    source = (
+        "Four percent of taxable income in excess of five hundred dollars "
+        "($500) and not in excess of three thousand dollars ($3,000)."
+    )
+    branch = completeness_module.SourceStructureBranch(
+        ("1", "b"),
+        "letter",
+        "Buchstabe (b)",
+        source,
+        0,
+        len(source),
+    )
+    interval = completeness_module._formula_branch_interval(
+        branch,
+        extract_numeric_occurrences=LEGACY_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+    )
+
+    def execution(subject: str):
+        return completeness_module._FormulaExecution(
+            trace=(),
+            leaf=(
+                "nonjoint_second_bracket_rate * min(max(0, "
+                f"{subject} - nonjoint_second_bracket_lower_threshold), "
+                "nonjoint_second_bracket_ceiling - "
+                "nonjoint_second_bracket_lower_threshold)"
+            ),
+            evaluated_value=None,
+            evaluates_to_zero=False,
+            constant_environment={},
+        )
+
+    formula_environment = {
+        "nonjoint_second_bracket_rate": 0.04,
+        "nonjoint_second_bracket_lower_threshold": 500,
+        "nonjoint_second_bracket_ceiling": 3000,
+    }
+    shared_arguments = {
+        "interval": interval,
+        "formula_environment": formula_environment,
+        "extract_numeric_occurrences": (LEGACY_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR),
+        "numeric_value_is_grounded": numeric_value_is_grounded,
+    }
+
+    assert completeness_module._formula_execution_matches_source_branch(
+        execution("taxable_income_boundary"),
+        branch,
+        **shared_arguments,
+    )
+    assert not completeness_module._formula_execution_matches_source_branch(
+        execution("gross_income_boundary"),
+        branch,
+        **shared_arguments,
+    )
+
+
+def test_formula_interval_does_not_merge_unequal_parenthetical_amount():
+    interval = completeness_module._formula_interval_from_text(
+        "Taxable income in excess of five hundred dollars ($600) and not in "
+        "excess of three thousand dollars ($3,000).",
+        extract_numeric_occurrences=LEGACY_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is None
+
+
+@pytest.mark.parametrize(
     ("lower", "lower_inclusive", "connector", "upper", "upper_inclusive"),
     (
         ("greater than", False, "but", "not exceeding", True),

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1658"
+version = "0.2.1659"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- recognize statutory `in excess of` as an exclusive lower bracket bound
- collapse equal word-number and parenthetical-currency restatements into one threshold while rejecting unequal restatements fail-closed
- allow established trailing `_boundary` helper names to bind their source-named tax base without weakening subject matching
- bump the encoder release to 0.2.1659 and add the required changelog fragment

## Alabama retained-candidate validation

The retained batch-004 Sol candidate for Alabama section 40-18-5 validates with zero completeness issues and 22/22 numeric cases under this fix. No failed workflow was replayed, approved, adopted, or signed.

## Review-fix cycle

An independent first review found two actionable fail-closed issues: literal source subjects ending in “boundary” and unequal parenthetical restatements. Both were fixed with regressions. The independent second pass reported no remaining actionable findings.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run ruff format --check src/ tests/`
- `uv run pytest -q tests/test_source_completeness.py --no-cov` (5,374 passed)
- focused oracle registry tests (24 passed)
- `uv run pytest` (12,541 passed, 123 skipped)