### PR TITLE
Fix source deferral retry feedback

### DIFF
--- a/changelog.d/pit-source-deferral-retry-feedback.fixed.md
+++ b/changelog.d/pit-source-deferral-retry-feedback.fixed.md
@@ -1,0 +1,4 @@
+Preserve precise canonical source-root deferrals during policy-module apply
+repair, diagnose misplaced document-root deferrals, and retain the paired
+source-structure and exact formula-binding remediation in bounded validation
+retry feedback.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1659"
+version = "0.2.1660"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1659"
+__version__ = "0.2.1660"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -223,6 +223,7 @@ from .harness.proof_validator import (
     proof_source_citation_paths,
     validate_rulespec_proofs,
 )
+from .harness.source_completeness import _rulespec_target_base
 from .harness.validator_pipeline import (
     _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS,
     _US_TAX_JOINT_ONLY_ANY_OTHER_CASE_TEXT_PATTERN,
@@ -26162,9 +26163,9 @@ def _latest_validation_retry_candidate(
 def _validation_retry_issue_snapshot(
     *issue_groups: object,
 ) -> tuple[str, ...]:
-    """Snapshot bounded validator issues that match one captured candidate."""
+    """Snapshot bounded, category-diverse issues for one captured candidate."""
 
-    issues: list[str] = []
+    candidates: list[str] = []
     seen: set[str] = set()
     inspection_limit = VALIDATION_RETRY_FEEDBACK_MAX_ITEMS * 4
     for issue_group in issue_groups:
@@ -26174,10 +26175,7 @@ def _validation_retry_issue_snapshot(
             continue
         inspected = 0
         issue_iterator = iter(issue_group)
-        while (
-            len(issues) < VALIDATION_RETRY_FEEDBACK_MAX_ITEMS
-            and inspected < inspection_limit
-        ):
+        while inspected < inspection_limit:
             try:
                 issue = next(issue_iterator)
             except StopIteration:
@@ -26189,10 +26187,105 @@ def _validation_retry_issue_snapshot(
             if not item or item in seen:
                 continue
             seen.add(item)
-            issues.append(item)
-        if len(issues) >= VALIDATION_RETRY_FEEDBACK_MAX_ITEMS:
+            candidates.append(item)
+    return _category_diverse_validation_retry_issues(candidates)
+
+
+def _category_diverse_validation_retry_issues(
+    candidates: Sequence[str],
+) -> tuple[str, ...]:
+    """Keep the first failure while retaining paired and diverse diagnostics."""
+
+    if not candidates:
+        return ()
+    limit = VALIDATION_RETRY_FEEDBACK_MAX_ITEMS
+    selected: list[str] = [candidates[0]]
+    selected_set = {candidates[0]}
+
+    structure_issue = next(
+        (
+            issue
+            for issue in candidates
+            if issue.startswith("[complete-source-unit:structure]")
+        ),
+        None,
+    )
+    if structure_issue is not None and structure_issue not in selected_set:
+        selected.append(structure_issue)
+        selected_set.add(structure_issue)
+    structure_locator = (
+        _validation_retry_branch_locator(structure_issue) if structure_issue else None
+    )
+    if structure_locator:
+        paired_formula_issue = next(
+            (
+                issue
+                for issue in candidates
+                if issue.startswith("[complete-source-unit:formula-output]")
+                and _validation_retry_branch_locator(issue) == structure_locator
+            ),
+            None,
+        )
+        if paired_formula_issue is not None:
+            selected.append(paired_formula_issue)
+            selected_set.add(paired_formula_issue)
+
+    selected_categories = {
+        category
+        for issue in selected
+        if (category := _validation_retry_issue_category(issue)) is not None
+    }
+    for issue in candidates:
+        category = _validation_retry_issue_category(issue)
+        if (
+            len(selected) >= limit
+            or issue in selected_set
+            or category is None
+            or category in selected_categories
+        ):
+            continue
+        selected.append(issue)
+        selected_set.add(issue)
+        selected_categories.add(category)
+    for issue in candidates:
+        if len(selected) >= limit:
             break
-    return tuple(issues)
+        if issue in selected_set:
+            continue
+        selected.append(issue)
+        selected_set.add(issue)
+    return tuple(selected)
+
+
+def _validation_retry_issue_category(issue: str) -> str | None:
+    match = re.match(r"\[([A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)?)\]", issue)
+    return match.group(1).lower() if match is not None else None
+
+
+def _validation_retry_branch_locator(issue: str) -> str | None:
+    if issue.startswith("[complete-source-unit:structure]"):
+        match = re.search(
+            r"\bat (.+?) is neither encoded nor precisely deferred", issue
+        )
+    elif issue.startswith("[complete-source-unit:formula-output]"):
+        match = re.search(r"\bin (.+?) has no principal derived/relation output", issue)
+    else:
+        return None
+    if match is None:
+        return None
+    locator = match.group(1).strip()
+    structured = re.fullmatch(r"(.+?)\s+\[([^]]+)\]", locator)
+    if structured is None:
+        return " ".join(locator.casefold().split())
+    citation, rendered_components = structured.groups()
+    components = tuple(
+        component.strip().rsplit(maxsplit=1)[-1].casefold()
+        for component in rendered_components.split(",")
+        if component.strip()
+    )
+    if not components:
+        return " ".join(locator.casefold().split())
+    return f"{' '.join(citation.casefold().split())} [{' / '.join(components)}]"
 
 
 def _encode_validation_retry_feedback(
@@ -39827,6 +39920,7 @@ def _remove_out_of_scope_deferred_outputs(
     deferred_outputs = module.get("deferred_outputs")
     if not isinstance(deferred_outputs, list):
         return []
+    source_anchor = _source_verification_rulespec_anchor(module)
 
     kept: list[Any] = []
     removed: list[str] = []
@@ -39841,6 +39935,12 @@ def _remove_out_of_scope_deferred_outputs(
         if _rulespec_target_within_anchor(output, base_anchor=base_anchor):
             kept.append(record)
             continue
+        if source_anchor and _rulespec_target_within_anchor(
+            output,
+            base_anchor=source_anchor,
+        ):
+            kept.append(record)
+            continue
         removed.append(f"deferred_outputs[{index}]")
 
     if not removed:
@@ -39851,6 +39951,20 @@ def _remove_out_of_scope_deferred_outputs(
         module.pop("deferred_outputs", None)
     rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
     return removed
+
+
+def _source_verification_rulespec_anchor(module: dict[str, Any]) -> str | None:
+    source_verification = module.get("source_verification")
+    if not isinstance(source_verification, dict):
+        return None
+    citation_path = source_verification.get("corpus_citation_path")
+    if not isinstance(citation_path, str):
+        return None
+    try:
+        canonical_path = require_canonical_corpus_citation_path(citation_path)
+    except CorpusResolutionError:
+        return None
+    return _rulespec_target_base(canonical_path)
 
 
 def _rulespec_target_within_anchor(target: str, *, base_anchor: str) -> bool:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -15590,15 +15590,23 @@ def find_deferred_output_issues(content: str) -> list[str]:
     payload = _rulespec_payload(content)
     if payload is None:
         return []
+    issues: list[str] = []
+    if "deferred_outputs" in payload:
+        issues.append(
+            "`deferred_outputs` is misplaced at the document root; move it to "
+            "`module.deferred_outputs`."
+        )
     module = payload.get("module")
     if not isinstance(module, dict) or "deferred_outputs" not in module:
-        return []
+        return issues
 
     deferred_outputs = module.get("deferred_outputs")
     if not isinstance(deferred_outputs, list):
-        return ["`module.deferred_outputs` must be a list of deferred output records."]
+        issues.append(
+            "`module.deferred_outputs` must be a list of deferred output records."
+        )
+        return issues
 
-    issues: list[str] = []
     for index, record in enumerate(deferred_outputs):
         label = f"module.deferred_outputs[{index}]"
         if not isinstance(record, dict):

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1659"
+ENCODER_VERSION = "0.2.1660"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13509,6 +13509,48 @@ class TestCmdEncode:
             ["current CI issue"],
         ) == ("duplicate compile issue", "current CI issue")
 
+    def test_encode_retry_issue_snapshot_pairs_structure_with_formula_remediation(self):
+        import axiom_encode.cli as cli_module
+
+        structure_locator = "us-ms/statute/27-7-5(1) [Absatz 1, Nummer b, Buchstabe ii]"
+        formula_locator = "us-ms/statute/27-7-5(1) [Absatz 1, Nummer b, Nummer ii]"
+        structure = (
+            "[complete-source-unit:structure] Source branch (1)(b)(ii) at "
+            f"{structure_locator} is neither encoded nor precisely deferred."
+        )
+        formula = (
+            "[complete-source-unit:formula-output] Explicit source computation "
+            f"(1)(b)(ii) in {formula_locator} has no principal derived/relation "
+            "output "
+            "(`derived` or `derived_relation`) and is not precisely deferred; "
+            "add a `versions[N].formula` proof atom whose "
+            "`source.corpus_citation_path` is exactly "
+            "`us-ms/statute/27-7-5` and whose excerpt is the complete chapeau."
+        )
+        unrelated_formula = (
+            "[complete-source-unit:formula-output] Explicit source computation "
+            "(1)(a)(iii) in us-ms/statute/27-7-5(1) "
+            "[Absatz 1, Nummer a, Nummer iii] has no principal derived/relation "
+            "output (`derived` or `derived_relation`)."
+        )
+        structure_flood = tuple(
+            "[complete-source-unit:structure] Source branch "
+            f"{index} at us-ms/statute/27-7-5(1) [Nummer {index}] is neither "
+            "encoded nor precisely deferred."
+            for index in range(20)
+        )
+        tests_issue = "[complete-source-unit:tests] missing positive control"
+
+        snapshot = cli_module._validation_retry_issue_snapshot(
+            (structure, *structure_flood, unrelated_formula, formula, tests_issue)
+        )
+
+        assert snapshot[:2] == (structure, formula)
+        assert unrelated_formula not in snapshot
+        assert tests_issue in snapshot
+        assert "complete chapeau" in snapshot[1]
+        assert "`us-ms/statute/27-7-5`" in snapshot[1]
+
     def test_encode_retry_feedback_retains_compound_diagnostic_tail(self):
         import axiom_encode.cli as cli_module
 
@@ -18979,7 +19021,7 @@ rules:
 module:
   status: deferred
   source_verification:
-    corpus_citation_path: us/statute/26/3121
+    corpus_citation_path: us/statute/26/3121/t
   deferred_outputs:
     - output: us:statutes/26/3121/a#wages
       reason: Outside subsection t.
@@ -19025,6 +19067,45 @@ rules: []
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_apply_scope_repair_preserves_requested_source_root_deferral(
+        self,
+        tmp_path,
+    ):
+        import axiom_encode.cli as cli_module
+
+        rules_file = tmp_path / "2026_section_27_7_5_schedule.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ms/statute/27-7-5
+  deferred_outputs:
+    - output: us-ms:statutes/27-7-5/1/b/ii/7#individual_upper_band_tax_for_2030_and_later
+      reason: Precise requested-source deferral.
+    - output: us-ms:policies/income_tax/2026_section_27_7_5_schedule#individual_income_tax
+      reason: Generated policy output.
+    - output: us-ms:statutes/27-7-9#unrelated_credit
+      reason: Unrelated source unit.
+rules: []
+"""
+        )
+
+        removed = cli_module._remove_out_of_scope_deferred_outputs(
+            rules_file=rules_file,
+            base_anchor=("us-ms:policies/income_tax/2026_section_27_7_5_schedule"),
+        )
+
+        assert removed == ["deferred_outputs[2]"]
+        repaired = yaml.safe_load(rules_file.read_text())
+        assert [
+            record["output"] for record in repaired["module"]["deferred_outputs"]
+        ] == [
+            "us-ms:statutes/27-7-5/1/b/ii/7#"
+            "individual_upper_band_tax_for_2030_and_later",
+            "us-ms:policies/income_tax/2026_section_27_7_5_schedule#"
+            "individual_income_tax",
+        ]
 
     def test_encode_apply_promotes_module_imports(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1659"
+ENCODER_VERSION = "0.2.1660"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1659"
+ENCODER_VERSION = "0.2.1660"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1659"
+ENCODER_VERSION = "0.2.1660"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1659"
+ENCODER_VERSION = "0.2.1660"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1659"
+ENCODER_VERSION = "0.2.1660"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1659"
+ENCODER_VERSION = "0.2.1660"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1659"')
+        .startswith('__version__ = "0.2.1660"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1659"
+    assert encoder_package["version"] == "0.2.1660"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1659"
+    assert project["project"]["version"] == "0.2.1660"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1659"')
+        .startswith('__version__ = "0.2.1660"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1659"
+    assert encoder_package["version"] == "0.2.1660"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1659"
+    assert project["project"]["version"] == "0.2.1660"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1659"')
+        .startswith('__version__ = "0.2.1660"')
     )
 
 
@@ -30438,6 +30438,23 @@ rules: []
         "source_values" in issue and "absolute RuleSpec target" in issue
         for issue in issues
     )
+
+
+def test_deferred_output_rejects_misplaced_document_root_records():
+    content = """format: rulespec/v1
+deferred_outputs:
+  - output: us-ms:statutes/27-7-5/1/b/ii/7#individual_upper_band_tax
+    reason: Missing same-act Section 2 dependency.
+module:
+  source_verification:
+    corpus_citation_path: us-ms/statute/27-7-5
+rules: []
+"""
+
+    assert find_deferred_output_issues(content) == [
+        "`deferred_outputs` is misplaced at the document root; move it to "
+        "`module.deferred_outputs`."
+    ]
 
 
 def test_deferred_output_rejects_absolute_blocker_without_rule_fragment():

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1659"
+ENCODER_VERSION = "0.2.1660"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1659"
+version = "0.2.1660"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- preserve canonical source-root deferrals within the authoritative `module.source_verification` unit during policy-module apply repair while still pruning unrelated source targets
- keep the exact same-branch formula-output remediation beside a bounded complete-source structure failure, normalizing cosmetic `Buchstabe`/`Nummer` locator differences
- retain diagnostic category diversity and existing inspection/output bounds
- diagnose `deferred_outputs` misplaced at the document root
- bump the encoder release to 0.2.1660 with a changelog fragment

## Retained Mississippi evidence

Batch 004 exposed only the generic `(1)(b)(ii)` structure line on retry, despite an available formula-output diagnostic carrying the exact chapeau/proof shape. Its repair pass also removed the canonical `/1/b/ii/7` source deferral because the generated module used a policy anchor. Regressions reproduce both behaviors, including the real `Buchstabe ii` versus `Nummer ii` locator mismatch and an earlier unrelated formula diagnostic.

No failed workflow was replayed, approved, adopted, or signed.

## Review-fix cycle

Independent review found one blocker: exact locator-string equality could pair the wrong formula diagnostic. The locator now normalizes to structural path values, the regression uses the exact retained mismatch, and the independent second pass reported no remaining actionable findings.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run ruff format --check src/ tests/`
- focused owner regressions (26 passed)
- `tests/test_cli.py` (1,177 passed, 10 skipped)
- `tests/test_rulespec_validation.py` (2,296 passed, 31 skipped)
- oracle registry tests (24 passed)
- `uv run pytest` (12,544 passed, 123 skipped)