### PR TITLE
Fix Batch 7 replacement validation and numeric grounding

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1538,6 +1538,9 @@ jobs:
                 "$refresh_rulespec_path" "" false \
                 "$refresh_deferred_output_contracts" \
                 "$refresh_required_test_cases"
+              "$workflow_python" "$backfill_helper" \
+                reconcile-retired-manifest-inventory \
+                "$RULESPEC_CHECKOUT" "$refresh_rulespec_path"
               checkpoint_signed_changes \
                 "Refresh signed canonical module for ${refresh_citation}"
               cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1552,6 +1552,9 @@ jobs:
               run_signed_encode \
                 "$CITATION" "" false target-preflight \
                 "$REPLACE_RULESPEC_PATH" "" false
+              "$workflow_python" "$backfill_helper" \
+                reconcile-retired-manifest-inventory \
+                "$RULESPEC_CHECKOUT" "$REPLACE_RULESPEC_PATH"
               checkpoint_signed_changes \
                 "Canonicalize signed replacement target before source bundle"
               cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
@@ -1593,6 +1596,14 @@ jobs:
                 target "$REPLACE_RULESPEC_PATH" \
                 "$REPLACE_LEGACY_RULESPEC_PATH" \
                 "$required_imports_enabled"
+            fi
+
+            if [ "$source_bundle_enabled" = "false" ] && \
+               [ -n "$REPLACE_RULESPEC_PATH" ] && \
+               [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
+              "$workflow_python" "$backfill_helper" \
+                reconcile-retired-manifest-inventory \
+                "$RULESPEC_CHECKOUT" "$REPLACE_RULESPEC_PATH"
             fi
 
             if [ "$source_bundle_enabled" = "true" ]; then

--- a/changelog.d/apply-overlay-existing-target-contract.fixed.md
+++ b/changelog.d/apply-overlay-existing-target-contract.fixed.md
@@ -1,0 +1,3 @@
+Preserve exact-oracle replacement surface visibility and typed inputs during
+apply-overlay validation, and reject new helper names that repeat a target
+path's year and legal-source identity.

--- a/changelog.d/legacy-decimal-percentage-tokenization.fixed.md
+++ b/changelog.d/legacy-decimal-percentage-tokenization.fixed.md
@@ -1,0 +1,3 @@
+Parse worded decimal percentages such as `four and seven-tenths percent`
+atomically and deduplicate scaled numeric recall only within the same source
+evidence span.

--- a/changelog.d/targeted-retired-manifest-reconciliation.fixed.md
+++ b/changelog.d/targeted-retired-manifest-reconciliation.fixed.md
@@ -1,0 +1,3 @@
+Remove an exact retired-schema manifest allowance automatically when a signed
+targeted replacement upgrades that manifest, with fail-closed publication
+authorization for the derived inventory change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1663"
+version = "0.2.1664"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1662"
+version = "0.2.1663"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1662"
+__version__ = "0.2.1663"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1663"
+__version__ = "0.2.1664"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -176,6 +176,7 @@ from .harness.evals import (
     _bind_eval_result_payload,
     _build_eval_suite_execution_identity,
     _build_eval_suite_manifest_identity,
+    _build_existing_target_oracle_contract_for_file,
     _deterministic_tree_identity,
     _eval_artifact_validation_error,
     _eval_result_from_payload,
@@ -53126,6 +53127,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         relative_output,
     )
     existing_output = policy_content_root / relative_output
+    existing_target_oracle_contract = None
     if (
         replacement_overlay_scope
         and legacy_replacement is None
@@ -53141,6 +53143,16 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         )
     if existing_output.exists():
         existing_content = existing_output.read_text()
+        target = _relative_output_to_anchor(
+            relative_output,
+            policy_repo_path=policy_repo_path,
+        )
+        existing_target_oracle_contract = (
+            _build_existing_target_oracle_contract_for_file(
+                existing_output,
+                target=target,
+            )
+        )
         preservation_issues = _source_relation_preservation_issues(
             existing_content,
             generated_content,
@@ -53282,6 +53294,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             rulespec_dependency_roots=staged_dependency_roots,
             source_metadata=source_metadata,
             require_complete_source_unit=require_complete_source_unit,
+            existing_target_oracle_contract=existing_target_oracle_contract,
         )
         dependents = (
             _find_rulespec_dependents(overlay_content_root, relative_output)

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7231,6 +7231,28 @@ def _add_attached_amendment_import_retry_guidance(
         compile_result.error = "\n".join(error_parts)
 
 
+def _build_existing_target_oracle_contract_for_file(
+    existing_target: Path,
+    *,
+    target: str,
+    context_files: list[EvalContextFile] | None = None,
+) -> ExistingTargetOracleContract | None:
+    """Build one shared standalone/apply contract from a regular target file."""
+
+    path = Path(existing_target)
+    if path.is_symlink() or not path.is_file():
+        return None
+    return build_existing_target_oracle_contract(
+        path.read_text(),
+        target=target,
+        policyengine_registry=load_policyengine_registry(),
+        invalid_input_names=_context_file_invalid_local_inputs(
+            str(path),
+            context_files=context_files,
+        ),
+    )
+
+
 def _evaluate_artifact_in_scope(
     rulespec_file: Path,
     policy_repo_root: Path,
@@ -7259,13 +7281,11 @@ def _evaluate_artifact_in_scope(
                 f"{Path(policy_repo_root).name}:"
                 f"{relative_target.with_suffix('').as_posix()}"
             )
-            existing_target_oracle_contract = build_existing_target_oracle_contract(
-                existing_target.read_text(),
-                target=target,
-                policyengine_registry=load_policyengine_registry(),
-                invalid_input_names=_context_file_invalid_local_inputs(
-                    str(existing_target)
-                ),
+            existing_target_oracle_contract = (
+                _build_existing_target_oracle_contract_for_file(
+                    existing_target,
+                    target=target,
+                )
             )
     with _rulespec_validation_target(
         rulespec_file,
@@ -10431,6 +10451,10 @@ RuleSpec requirements:
   parent file.
 - Do not create standalone small-number parameters just to restate prose such as "one-time" or "more than one consecutive month" when the number only qualifies a local factual condition. Encode the whole source-stated condition as a fact predicate or derived condition unless the scalar is an independent reusable amount, rate, threshold, cap, or limit.
 - Do not append citation or file suffixes like `_2014_a` to new local rule names; the file path is already the legal ID. Keep names concise and semantic unless a copied public interface must be preserved.
+- For a replacement target, only exact names listed by the Exact-oracle
+  replacement contract may retain the target path's year/legal-source identity.
+  New helper concepts must use concise semantic names instead of repeating that
+  identity as a prefix or suffix.
 - Rule names ending in the current path fragments, such as `_2_C`, `_b_1`,
   `_d_2_C`, or `_2014_a`, are invalid.
 - If an existing copied output name violates the no-citation/path-suffix rule,
@@ -11504,24 +11528,23 @@ def _format_existing_target_contract_guidance(
     """Return explicit public-surface contracts for copied target files."""
     contract_lines: list[str] = []
     required_lines: list[str] = []
+    replacement_name_identities: set[str] = set()
     for item in context_files:
         if item.kind != "existing_target":
             continue
         surfaces = _context_file_executable_surfaces(item.source_path)
-        oracle_contract = build_existing_target_oracle_contract(
-            Path(item.source_path).read_text(),
+        oracle_contract = _build_existing_target_oracle_contract_for_file(
+            Path(item.source_path),
             target=item.import_path,
-            policyengine_registry=load_policyengine_registry(),
-            invalid_input_names=_context_file_invalid_local_inputs(
-                item.source_path,
-                context_files=context_files,
-            ),
+            context_files=context_files,
         )
         required_names = (
             {surface.name for surface in oracle_contract.surfaces}
             if oracle_contract is not None
             else set()
         )
+        if oracle_contract is not None and oracle_contract.replacement_name_identity:
+            replacement_name_identities.add(oracle_contract.replacement_name_identity)
         for name, surface in surfaces.items():
             details = [
                 f"kind={surface.get('kind') or ''}",
@@ -11535,6 +11558,11 @@ def _format_existing_target_contract_guidance(
             indexed_by = surface.get("indexed_by") or ()
             if indexed_by:
                 details.append(f"indexed_by={','.join(indexed_by)}")
+            details.append(
+                "visibility=private"
+                if surface.get("private") is True
+                else "visibility=public"
+            )
             effective_dates = surface.get("effective_dates") or ()
             if effective_dates:
                 details.append(f"effective_from={','.join(effective_dates)}")
@@ -11554,15 +11582,30 @@ def _format_existing_target_contract_guidance(
         return ""
     required_section = ""
     if required_lines:
+        naming_guidance = (
+            "\nNew helper concepts must not repeat target-path year/legal-source "
+            "identity "
+            + ", ".join(
+                f"`{identity}`" for identity in sorted(replacement_name_identities)
+            )
+            + "; use concise semantic helper names. "
+            "The exact mapped legacy surface names listed above are the only "
+            "exception.\n"
+            if replacement_name_identities
+            else ""
+        )
         required_section = """
 Exact-oracle replacement contract:
 These valid existing names are owned by exact oracle registry entries. Preserve
-each executable name and its listed public shape, and preserve each listed valid
-explicit input contract. Repair formulas, proofs, tests, and temporal coverage
-behind those stable surfaces. This exception does not preserve any invalid
-legacy input:
+each executable name and its listed public/private shape, and preserve each
+listed valid explicit input contract. Repair formulas, proofs, tests, and
+temporal coverage behind those stable surfaces. This exception does not
+preserve any invalid legacy input:
 {lines}
-""".format(lines="\n".join(required_lines))
+{naming_guidance}""".format(
+            lines="\n".join(required_lines),
+            naming_guidance=naming_guidance,
+        )
     advisory_section = ""
     if contract_lines:
         advisory_section = """
@@ -13291,6 +13334,10 @@ def _context_file_executable_surfaces(source_path: str) -> dict[str, dict[str, o
             "unit": str(rule.get("unit") or "").strip(),
             "indexed_by": _context_surface_sequence(rule.get("indexed_by")),
             "effective_dates": tuple(effective_dates),
+            "private": (
+                isinstance(rule.get("metadata"), dict)
+                and rule["metadata"].get("private") is True
+            ),
         }
     return surfaces
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -4371,6 +4371,23 @@ def _iter_normalized_special_numeric_matches(
         matches.append((match.span(), (whole + numerator / denominator) / 100))
 
     for match in re.finditer(
+        rf"\b(?:(?P<whole>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})\s+and\s+)?"
+        rf"(?P<numerator>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})[-\s]+"
+        rf"{_DECIMAL_FRACTION_DENOMINATOR_PATTERN}\s+"
+        r"(?:percent|per\s*cent(?:um)?)\b",
+        text,
+        re.IGNORECASE,
+    ):
+        whole = _parse_strict_cardinal_number_words(match.group("whole") or "") or 0
+        numerator = _parse_strict_cardinal_number_words(match.group("numerator"))
+        denominator = _DECIMAL_FRACTION_DENOMINATORS.get(
+            match.group("denominator").lower().removesuffix("s")
+        )
+        if numerator is None or denominator is None:
+            continue
+        matches.append((match.span(), (whole + numerator / denominator) / 100))
+
+    for match in re.finditer(
         rf"\b(?P<numerator>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})[-\s]+"
         rf"{_DECIMAL_FRACTION_DENOMINATOR_PATTERN}\s+of\s+"
         rf"(?P<percent>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})\s+"
@@ -8053,6 +8070,29 @@ def _scalar_recall_numeric_inventory(
     )
 
 
+def _is_same_evidence_scaled_inventory_duplicate(
+    occurrence: NumericOccurrence,
+    occurrences: Sequence[NumericOccurrence],
+) -> bool:
+    """Collapse scaled/unscaled readings only when one source span supplied both."""
+    if math.isclose(
+        occurrence.value,
+        0,
+        rel_tol=0,
+        abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+    ):
+        return True
+    if occurrence.value > 1:
+        return False
+    scaled_value = round(occurrence.value * 100, 9)
+    return any(
+        candidate is not occurrence
+        and candidate.span == occurrence.span
+        and _occurrence_value_matches(candidate.value, scaled_value)
+        for candidate in occurrences
+    )
+
+
 def _complete_typed_year_occurrences(
     collector: _LegacyNumericCollector,
     occurrences: Iterable[NumericOccurrence],
@@ -8831,13 +8871,13 @@ def _tokenize_numeric_occurrences_from_text(
     collector.inventory = list(
         _complete_typed_year_occurrences(collector, collector.inventory)
     )
-    occurrence_counts = Counter(occurrence.value for occurrence in collector.inventory)
+    inventory_occurrences = tuple(collector.inventory)
     normalized_inventory = _scalar_recall_numeric_inventory(
         occurrence
-        for occurrence in collector.inventory
-        if not (
-            occurrence.value <= 1
-            and round(occurrence.value * 100, 9) in occurrence_counts
+        for occurrence in inventory_occurrences
+        if not _is_same_evidence_scaled_inventory_duplicate(
+            occurrence,
+            inventory_occurrences,
         )
     )
     return _NumericTokenization(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -173,6 +173,7 @@ class ExistingTargetSurfaceContract:
     period: str
     unit: str
     indexed_by: tuple[str, ...]
+    private: bool
 
 
 @dataclass(frozen=True)
@@ -193,6 +194,7 @@ class ExistingTargetOracleContract:
     target: str
     surfaces: tuple[ExistingTargetSurfaceContract, ...]
     inputs: tuple[ExistingTargetInputContract, ...]
+    replacement_name_identity: str
 
 
 @dataclass(frozen=True)
@@ -12399,6 +12401,7 @@ def _existing_target_surface_contract(
         or not versions
     ):
         return None
+    metadata = rule.get("metadata")
     return ExistingTargetSurfaceContract(
         name=name,
         kind=kind,
@@ -12407,6 +12410,7 @@ def _existing_target_surface_contract(
         period=str(rule.get("period") or "").strip(),
         unit=str(rule.get("unit") or "").strip(),
         indexed_by=_contract_sequence(rule.get("indexed_by")),
+        private=(isinstance(metadata, Mapping) and metadata.get("private") is True),
     )
 
 
@@ -12423,6 +12427,57 @@ def _existing_target_input_contract(
         dtype=dtype,
         period=str(item.get("period") or "").strip(),
         unit=str(item.get("unit") or "").strip(),
+    )
+
+
+_REPLACEMENT_LEGAL_SOURCE_NAME_MARKERS = frozenset(
+    {
+        "article",
+        "chapter",
+        "code",
+        "cfr",
+        "krs",
+        "regulation",
+        "section",
+        "statute",
+        "title",
+        "usc",
+    }
+)
+_REPLACEMENT_LEGAL_SOURCE_FRAGMENT = re.compile(r"[0-9]+[a-z]*", re.IGNORECASE)
+
+
+def _replacement_target_name_identity(target: str) -> str:
+    """Return a narrow year/source identity repeated by legacy target names."""
+
+    target_path = target.partition(":")[2] or target
+    basename = Path(target_path).name
+    tokens = tuple(token for token in basename.lower().split("_") if token)
+    if len(tokens) < 3 or re.fullmatch(r"(?:19|20)\d{2}", tokens[0]) is None:
+        return ""
+    if tokens[1] not in _REPLACEMENT_LEGAL_SOURCE_NAME_MARKERS:
+        return ""
+    identity = list(tokens[:2])
+    for token in tokens[2:]:
+        if _REPLACEMENT_LEGAL_SOURCE_FRAGMENT.fullmatch(token) is None:
+            break
+        identity.append(token)
+    if len(identity) < 3:
+        return ""
+    return "_".join(identity)
+
+
+def _rule_name_contains_token_sequence(name: str, sequence: str) -> bool:
+    """Return whether one snake-case name contains an exact token sequence."""
+
+    name_tokens = tuple(token for token in name.lower().split("_") if token)
+    sequence_tokens = tuple(token for token in sequence.split("_") if token)
+    if not sequence_tokens or len(sequence_tokens) > len(name_tokens):
+        return False
+    width = len(sequence_tokens)
+    return any(
+        name_tokens[index : index + width] == sequence_tokens
+        for index in range(len(name_tokens) - width + 1)
     )
 
 
@@ -12500,7 +12555,12 @@ def build_existing_target_oracle_contract(
         explicit_inputs[name]
         for name in sorted(reachable_identifiers & explicit_inputs.keys() - invalid)
     )
-    return ExistingTargetOracleContract(target, surfaces, inputs)
+    return ExistingTargetOracleContract(
+        target,
+        surfaces,
+        inputs,
+        _replacement_target_name_identity(target),
+    )
 
 
 def find_existing_target_oracle_contract_issues(
@@ -12542,8 +12602,9 @@ def find_existing_target_oracle_contract_issues(
         issues.append(
             "[existing-target-oracle-contract] Replacement must retain valid "
             f"exact-oracle-mapped surface `{contract.target}#{expected.name}` "
-            "with its existing kind/entity/dtype/period/unit/index contract. "
-            "Repair its implementation under that stable public surface."
+            "with its existing kind/entity/dtype/period/unit/index and "
+            "metadata.private/public contract. Repair its implementation under "
+            "that stable surface."
         )
     for expected in contract.inputs:
         actual_item = inputs.get(expected.name)
@@ -12560,6 +12621,32 @@ def find_existing_target_oracle_contract_issues(
             "existing entity/dtype/period/unit contract because an exact-oracle-"
             "mapped surface depends on it. Invalid legacy inputs are not covered."
         )
+    mapped_names = {surface.name for surface in contract.surfaces}
+    if contract.replacement_name_identity:
+        for name, rule in sorted(rules.items()):
+            if name in mapped_names:
+                continue
+            kind = str(rule.get("kind") or "").strip().lower()
+            if kind not in {
+                "parameter",
+                "derived",
+                "derived_relation",
+                "data_relation",
+            }:
+                continue
+            if not _rule_name_contains_token_sequence(
+                name,
+                contract.replacement_name_identity,
+            ):
+                continue
+            issues.append(
+                "[existing-target-naming-contract] New replacement helper "
+                f"`{name}` repeats target-path year/legal-source identity "
+                f"`{contract.replacement_name_identity}`. The file path already "
+                "supplies that identity; use a concise semantic helper name. "
+                "Only exact-oracle-mapped legacy surface names listed by the "
+                "replacement contract may retain this prefix."
+            )
     return issues
 
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -4380,12 +4380,15 @@ def _iter_normalized_special_numeric_matches(
         text,
         re.IGNORECASE,
     ):
-        whole = _parse_strict_cardinal_number_words(match.group("whole") or "") or 0
+        whole_text = match.group("whole")
+        whole = (
+            0 if whole_text is None else _parse_strict_cardinal_number_words(whole_text)
+        )
         numerator = _parse_strict_cardinal_number_words(match.group("numerator"))
         denominator = _DECIMAL_FRACTION_DENOMINATORS.get(
             match.group("denominator").lower().removesuffix("s")
         )
-        if numerator is None or denominator is None:
+        if whole is None or numerator is None or denominator is None:
             continue
         matches.append((match.span(), (whole + numerator / denominator) / 100))
 

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import hashlib
 import json
 import math
+import os
 import re
 import stat
 import subprocess
+import tempfile
 from datetime import date
 from pathlib import Path, PurePosixPath
 
@@ -21,7 +24,9 @@ MANIFEST_ROOT = PurePosixPath(".axiom/encoding-manifests")
 LEGACY_REPLACEMENT_RECEIPT_ROOT = PurePosixPath(".axiom/legacy-replacements")
 LEGACY_REPLACEMENT_TOOL = "axiom-encode encode --apply --replace-legacy-rulespec-path"
 APPLIED_MANIFEST_SCHEMA_V5 = "axiom-encode/applied-rulespec/v5"
+APPLIED_MANIFEST_SIGNATURE_ALGORITHM = "ed25519-domain-v1"
 PROVISIONS_TO_RULES_INDEX = PurePosixPath(".axiom/index/provisions_to_rules.json")
+RETIRED_MANIFEST_INVENTORY = PurePosixPath("tests/test_encoding_manifests.py")
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1 = "axiom-encode/legacy-fresh-reencode-receipt/v1"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2 = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3 = "axiom-encode/legacy-fresh-reencode-receipt/v3"
@@ -1593,6 +1598,253 @@ def _rulespec_companion_path(primary: PurePosixPath) -> PurePosixPath:
     return primary.with_name(f"{primary.stem}.test.yaml")
 
 
+def _rulespec_manifest_path(primary: PurePosixPath) -> PurePosixPath:
+    return MANIFEST_ROOT / primary.with_suffix(".json")
+
+
+def _retired_manifest_inventory_without_entry(
+    raw: bytes,
+    manifest_path: PurePosixPath,
+) -> bytes | None:
+    """Remove one exact literal from the canonical retired-manifest set."""
+
+    manifest = manifest_path.as_posix()
+    try:
+        text = raw.decode("utf-8")
+        module = ast.parse(text, filename=RETIRED_MANIFEST_INVENTORY.as_posix())
+    except (UnicodeError, SyntaxError, ValueError) as exc:
+        raise ValueError("retired manifest inventory is not valid UTF-8 Python") from exc
+
+    assignments: list[ast.AnnAssign] = []
+    for node in ast.walk(module):
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "KNOWN_RETIRED_SCHEMA_MANIFESTS"
+        ):
+            assignments.append(node)
+        elif isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name)
+            and target.id == "KNOWN_RETIRED_SCHEMA_MANIFESTS"
+            for target in node.targets
+        ):
+            raise ValueError(
+                "retired manifest inventory assignment is not canonical"
+            )
+    if len(assignments) != 1 or assignments[0] not in module.body:
+        raise ValueError(
+            "retired manifest inventory lacks one canonical top-level assignment"
+        )
+    assignment = assignments[0]
+    value = assignment.value
+    if (
+        not isinstance(value, ast.Call)
+        or not isinstance(value.func, ast.Name)
+        or value.func.id != "frozenset"
+        or len(value.args) != 1
+        or value.keywords
+        or not isinstance(value.args[0], ast.Set)
+    ):
+        raise ValueError("retired manifest inventory set shape is not canonical")
+    elements = value.args[0].elts
+    if not all(
+        isinstance(element, ast.Constant) and isinstance(element.value, str)
+        for element in elements
+    ):
+        raise ValueError("retired manifest inventory contains a non-literal entry")
+    values = [element.value for element in elements]
+    if len(values) != len(set(values)):
+        raise ValueError("retired manifest inventory contains duplicate entries")
+
+    matches = [
+        element
+        for element in elements
+        if isinstance(element, ast.Constant) and element.value == manifest
+    ]
+    textual_matches = text.count(manifest)
+    if not matches:
+        if textual_matches:
+            raise ValueError(
+                "retired manifest inventory path is present outside an exact entry"
+            )
+        return None
+    if len(matches) != 1 or textual_matches != 1:
+        raise ValueError("retired manifest inventory path match is ambiguous")
+
+    entry = matches[0]
+    if entry.end_lineno != entry.lineno:
+        raise ValueError("retired manifest inventory entry is not one canonical line")
+    lines = text.splitlines(keepends=True)
+    if entry.lineno < 1 or entry.lineno > len(lines):
+        raise ValueError("retired manifest inventory entry location is invalid")
+    line = lines[entry.lineno - 1]
+    if line not in {f"    '{manifest}',\n", f'    "{manifest}",\n'}:
+        raise ValueError("retired manifest inventory match is not an exact entry")
+    del lines[entry.lineno - 1]
+    rewritten = "".join(lines).encode("utf-8")
+    if manifest.encode("utf-8") in rewritten:
+        raise ValueError("retired manifest inventory still contains the removed path")
+    try:
+        compile(rewritten, RETIRED_MANIFEST_INVENTORY.as_posix(), "exec")
+    except (SyntaxError, ValueError) as exc:
+        raise ValueError(
+            "retired manifest inventory removal produced invalid Python"
+        ) from exc
+    return rewritten
+
+
+def _require_normal_model_apply_target_binding(
+    repo: Path,
+    target: PurePosixPath,
+    payload: dict[str, object],
+    *,
+    label: str,
+) -> None:
+    """Require one normal model manifest to hash-bind its canonical primary."""
+
+    signature = payload.get("signature")
+    if (
+        payload.get("schema_version") != APPLIED_MANIFEST_SCHEMA_V5
+        or payload.get("tool") != MODEL_APPLY_TOOL
+        or payload.get("backend") not in MODEL_APPLY_BACKENDS
+        or not isinstance(signature, dict)
+        or set(signature) != {"algorithm", "key_id", "value"}
+        or signature.get("algorithm") != APPLIED_MANIFEST_SIGNATURE_ALGORITHM
+        or not all(
+            isinstance(signature.get(field), str) and signature[field]
+            for field in ("key_id", "value")
+        )
+    ):
+        raise ValueError(f"{label} is not an exact signed-v5 model apply")
+    applied_files = payload.get("applied_files")
+    target_records = (
+        [
+            item
+            for item in applied_files
+            if isinstance(item, dict) and item.get("path") == target.as_posix()
+        ]
+        if isinstance(applied_files, list)
+        else []
+    )
+    target_raw = _read_bounded_regular(
+        repo,
+        target,
+        label=f"{label} RuleSpec",
+        max_bytes=16 * 1024 * 1024,
+    )
+    if (
+        len(target_records) != 1
+        or set(target_records[0]) != {"path", "sha256"}
+        or target_records[0].get("sha256")
+        != hashlib.sha256(target_raw).hexdigest()
+    ):
+        raise ValueError(f"{label} does not bind exact target bytes")
+
+
+def _normal_model_apply_manifest_for_target(
+    repo: Path,
+    target: PurePosixPath,
+) -> tuple[PurePosixPath, dict[str, object]]:
+    """Bind one changed signed-v5 model manifest to its exact target bytes."""
+
+    manifest_path = _rulespec_manifest_path(target)
+    changed = _changed_paths(repo)
+    if manifest_path not in changed:
+        raise ValueError(
+            "targeted replacement lacks its exact changed apply manifest"
+        )
+    try:
+        payload = _load_unambiguous_json(
+            _read_bounded_regular(
+                repo,
+                manifest_path,
+                label="targeted replacement apply manifest",
+                max_bytes=1024 * 1024,
+            ).decode("utf-8"),
+            label="targeted replacement apply manifest",
+        )
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError("targeted replacement apply manifest is malformed") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("targeted replacement apply manifest is malformed")
+    _require_normal_model_apply_target_binding(
+        repo,
+        target,
+        payload,
+        label="targeted replacement apply manifest",
+    )
+    return manifest_path, payload
+
+
+def reconcile_retired_manifest_inventory(
+    repo: Path,
+    target_rulespec_path: str,
+) -> PurePosixPath | None:
+    """Retire one stale schema allowance after a normal signed replacement."""
+
+    target = _safe_relative_path(
+        target_rulespec_path,
+        label="target RuleSpec path",
+    )
+    _validate_rulespec_path(repo, target, label="target RuleSpec path")
+    if target.name.endswith(".test.yaml"):
+        raise ValueError("target RuleSpec path must be a primary module")
+    manifest_path, _payload = _normal_model_apply_manifest_for_target(repo, target)
+    if RETIRED_MANIFEST_INVENTORY in _changed_paths(repo):
+        raise ValueError(
+            "retired manifest inventory changed before exact reconciliation"
+        )
+    try:
+        base_raw = _git(
+            repo,
+            "show",
+            f"HEAD:{RETIRED_MANIFEST_INVENTORY.as_posix()}",
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError("retired manifest inventory is absent from HEAD") from exc
+    live_raw = _read_bounded_regular(
+        repo,
+        RETIRED_MANIFEST_INVENTORY,
+        label="retired manifest inventory",
+        max_bytes=16 * 1024 * 1024,
+    )
+    if live_raw != base_raw:
+        raise ValueError("retired manifest inventory differs from clean HEAD")
+    rewritten = _retired_manifest_inventory_without_entry(base_raw, manifest_path)
+    if rewritten is None:
+        return None
+
+    root = repo.resolve(strict=True)
+    destination = root.joinpath(*RETIRED_MANIFEST_INVENTORY.parts)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            temporary.write(rewritten)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        temporary_path.chmod(0o644)
+        os.replace(temporary_path, destination)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+    observed = _read_bounded_regular(
+        repo,
+        RETIRED_MANIFEST_INVENTORY,
+        label="reconciled retired manifest inventory",
+        max_bytes=16 * 1024 * 1024,
+    )
+    if observed != rewritten:
+        raise ValueError("retired manifest inventory changed during reconciliation")
+    return manifest_path
+
+
 def authorize_legacy_index_manifest_shrink(
     repo: Path,
     target_rulespec_path: str,
@@ -2335,6 +2587,70 @@ def _validate_legacy_exact_dependents(
     return unchanged_authorized
 
 
+def _authorized_retired_manifest_inventory_reconciliation(
+    repo: Path,
+    *,
+    manifest_payloads: dict[PurePosixPath, dict[str, object]],
+) -> PurePosixPath:
+    """Authenticate the one unsigned inventory delta derived from signed paths."""
+
+    try:
+        base_raw = _git(
+            repo,
+            "show",
+            f"HEAD:{RETIRED_MANIFEST_INVENTORY.as_posix()}",
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError("retired manifest inventory is absent from HEAD") from exc
+    live_raw = _read_bounded_regular(
+        repo,
+        RETIRED_MANIFEST_INVENTORY,
+        label="changed retired manifest inventory",
+        max_bytes=16 * 1024 * 1024,
+    )
+    candidates: list[PurePosixPath] = []
+    for manifest_path, payload in sorted(
+        manifest_payloads.items(),
+        key=lambda item: item[0].as_posix(),
+    ):
+        if (
+            payload.get("tool") != MODEL_APPLY_TOOL
+            or payload.get("backend") not in MODEL_APPLY_BACKENDS
+        ):
+            continue
+        target = PurePosixPath(
+            *manifest_path.relative_to(MANIFEST_ROOT).parts
+        ).with_suffix(".yaml")
+        try:
+            _validate_rulespec_path(
+                repo,
+                target,
+                label="retired inventory model apply target",
+            )
+            if target.name.endswith(".test.yaml"):
+                raise ValueError("model apply target is not a primary module")
+            _require_normal_model_apply_target_binding(
+                repo,
+                target,
+                payload,
+                label="retired inventory model apply manifest",
+            )
+        except ValueError:
+            continue
+        expected = _retired_manifest_inventory_without_entry(
+            base_raw,
+            manifest_path,
+        )
+        if expected is not None and expected == live_raw:
+            candidates.append(manifest_path)
+    if len(candidates) != 1:
+        raise ValueError(
+            "retired manifest inventory change is not the exact removal for one "
+            "changed signed-v5 model manifest"
+        )
+    return candidates[0]
+
+
 def authorized_changed_paths(
     repo: Path,
     *,
@@ -2360,13 +2676,14 @@ def authorized_changed_paths(
 
     manifest_payloads: dict[PurePosixPath, dict[str, object]] = {}
     for relative in live_manifests:
-        payload = json.loads(
+        payload = _load_unambiguous_json(
             _read_bounded_regular(
                 repo,
                 relative,
                 label="changed manifest",
                 max_bytes=1024 * 1024,
-            ).decode("utf-8")
+            ).decode("utf-8"),
+            label=f"changed manifest {relative.as_posix()}",
         )
         if not isinstance(payload, dict):
             raise ValueError(f"changed manifest is malformed: {relative}")
@@ -2384,6 +2701,12 @@ def authorized_changed_paths(
         )
 
     authorized = set(live_manifests)
+    if RETIRED_MANIFEST_INVENTORY in changed and not legacy_manifests:
+        _authorized_retired_manifest_inventory_reconciliation(
+            repo,
+            manifest_payloads=manifest_payloads,
+        )
+        authorized.add(RETIRED_MANIFEST_INVENTORY)
     authorized_unchanged: set[PurePosixPath] = set()
     authenticated_unchanged_claims: set[tuple[PurePosixPath, PurePosixPath]] = set()
     unchanged_claims: set[tuple[PurePosixPath, PurePosixPath]] = set()
@@ -3555,6 +3878,11 @@ def main() -> None:
     shrink_parser = subparsers.add_parser("authorize-legacy-index-manifest-shrink")
     shrink_parser.add_argument("repo", type=Path)
     shrink_parser.add_argument("target_rulespec_path")
+    retired_inventory_parser = subparsers.add_parser(
+        "reconcile-retired-manifest-inventory"
+    )
+    retired_inventory_parser.add_argument("repo", type=Path)
+    retired_inventory_parser.add_argument("target_rulespec_path")
     source_bundle_parser = subparsers.add_parser(
         "parse-source-bundle",
         help="validate a bounded source bundle and emit one normalized JSON array",
@@ -3700,6 +4028,15 @@ def main() -> None:
                 )
                 else "false"
             )
+        elif args.command == "reconcile-retired-manifest-inventory":
+            reconciled = reconcile_retired_manifest_inventory(
+                args.repo,
+                args.target_rulespec_path,
+            )
+            if reconciled is None:
+                print("retired manifest inventory unchanged")
+            else:
+                print(f"retired manifest inventory removed {reconciled.as_posix()}")
         elif args.command == "parse-source-bundle":
             print(
                 json.dumps(

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import contextlib
 import hashlib
 import json
 import math
@@ -12,7 +13,6 @@ import os
 import re
 import stat
 import subprocess
-import tempfile
 from datetime import date
 from pathlib import Path, PurePosixPath
 
@@ -1613,7 +1613,9 @@ def _retired_manifest_inventory_without_entry(
         text = raw.decode("utf-8")
         module = ast.parse(text, filename=RETIRED_MANIFEST_INVENTORY.as_posix())
     except (UnicodeError, SyntaxError, ValueError) as exc:
-        raise ValueError("retired manifest inventory is not valid UTF-8 Python") from exc
+        raise ValueError(
+            "retired manifest inventory is not valid UTF-8 Python"
+        ) from exc
 
     assignments: list[ast.AnnAssign] = []
     for node in ast.walk(module):
@@ -1628,9 +1630,7 @@ def _retired_manifest_inventory_without_entry(
             and target.id == "KNOWN_RETIRED_SCHEMA_MANIFESTS"
             for target in node.targets
         ):
-            raise ValueError(
-                "retired manifest inventory assignment is not canonical"
-            )
+            raise ValueError("retired manifest inventory assignment is not canonical")
     if len(assignments) != 1 or assignments[0] not in module.body:
         raise ValueError(
             "retired manifest inventory lacks one canonical top-level assignment"
@@ -1641,12 +1641,12 @@ def _retired_manifest_inventory_without_entry(
         not isinstance(value, ast.Call)
         or not isinstance(value.func, ast.Name)
         or value.func.id != "frozenset"
-        or len(value.args) != 1
         or value.keywords
-        or not isinstance(value.args[0], ast.Set)
+        or len(value.args) > 1
+        or (len(value.args) == 1 and not isinstance(value.args[0], ast.Set))
     ):
         raise ValueError("retired manifest inventory set shape is not canonical")
-    elements = value.args[0].elts
+    elements = value.args[0].elts if value.args else []
     if not all(
         isinstance(element, ast.Constant) and isinstance(element.value, str)
         for element in elements
@@ -1680,7 +1680,16 @@ def _retired_manifest_inventory_without_entry(
     line = lines[entry.lineno - 1]
     if line not in {f"    '{manifest}',\n", f'    "{manifest}",\n'}:
         raise ValueError("retired manifest inventory match is not an exact entry")
-    del lines[entry.lineno - 1]
+    if len(elements) == 1:
+        start_line = value.lineno - 1
+        end_line = value.end_lineno - 1
+        lines[start_line : end_line + 1] = [
+            lines[start_line][: value.col_offset]
+            + "frozenset()"
+            + lines[end_line][value.end_col_offset :]
+        ]
+    else:
+        del lines[entry.lineno - 1]
     rewritten = "".join(lines).encode("utf-8")
     if manifest.encode("utf-8") in rewritten:
         raise ValueError("retired manifest inventory still contains the removed path")
@@ -1735,8 +1744,7 @@ def _require_normal_model_apply_target_binding(
     if (
         len(target_records) != 1
         or set(target_records[0]) != {"path", "sha256"}
-        or target_records[0].get("sha256")
-        != hashlib.sha256(target_raw).hexdigest()
+        or target_records[0].get("sha256") != hashlib.sha256(target_raw).hexdigest()
     ):
         raise ValueError(f"{label} does not bind exact target bytes")
 
@@ -1750,9 +1758,7 @@ def _normal_model_apply_manifest_for_target(
     manifest_path = _rulespec_manifest_path(target)
     changed = _changed_paths(repo)
     if manifest_path not in changed:
-        raise ValueError(
-            "targeted replacement lacks its exact changed apply manifest"
-        )
+        raise ValueError("targeted replacement lacks its exact changed apply manifest")
     try:
         payload = _load_unambiguous_json(
             _read_bounded_regular(
@@ -1814,26 +1820,12 @@ def reconcile_retired_manifest_inventory(
     if rewritten is None:
         return None
 
-    root = repo.resolve(strict=True)
-    destination = root.joinpath(*RETIRED_MANIFEST_INVENTORY.parts)
-    temporary_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="wb",
-            dir=destination.parent,
-            prefix=f".{destination.name}.",
-            delete=False,
-        ) as temporary:
-            temporary_path = Path(temporary.name)
-            temporary.write(rewritten)
-            temporary.flush()
-            os.fsync(temporary.fileno())
-        temporary_path.chmod(0o644)
-        os.replace(temporary_path, destination)
-        temporary_path = None
-    finally:
-        if temporary_path is not None:
-            temporary_path.unlink(missing_ok=True)
+    _secure_replace_regular_file(
+        repo,
+        RETIRED_MANIFEST_INVENTORY,
+        expected=live_raw,
+        replacement=rewritten,
+    )
     observed = _read_bounded_regular(
         repo,
         RETIRED_MANIFEST_INVENTORY,
@@ -1843,6 +1835,120 @@ def reconcile_retired_manifest_inventory(
     if observed != rewritten:
         raise ValueError("retired manifest inventory changed during reconciliation")
     return manifest_path
+
+
+def _secure_replace_regular_file(
+    repo: Path,
+    relative: PurePosixPath,
+    *,
+    expected: bytes,
+    replacement: bytes,
+) -> None:
+    """Replace one existing 0644 file through symlink-free directory handles."""
+
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory is None:
+        raise RuntimeError("secure reconciliation requires no-follow directory opens")
+    directory_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | nofollow | directory
+    file_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | nofollow
+    )
+    descriptors: list[int] = []
+
+    def read_current(parent_fd: int, name: str) -> bytes:
+        descriptor = os.open(name, file_flags, dir_fd=parent_fd)
+        try:
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or stat.S_IMODE(metadata.st_mode) != 0o644
+                or metadata.st_nlink != 1
+                or metadata.st_uid != os.geteuid()
+                or metadata.st_size > 16 * 1024 * 1024
+            ):
+                raise ValueError("reconciliation target is not one owned 0644 file")
+            chunks: list[bytes] = []
+            remaining = 16 * 1024 * 1024 + 1
+            while remaining:
+                chunk = os.read(descriptor, min(1024 * 1024, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            raw = b"".join(chunks)
+            if len(raw) > 16 * 1024 * 1024:
+                raise ValueError("reconciliation target exceeds its size limit")
+            return raw
+        finally:
+            os.close(descriptor)
+
+    temporary_name: str | None = None
+    temporary_fd: int | None = None
+    try:
+        current_fd = os.open(repo.resolve(strict=True), directory_flags)
+        descriptors.append(current_fd)
+        for component in relative.parts[:-1]:
+            current_fd = os.open(component, directory_flags, dir_fd=current_fd)
+            descriptors.append(current_fd)
+        target_name = relative.name
+        if read_current(current_fd, target_name) != expected:
+            raise ValueError("reconciliation target changed before secure replacement")
+        create_flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0)
+            | nofollow
+        )
+        for _attempt in range(100):
+            candidate = f".{target_name}.{os.urandom(16).hex()}.tmp"
+            try:
+                temporary_fd = os.open(
+                    candidate,
+                    create_flags,
+                    0o600,
+                    dir_fd=current_fd,
+                )
+            except FileExistsError:
+                continue
+            temporary_name = candidate
+            break
+        if temporary_fd is None or temporary_name is None:
+            raise OSError("could not reserve a reconciliation temporary file")
+        remaining = memoryview(replacement)
+        while remaining:
+            written = os.write(temporary_fd, remaining)
+            if written <= 0:
+                raise OSError("short write during retired inventory reconciliation")
+            remaining = remaining[written:]
+        os.fchmod(temporary_fd, 0o644)
+        os.fsync(temporary_fd)
+        os.close(temporary_fd)
+        temporary_fd = None
+        if read_current(current_fd, target_name) != expected:
+            raise ValueError("reconciliation target changed during secure replacement")
+        os.replace(
+            temporary_name,
+            target_name,
+            src_dir_fd=current_fd,
+            dst_dir_fd=current_fd,
+        )
+        temporary_name = None
+        os.fsync(current_fd)
+        if read_current(current_fd, target_name) != replacement:
+            raise ValueError("secure reconciliation replacement bytes differ")
+    finally:
+        if temporary_fd is not None:
+            os.close(temporary_fd)
+        if temporary_name is not None and descriptors:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(temporary_name, dir_fd=descriptors[-1])
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
 
 
 def authorize_legacy_index_manifest_shrink(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -8,6 +8,8 @@ pinned by tests and guard encoding-benchmark regressions. Restructure freely;
 reword guarded content only with a benchmark run.
 """
 
+__version__ = 1
+
 SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
 - Match each executable rule's `entity:` to the legal subject stated by the
   supplied source text. If the source states an individual, member, claimant,
@@ -536,6 +538,10 @@ _NAMING_PROTOCOL = """- Do not create standalone small-number parameters just to
 - Do not append citation or file suffixes like `_2014_a` to new local rule
   names; the file path is already the legal ID. Keep names concise and
   semantic unless a copied public interface must be preserved.
+- For a replacement target, only exact names listed by the Exact-oracle
+  replacement contract may retain the target path's year/legal-source identity.
+  New helper concepts must use concise semantic names instead of repeating that
+  identity as a prefix or suffix.
 - Rule names ending in the current path fragments, such as `_2_C`, `_b_1`,
   `_d_2_C`, or `_2014_a`, are invalid.
 - If an existing copied output name violates the no-citation/path-suffix rule,

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1663"
+ENCODER_VERSION = "0.2.1664"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1662"
+ENCODER_VERSION = "0.2.1663"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41871,6 +41871,140 @@ rules:
         ]
         assert supplemental == {}
 
+    def test_standalone_contract_failure_cannot_be_rescued_by_apply_overlay(
+        self, tmp_path
+    ):
+        from axiom_encode.harness.evals import (
+            _build_existing_target_oracle_contract_for_file,
+        )
+        from axiom_encode.harness.validator_pipeline import (
+            find_existing_target_oracle_contract_issues,
+        )
+
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-al"
+        relative = Path(
+            "policies/income_tax/2026_section_40_18_5_schedule_before_credits.yaml"
+        )
+        target = policy_repo / relative
+        generated = output_root / "codex-test-model" / relative
+        target.parent.mkdir(parents=True)
+        generated.parent.mkdir(parents=True)
+        mapped_name = "al_pit_2026_section_40_18_5_schedule_before_credits"
+        target.write_text(
+            f"""format: rulespec/v1
+rules:
+  - name: {mapped_name}
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: al_pit_completed_taxable_income
+inputs:
+  - name: al_pit_completed_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+"""
+        )
+        generated.write_text(
+            f"""format: rulespec/v1
+rules:
+  - name: {mapped_name}
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    metadata:
+      private: true
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: al_pit_completed_taxable_income
+  - name: al_pit_2026_section_40_18_5_taxable_income_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+inputs:
+  - name: al_pit_completed_taxable_income
+    entity: TaxUnit
+    dtype: Decimal
+    period: Year
+    unit: USD
+"""
+        )
+        contract_target = (
+            "us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits"
+        )
+        standalone_contract = _build_existing_target_oracle_contract_for_file(
+            target,
+            target=contract_target,
+        )
+        assert standalone_contract is not None
+        standalone_issues = find_existing_target_oracle_contract_issues(
+            generated.read_text(),
+            standalone_contract,
+        )
+        assert len(standalone_issues) == 3
+
+        observed_contracts = []
+
+        class ContractPipeline:
+            def __init__(self, **kwargs):
+                self.contract = kwargs.get("existing_target_oracle_contract")
+                observed_contracts.append(self.contract)
+
+            def validate(self, path, *, skip_reviewers):
+                assert skip_reviewers is True
+                issues = find_existing_target_oracle_contract_issues(
+                    Path(path).read_text(),
+                    self.contract,
+                )
+                return SimpleNamespace(
+                    all_passed=not issues,
+                    results={
+                        "ci": SimpleNamespace(
+                            validator_name="ci",
+                            issues=issues,
+                            error=issues[0] if issues else None,
+                        )
+                    },
+                )
+
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="codex-test-model",
+            backend="codex",
+        )
+        with patch("axiom_encode.cli.ValidatorPipeline", ContractPipeline):
+            ok, overlay_issues, supplemental = (
+                _validate_generated_encoding_in_policy_overlay(
+                    result,
+                    output_root=output_root,
+                    policy_repo_path=policy_repo,
+                    axiom_rules_path=tmp_path / "axiom-rules-engine",
+                    local_corpus_release=_bind_test_corpus_release(
+                        policy_repo, tmp_path / "axiom-corpus"
+                    ),
+                )
+            )
+
+        assert ok is False
+        assert supplemental == {}
+        assert observed_contracts == [standalone_contract]
+        assert [issue.partition(": ci: ")[2] for issue in overlay_issues] == (
+            standalone_issues
+        )
+
     def test_apply_overlay_scopes_authenticated_canonical_replacement(self, tmp_path):
         output_root = tmp_path / "out"
         policy_repo = tmp_path / "rulespec-us" / "us"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4003,6 +4003,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert 'If the source says only "joint return"' in prompt
     assert 'status 4 falls under any "other case" branch' in prompt
     assert "Existing executable output names are public API contracts" not in prompt
+    assert "only exact names listed by the Exact-oracle" in prompt
+    assert "target path's year/legal-source identity" in prompt
     assert "applicable_amount_in_effect_under_section_<section>" not in prompt
     assert "Do not put the date or year value in the fact name" in prompt
     assert "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`" in prompt
@@ -4466,6 +4468,9 @@ inputs:
     assert "Exact-oracle replacement contract:" in guidance
     assert "#al_pit_2026_section_40_18_5_schedule_before_credits`" in guidance
     assert "#input.al_pit_completed_taxable_income`" in guidance
+    assert "visibility=public" in guidance
+    assert "`2026_section_40_18_5`" in guidance
+    assert "exact mapped legacy surface names listed above are the only" in guidance
     assert "invalid" in guidance
     assert "legacy input" in guidance
 

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1662"
+ENCODER_VERSION = "0.2.1663"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1663"
+ENCODER_VERSION = "0.2.1664"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1662"
+ENCODER_VERSION = "0.2.1663"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1663"
+ENCODER_VERSION = "0.2.1664"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1662"
+ENCODER_VERSION = "0.2.1663"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1663"
+ENCODER_VERSION = "0.2.1664"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1662"
+ENCODER_VERSION = "0.2.1663"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1663"
+ENCODER_VERSION = "0.2.1664"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1663"
+ENCODER_VERSION = "0.2.1664"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1662"
+ENCODER_VERSION = "0.2.1663"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1662"
+ENCODER_VERSION = "0.2.1663"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1663"
+ENCODER_VERSION = "0.2.1664"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
@@ -22,6 +23,7 @@ from scripts.prepare_signed_backfill import (
     REVIEWED_RULESPEC_PR_BASE_BRANCHES,
     REVIEWED_RULESPEC_REFS,
     _normalize_required_test_cases,
+    _retired_manifest_inventory_without_entry,
     authorize_legacy_index_manifest_shrink,
     authorized_changed_paths,
     branch_name,
@@ -1169,10 +1171,7 @@ def _retired_inventory_replacement_repo(
     target = repo / "us/policies/income_tax/schedule.yaml"
     target.parent.mkdir(parents=True)
     target.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
-    manifest = (
-        repo
-        / ".axiom/encoding-manifests/us/policies/income_tax/schedule.json"
-    )
+    manifest = repo / ".axiom/encoding-manifests/us/policies/income_tax/schedule.json"
     manifest.parent.mkdir(parents=True)
     manifest.write_text(
         json.dumps({"schema_version": "axiom-encode/applied-rulespec/v1"}) + "\n",
@@ -1247,9 +1246,40 @@ def test_reconcile_retired_manifest_inventory_is_end_to_end_authorized(
 
     stage_authorized_changes(repo)
 
-    assert set(
-        _git(repo, "diff", "--cached", "--name-only").splitlines()
-    ) == {path.as_posix() for path in expected}
+    assert set(_git(repo, "diff", "--cached", "--name-only").splitlines()) == {
+        path.as_posix() for path in expected
+    }
+
+
+def test_reconcile_final_retired_manifest_entry_writes_reusable_empty_set(
+    tmp_path: Path,
+) -> None:
+    manifest_path = ".axiom/encoding-manifests/us/policies/income_tax/schedule.json"
+    repo, target, manifest, inventory = _retired_inventory_replacement_repo(
+        tmp_path,
+        inventory_text=(
+            "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset({\n"
+            f"    '{manifest_path}',\n"
+            "})\n"
+        ),
+    )
+    manifest_relative = PurePosixPath(manifest.relative_to(repo).as_posix())
+
+    reconcile_retired_manifest_inventory(
+        repo,
+        target.relative_to(repo).as_posix(),
+    )
+
+    assert inventory.read_text(encoding="utf-8") == (
+        "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset()\n"
+    )
+    assert (
+        _retired_manifest_inventory_without_entry(
+            inventory.read_bytes(),
+            manifest_relative,
+        )
+        is None
+    )
 
 
 def test_reconcile_retired_manifest_inventory_cli_reports_exact_removal(
@@ -1272,8 +1302,7 @@ def test_reconcile_retired_manifest_inventory_cli_reports_exact_removal(
     prepare_signed_backfill_main()
 
     assert capsys.readouterr().out == (
-        "retired manifest inventory removed "
-        f"{manifest.relative_to(repo).as_posix()}\n"
+        f"retired manifest inventory removed {manifest.relative_to(repo).as_posix()}\n"
     )
 
 
@@ -1317,7 +1346,7 @@ def test_reconcile_retired_manifest_inventory_is_noop_when_absent(
         (
             "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset()\n"
             "# .axiom/encoding-manifests/us/policies/income_tax/schedule.json\n",
-            "set shape is not canonical",
+            "present outside an exact entry",
         ),
         (
             "KNOWN_RETIRED_SCHEMA_MANIFESTS = {\n"
@@ -1364,6 +1393,49 @@ def test_reconcile_retired_manifest_inventory_rejects_preexisting_edit(
             repo,
             target.relative_to(repo).as_posix(),
         )
+
+
+def test_reconcile_retired_manifest_inventory_resists_parent_symlink_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, target, manifest, inventory = _retired_inventory_replacement_repo(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_inventory = outside / inventory.name
+    outside_inventory.write_text("outside sentinel\n", encoding="utf-8")
+    original_parent = inventory.parent
+    moved_parent = repo / "tests-pinned"
+    original_replace = os.replace
+
+    def race_parent(
+        source: str,
+        destination: str,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+    ) -> None:
+        original_parent.rename(moved_parent)
+        original_parent.symlink_to(outside, target_is_directory=True)
+        original_replace(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+
+    monkeypatch.setattr(os, "replace", race_parent)
+
+    with pytest.raises(ValueError):
+        reconcile_retired_manifest_inventory(
+            repo,
+            target.relative_to(repo).as_posix(),
+        )
+
+    assert outside_inventory.read_text(encoding="utf-8") == "outside sentinel\n"
+    assert manifest.relative_to(repo).as_posix() not in (
+        moved_parent / inventory.name
+    ).read_text(encoding="utf-8")
 
 
 def test_stage_rejects_nonexact_retired_manifest_inventory_edit(

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -28,6 +28,7 @@ from scripts.prepare_signed_backfill import (
     parse_canonical_refresh_bundle,
     parse_existing_signed_imports,
     parse_source_bundle,
+    reconcile_retired_manifest_inventory,
     split_atomic_source_input,
     stage_authorized_changes,
     validate_country,
@@ -1157,6 +1158,244 @@ def _write_signed_change(repo: Path) -> tuple[Path, Path]:
         encoding="utf-8",
     )
     return rule, manifest
+
+
+def _retired_inventory_replacement_repo(
+    tmp_path: Path,
+    *,
+    inventory_text: str | None = None,
+) -> tuple[Path, Path, Path, Path]:
+    repo = _repo(tmp_path)
+    target = repo / "us/policies/income_tax/schedule.yaml"
+    target.parent.mkdir(parents=True)
+    target.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+    manifest = (
+        repo
+        / ".axiom/encoding-manifests/us/policies/income_tax/schedule.json"
+    )
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        json.dumps({"schema_version": "axiom-encode/applied-rulespec/v1"}) + "\n",
+        encoding="utf-8",
+    )
+    inventory = repo / "tests/test_encoding_manifests.py"
+    inventory.parent.mkdir(parents=True)
+    manifest_relative = manifest.relative_to(repo).as_posix()
+    inventory.write_text(
+        inventory_text
+        or (
+            "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset({\n"
+            f"    '{manifest_relative}',\n"
+            "    '.axiom/encoding-manifests/us/statutes/other.json',\n"
+            "})\n"
+        ),
+        encoding="utf-8",
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "add retired target")
+
+    target.write_text(
+        "format: rulespec/v1\nrules:\n  - name: schedule\n",
+        encoding="utf-8",
+    )
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom-encode/applied-rulespec/v5",
+                "tool": "axiom-encode encode --apply",
+                "backend": "openai",
+                "signature": {
+                    "algorithm": "ed25519-domain-v1",
+                    "key_id": "test-key",
+                    "value": "test-signature",
+                },
+                "applied_files": [
+                    {
+                        "path": target.relative_to(repo).as_posix(),
+                        "sha256": hashlib.sha256(target.read_bytes()).hexdigest(),
+                    }
+                ],
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return repo, target, manifest, inventory
+
+
+def test_reconcile_retired_manifest_inventory_is_end_to_end_authorized(
+    tmp_path: Path,
+) -> None:
+    repo, target, manifest, inventory = _retired_inventory_replacement_repo(tmp_path)
+    manifest_relative = PurePosixPath(manifest.relative_to(repo).as_posix())
+
+    assert (
+        reconcile_retired_manifest_inventory(
+            repo,
+            target.relative_to(repo).as_posix(),
+        )
+        == manifest_relative
+    )
+    assert manifest_relative.as_posix() not in inventory.read_text(encoding="utf-8")
+    expected = {
+        PurePosixPath(target.relative_to(repo).as_posix()),
+        manifest_relative,
+        PurePosixPath("tests/test_encoding_manifests.py"),
+    }
+    assert authorized_changed_paths(repo) == expected
+
+    stage_authorized_changes(repo)
+
+    assert set(
+        _git(repo, "diff", "--cached", "--name-only").splitlines()
+    ) == {path.as_posix() for path in expected}
+
+
+def test_reconcile_retired_manifest_inventory_cli_reports_exact_removal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, target, manifest, _inventory = _retired_inventory_replacement_repo(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prepare_signed_backfill.py",
+            "reconcile-retired-manifest-inventory",
+            str(repo),
+            target.relative_to(repo).as_posix(),
+        ],
+    )
+
+    prepare_signed_backfill_main()
+
+    assert capsys.readouterr().out == (
+        "retired manifest inventory removed "
+        f"{manifest.relative_to(repo).as_posix()}\n"
+    )
+
+
+def test_reconcile_retired_manifest_inventory_is_noop_when_absent(
+    tmp_path: Path,
+) -> None:
+    repo, target, manifest, inventory = _retired_inventory_replacement_repo(
+        tmp_path,
+        inventory_text=(
+            "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset({\n"
+            "    '.axiom/encoding-manifests/us/statutes/other.json',\n"
+            "})\n"
+        ),
+    )
+    before = inventory.read_bytes()
+
+    assert (
+        reconcile_retired_manifest_inventory(
+            repo,
+            target.relative_to(repo).as_posix(),
+        )
+        is None
+    )
+    assert inventory.read_bytes() == before
+    assert authorized_changed_paths(repo) == {
+        PurePosixPath(target.relative_to(repo).as_posix()),
+        PurePosixPath(manifest.relative_to(repo).as_posix()),
+    }
+
+
+@pytest.mark.parametrize(
+    ("inventory_text", "message"),
+    [
+        (
+            "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset({\n"
+            "    '.axiom/encoding-manifests/us/policies/income_tax/schedule.json',\n"
+            "    '.axiom/encoding-manifests/us/policies/income_tax/schedule.json',\n"
+            "})\n",
+            "duplicate entries",
+        ),
+        (
+            "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset()\n"
+            "# .axiom/encoding-manifests/us/policies/income_tax/schedule.json\n",
+            "set shape is not canonical",
+        ),
+        (
+            "KNOWN_RETIRED_SCHEMA_MANIFESTS = {\n"
+            "    '.axiom/encoding-manifests/us/policies/income_tax/schedule.json',\n"
+            "}\n",
+            "assignment is not canonical",
+        ),
+        (
+            "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset({\n"
+            "    '.axiom/encoding-manifests/us/policies/income_tax/schedule.json',  # stale\n"
+            "})\n",
+            "not an exact entry",
+        ),
+    ],
+)
+def test_reconcile_retired_manifest_inventory_fails_closed_on_ambiguous_shape(
+    tmp_path: Path,
+    inventory_text: str,
+    message: str,
+) -> None:
+    repo, target, _manifest, _inventory = _retired_inventory_replacement_repo(
+        tmp_path,
+        inventory_text=inventory_text,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        reconcile_retired_manifest_inventory(
+            repo,
+            target.relative_to(repo).as_posix(),
+        )
+
+
+def test_reconcile_retired_manifest_inventory_rejects_preexisting_edit(
+    tmp_path: Path,
+) -> None:
+    repo, target, _manifest, inventory = _retired_inventory_replacement_repo(tmp_path)
+    inventory.write_text(
+        inventory.read_text(encoding="utf-8") + "# unrelated\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="changed before exact reconciliation"):
+        reconcile_retired_manifest_inventory(
+            repo,
+            target.relative_to(repo).as_posix(),
+        )
+
+
+def test_stage_rejects_nonexact_retired_manifest_inventory_edit(
+    tmp_path: Path,
+) -> None:
+    repo, target, _manifest, inventory = _retired_inventory_replacement_repo(tmp_path)
+    reconcile_retired_manifest_inventory(
+        repo,
+        target.relative_to(repo).as_posix(),
+    )
+    inventory.write_text(
+        inventory.read_text(encoding="utf-8") + "# unsigned extra edit\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="exact removal for one"):
+        authorized_changed_paths(repo)
+
+
+def test_reconcile_retired_manifest_inventory_requires_normal_model_apply(
+    tmp_path: Path,
+) -> None:
+    repo, target, manifest, _inventory = _retired_inventory_replacement_repo(tmp_path)
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["tool"] = "axiom-encode encode --apply --replace-legacy-rulespec-path"
+    manifest.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not an exact signed-v5 model apply"):
+        reconcile_retired_manifest_inventory(
+            repo,
+            target.relative_to(repo).as_posix(),
+        )
 
 
 def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2443,6 +2443,116 @@ inputs:
     assert find_existing_target_oracle_contract_issues(existing, contract) == []
 
 
+def test_exact_oracle_replacement_contract_preserves_visibility_and_rejects_path_identity_helpers():
+    target = "us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits"
+    mapped_name = "al_pit_2026_section_40_18_5_schedule_before_credits"
+    existing = f"""\
+format: rulespec/v1
+rules:
+  - name: {mapped_name}
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: al_pit_completed_taxable_income
+inputs:
+  - name: al_pit_completed_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+"""
+    registry = SimpleNamespace(
+        mappings_by_legal_id={f"{target}#{mapped_name}": object()}
+    )
+    contract = build_existing_target_oracle_contract(
+        existing,
+        target=target,
+        policyengine_registry=registry,
+    )
+
+    assert contract is not None
+    assert contract.replacement_name_identity == "2026_section_40_18_5"
+    assert contract.surfaces[0].private is False
+
+    replacement = existing.replace(
+        "    unit: USD\n    versions:",
+        "    unit: USD\n    metadata:\n      private: true\n    versions:",
+        1,
+    ).replace(
+        "inputs:\n"
+        "  - name: al_pit_completed_taxable_income\n"
+        "    entity: TaxUnit\n"
+        "    dtype: Money\n",
+        "inputs:\n"
+        "  - name: al_pit_completed_taxable_income\n"
+        "    entity: TaxUnit\n"
+        "    dtype: Decimal\n",
+    )
+    replacement = replacement.replace(
+        "inputs:\n",
+        "  - name: al_pit_2026_section_40_18_5_taxable_income_floor\n"
+        "    kind: parameter\n"
+        "    dtype: Money\n"
+        "    unit: USD\n"
+        "    versions:\n"
+        "      - effective_from: '2026-01-01'\n"
+        "        formula: 0\n"
+        "inputs:\n",
+    )
+
+    issues = find_existing_target_oracle_contract_issues(replacement, contract)
+
+    assert len(issues) == 3
+    assert "metadata.private/public contract" in issues[0]
+    assert "#input.al_pit_completed_taxable_income" in issues[1]
+    assert "[existing-target-naming-contract]" in issues[2]
+    assert "`2026_section_40_18_5`" in issues[2]
+    assert mapped_name not in issues[2]
+
+
+def test_exact_oracle_replacement_naming_contract_allows_semantic_helpers():
+    target = "us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits"
+    mapped_name = "al_pit_2026_section_40_18_5_schedule_before_credits"
+    existing = f"""\
+format: rulespec/v1
+rules:
+  - name: {mapped_name}
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxable_income_floor
+  - name: taxable_income_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    metadata:
+      private: true
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+"""
+    registry = SimpleNamespace(
+        mappings_by_legal_id={f"{target}#{mapped_name}": object()}
+    )
+    contract = build_existing_target_oracle_contract(
+        existing,
+        target=target,
+        policyengine_registry=registry,
+    )
+
+    assert contract is not None
+    assert find_existing_target_oracle_contract_issues(existing, contract) == []
+
+
 def test_rule_source_metadata_rejects_executable_rules_without_rule_source():
     content = """format: rulespec/v1
 module:
@@ -6106,7 +6216,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1662"')
+        .startswith('__version__ = "0.2.1663"')
     )
 
 
@@ -6338,13 +6448,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1662"
+    assert encoder_package["version"] == "0.2.1663"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1662"
+    assert project["project"]["version"] == "0.2.1663"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1662"')
+        .startswith('__version__ = "0.2.1663"')
     )
 
 
@@ -6606,13 +6716,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1662"
+    assert encoder_package["version"] == "0.2.1663"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1662"
+    assert project["project"]["version"] == "0.2.1663"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1662"')
+        .startswith('__version__ = "0.2.1663"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6216,7 +6216,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1663"')
+        .startswith('__version__ = "0.2.1664"')
     )
 
 
@@ -6448,13 +6448,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1663"
+    assert encoder_package["version"] == "0.2.1664"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1663"
+    assert project["project"]["version"] == "0.2.1664"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1663"')
+        .startswith('__version__ = "0.2.1664"')
     )
 
 
@@ -6716,13 +6716,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1663"
+    assert encoder_package["version"] == "0.2.1664"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1663"
+    assert project["project"]["version"] == "0.2.1664"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1663"')
+        .startswith('__version__ = "0.2.1664"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1662"
+ENCODER_VERSION = "0.2.1663"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1663"
+ENCODER_VERSION = "0.2.1664"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2020,6 +2020,43 @@ def test_targeted_signed_reencode_only_allows_audited_legacy_index_shrink() -> N
     assert '[ -n "$replacement_path" ] && [ -z "$legacy_source_path" ]' in command
 
 
+def test_targeted_signed_reencode_reconciles_retired_inventory_before_commits() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    step = next(
+        item
+        for item in workflow["jobs"]["encode"]["steps"]
+        if item.get("name") == "Encode, review, validate, and apply"
+    )
+    command = step["run"]
+    invocation = "reconcile-retired-manifest-inventory"
+
+    assert command.count(invocation) == 2
+    assert '[ "$source_bundle_enabled" = "false" ]' in command
+    assert '[ -n "$REPLACE_RULESPEC_PATH" ]' in command
+    assert '[ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]' in command
+
+    preflight_apply = command.index("target-preflight")
+    preflight_reconciliation = command.index(invocation, preflight_apply)
+    preflight_checkpoint = command.index(
+        "Canonicalize signed replacement target before source bundle",
+        preflight_reconciliation,
+    )
+    assert preflight_apply < preflight_reconciliation < preflight_checkpoint
+
+    normal_gate = command.index('[ "$source_bundle_enabled" = "false" ]')
+    normal_reconciliation = command.index(
+        invocation,
+        preflight_reconciliation + len(invocation),
+    )
+    assert normal_gate < normal_reconciliation
+    assert normal_reconciliation < command.index(
+        'if [ "$source_bundle_enabled" = "true" ]; then',
+        normal_reconciliation,
+    )
+
+
 def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
@@ -4236,6 +4273,11 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
     ).replace(
         "/opt/axiom-verification/axiom-encode-apply-signer run",
         '"$SIGNER_STUB"',
+    ).replace(
+        '    "$workflow_python" "$backfill_helper" \\\n'
+        "      reconcile-retired-manifest-inventory \\\n"
+        '      "$RULESPEC_CHECKOUT" "$REPLACE_RULESPEC_PATH"',
+        "    printf '%s\\n' 'retired manifest inventory unchanged'",
     )
     before_checkpoint, checkpoint_and_after = command.split(
         "checkpoint_signed_changes() {",
@@ -4591,6 +4633,11 @@ def test_targeted_signed_reencode_runs_replacement_target(
     ).replace(
         "/opt/axiom-verification/axiom-encode-apply-signer run",
         '"$SIGNER_STUB"',
+    ).replace(
+        '    "$workflow_python" "$backfill_helper" \\\n'
+        "      reconcile-retired-manifest-inventory \\\n"
+        '      "$RULESPEC_CHECKOUT" "$REPLACE_RULESPEC_PATH"',
+        "    printf '%s\\n' 'retired manifest inventory unchanged'",
     )
     calls_path = tmp_path / "calls.jsonl"
     signer_stub = tmp_path / "signer-stub"

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2032,10 +2032,18 @@ def test_targeted_signed_reencode_reconciles_retired_inventory_before_commits() 
     command = step["run"]
     invocation = "reconcile-retired-manifest-inventory"
 
-    assert command.count(invocation) == 2
+    assert command.count(invocation) == 3
     assert '[ "$source_bundle_enabled" = "false" ]' in command
     assert '[ -n "$REPLACE_RULESPEC_PATH" ]' in command
     assert '[ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]' in command
+
+    refresh_apply = command.index('"$refresh_citation" "$refresh_finding"')
+    refresh_reconciliation = command.index(invocation, refresh_apply)
+    refresh_checkpoint = command.index(
+        "Refresh signed canonical module for ${refresh_citation}",
+        refresh_reconciliation,
+    )
+    assert refresh_apply < refresh_reconciliation < refresh_checkpoint
 
     preflight_apply = command.index("target-preflight")
     preflight_reconciliation = command.index(invocation, preflight_apply)
@@ -3906,6 +3914,18 @@ def test_targeted_signed_reencode_runs_canonical_refresh_bundle_in_order(
         + '}\n\nif [ "$canonical_refresh_enabled"'
         + after_checkpoint
     )
+    canonical_reconciliation = (
+        '    "$workflow_python" "$backfill_helper" \\\n'
+        "      reconcile-retired-manifest-inventory \\\n"
+        '      "$RULESPEC_CHECKOUT" "$refresh_rulespec_path"'
+    )
+    command_before_reconciliation_stub = command
+    command = command.replace(
+        canonical_reconciliation,
+        '    printf \'%s\\n\' "$refresh_rulespec_path" >> "$RECONCILIATIONS_PATH"',
+        1,
+    )
+    assert command != command_before_reconciliation_stub
 
     repo, primary_citation, primary_path, additions = _prepare_canonical_refresh_inputs(
         tmp_path
@@ -3990,6 +4010,7 @@ def test_targeted_signed_reencode_runs_canonical_refresh_bundle_in_order(
 
     calls_path = tmp_path / "calls.jsonl"
     checkpoints_path = tmp_path / "checkpoints.txt"
+    reconciliations_path = tmp_path / "reconciliations.txt"
     signer_stub = tmp_path / "signer-stub"
     signer_stub.write_text(
         """#!/usr/bin/env python3
@@ -4029,6 +4050,7 @@ if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) ==
         "EXISTING_SIGNED_IMPORTS_JSON": "[]",
         "GITHUB_WORKSPACE": str(tmp_path),
         "REPLACE_RULESPEC_PATH": primary_path,
+        "RECONCILIATIONS_PATH": str(reconciliations_path),
         "REVIEW_FINDING": "Refresh the independent Louisiana modules.",
         "RULESPEC_CHECKOUT": str(repo),
         "RULESPEC_REF": "a" * 40,
@@ -4124,9 +4146,13 @@ if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) ==
         f"Refresh signed canonical module for {citation}"
         for citation in expected_citations
     ]
+    assert reconciliations_path.read_text(encoding="utf-8").splitlines() == (
+        expected_paths
+    )
 
     calls_path.unlink()
     checkpoints_path.unlink()
+    reconciliations_path.unlink()
     future_companion = repo / str(normalized[1]["companion_path"])
     blocked = subprocess.run(
         ["bash", "-c", command],
@@ -4266,18 +4292,22 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
     )
-    command = next(
-        step["run"]
-        for step in workflow["jobs"]["encode"]["steps"]
-        if step.get("name") == "Encode, review, validate, and apply"
-    ).replace(
-        "/opt/axiom-verification/axiom-encode-apply-signer run",
-        '"$SIGNER_STUB"',
-    ).replace(
-        '    "$workflow_python" "$backfill_helper" \\\n'
-        "      reconcile-retired-manifest-inventory \\\n"
-        '      "$RULESPEC_CHECKOUT" "$REPLACE_RULESPEC_PATH"',
-        "    printf '%s\\n' 'retired manifest inventory unchanged'",
+    command = (
+        next(
+            step["run"]
+            for step in workflow["jobs"]["encode"]["steps"]
+            if step.get("name") == "Encode, review, validate, and apply"
+        )
+        .replace(
+            "/opt/axiom-verification/axiom-encode-apply-signer run",
+            '"$SIGNER_STUB"',
+        )
+        .replace(
+            '    "$workflow_python" "$backfill_helper" \\\n'
+            "      reconcile-retired-manifest-inventory \\\n"
+            '      "$RULESPEC_CHECKOUT" "$REPLACE_RULESPEC_PATH"',
+            "    printf '%s\\n' 'retired manifest inventory unchanged'",
+        )
     )
     before_checkpoint, checkpoint_and_after = command.split(
         "checkpoint_signed_changes() {",
@@ -4626,18 +4656,22 @@ def test_targeted_signed_reencode_runs_replacement_target(
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
     )
-    command = next(
-        step["run"]
-        for step in workflow["jobs"]["encode"]["steps"]
-        if step.get("name") == "Encode, review, validate, and apply"
-    ).replace(
-        "/opt/axiom-verification/axiom-encode-apply-signer run",
-        '"$SIGNER_STUB"',
-    ).replace(
-        '    "$workflow_python" "$backfill_helper" \\\n'
-        "      reconcile-retired-manifest-inventory \\\n"
-        '      "$RULESPEC_CHECKOUT" "$REPLACE_RULESPEC_PATH"',
-        "    printf '%s\\n' 'retired manifest inventory unchanged'",
+    command = (
+        next(
+            step["run"]
+            for step in workflow["jobs"]["encode"]["steps"]
+            if step.get("name") == "Encode, review, validate, and apply"
+        )
+        .replace(
+            "/opt/axiom-verification/axiom-encode-apply-signer run",
+            '"$SIGNER_STUB"',
+        )
+        .replace(
+            '    "$workflow_python" "$backfill_helper" \\\n'
+            "      reconcile-retired-manifest-inventory \\\n"
+            '      "$RULESPEC_CHECKOUT" "$REPLACE_RULESPEC_PATH"',
+            "    printf '%s\\n' 'retired manifest inventory unchanged'",
+        )
     )
     calls_path = tmp_path / "calls.jsonl"
     signer_stub = tmp_path / "signer-stub"

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -14945,6 +14945,152 @@ rules:
     assert _has_issue(result, "numeric-recall", "value 12")
 
 
+@pytest.mark.parametrize(
+    ("source", "expected_rate"),
+    (
+        ("four and seven-tenths percent (4.7%)", 0.047),
+        ("four and four-tenths percent (4.4%)", 0.044),
+    ),
+)
+def test_legacy_decimal_fraction_word_percentage_is_atomic(
+    source: str,
+    expected_rate: float,
+):
+    grounding = extract_typed_numeric_occurrences_from_text(source, profile="legacy")
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="legacy",
+    )
+
+    assert [occurrence.value for occurrence in inventory] == pytest.approx(
+        [expected_rate, expected_rate]
+    )
+    assert all(occurrence.has_rate_context for occurrence in inventory)
+    assert not any(occurrence.raw in {"four", "seven"} for occurrence in inventory)
+    assert not numeric_value_is_grounded(0.007, grounding)
+
+
+def test_legacy_standalone_decimal_fraction_percentage_grounds_scaled_rate():
+    source = "The component is seven-tenths percent."
+    grounding = extract_typed_numeric_occurrences_from_text(source, profile="legacy")
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="legacy",
+    )
+
+    assert [occurrence.value for occurrence in inventory] == pytest.approx([0.007])
+    assert inventory[0].raw == "seven-tenths percent"
+    assert numeric_value_is_grounded(0.007, grounding)
+
+
+def test_legacy_decimal_fraction_words_without_percent_do_not_ground_rate():
+    grounding = extract_typed_numeric_occurrences_from_text(
+        "The amount is seven-tenths of the base.",
+        profile="legacy",
+    )
+
+    assert not numeric_value_is_grounded(0.007, grounding)
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "4 dollars and four percent",
+        "4 dollars and 4%",
+    ),
+)
+def test_legacy_inventory_does_not_dedupe_scaled_value_across_source_spans(
+    source: str,
+):
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="legacy",
+    )
+
+    assert sorted(occurrence.value for occurrence in inventory) == pytest.approx(
+        [0.04, 4.0]
+    )
+
+
+def test_legacy_structural_four_does_not_hide_four_percent_rate():
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        "(4) The rate is four percent (4%).",
+        profile="legacy",
+    )
+
+    assert [occurrence.value for occurrence in inventory] == pytest.approx(
+        [0.04, 0.04]
+    )
+    assert all(occurrence.has_rate_context for occurrence in inventory)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_rate"),
+    (
+        ("three and one-half percent", 0.035),
+        ("four and three-quarters percent", 0.0475),
+    ),
+)
+def test_legacy_existing_mixed_fraction_percentage_behavior_is_preserved(
+    source: str,
+    expected_rate: float,
+):
+    grounding = extract_typed_numeric_occurrences_from_text(source, profile="legacy")
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="legacy",
+    )
+
+    assert [occurrence.value for occurrence in inventory] == pytest.approx(
+        [expected_rate]
+    )
+    assert numeric_value_is_grounded(expected_rate, grounding)
+
+
+def test_ms_decimal_rate_scalars_have_no_bare_cardinal_numeric_recall():
+    source = """\
+(1)(a)(ii) The rate shall be four percent (4%).
+(1)(b)(ii)(1) The rate shall be four and seven-tenths percent (4.7%).
+(1)(b)(ii)(2) The rate shall be four and four-tenths percent (4.4%).
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ms/statute/27-7-5
+rules:
+  - name: second_bracket_rate
+    kind: parameter
+    dtype: Rate
+    source: Miss. Code § 27-7-5(1)(a)(ii)
+    versions:
+      - effective_from: '1983-01-01'
+        formula: 0.04
+  - name: excess_income_rate_for_2024
+    kind: parameter
+    dtype: Rate
+    source: Miss. Code § 27-7-5(1)(b)(ii)(1)
+    versions:
+      - effective_from: '2024-01-01'
+        formula: 0.047
+  - name: excess_income_rate_for_2025
+    kind: parameter
+    dtype: Rate
+    source: Miss. Code § 27-7-5(1)(b)(ii)(2)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 0.044
+"""
+
+    issues = _pipeline_issues(
+        content,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+    )
+
+    assert not any("numeric-recall" in issue for issue in issues), issues
+
+
 RELEASED_RBEG_2021_8_BODY = """\
 Die Regelbedarfsstufen nach der Anlage zu § 28 des Zwölften Buches Sozialgesetzbuch belaufen sich zum 1. Januar 2021
 1. in der Regelbedarfsstufe 1 auf 446 Euro für jede erwachsene Person, die in einer Wohnung nach § 42a Absatz 2 Satz 2 des Zwölften Buches Sozialgesetzbuch lebt und für die nicht Nummer 2 gilt,

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -14983,6 +14983,15 @@ def test_legacy_standalone_decimal_fraction_percentage_grounds_scaled_rate():
     assert numeric_value_is_grounded(0.007, grounding)
 
 
+def test_legacy_invalid_whole_decimal_fraction_percentage_fails_closed():
+    grounding = extract_typed_numeric_occurrences_from_text(
+        "The rate is twenty ten and seven-tenths percent.",
+        profile="legacy",
+    )
+
+    assert not numeric_value_is_grounded(0.007, grounding)
+
+
 def test_legacy_decimal_fraction_words_without_percent_do_not_ground_rate():
     grounding = extract_typed_numeric_occurrences_from_text(
         "The amount is seven-tenths of the base.",
@@ -15018,9 +15027,7 @@ def test_legacy_structural_four_does_not_hide_four_percent_rate():
         profile="legacy",
     )
 
-    assert [occurrence.value for occurrence in inventory] == pytest.approx(
-        [0.04, 0.04]
-    )
+    assert [occurrence.value for occurrence in inventory] == pytest.approx([0.04, 0.04])
     assert all(occurrence.has_rate_context for occurrence in inventory)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1663"
+version = "0.2.1664"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1662"
+version = "0.2.1663"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- enforce the exact existing-target oracle contract in apply overlays, including typed inputs and private/public shape
- reject replacement helpers that repeat target-path year/legal-source identity while preserving mapped legacy names
- parse worded decimal percentages atomically and deduplicate numeric recall within one evidence span
- reconcile exact retired-manifest inventory entries for normal, source-bundle, and canonical-refresh signed replacements
- harden reconciliation with no-follow directory descriptors and exact-byte checks

This fixes systemic owner gaps found while reviewing the fresh Batch 007 AL/MS outputs. It does not change the 25-input dispatch contract, SNAP queue behavior, or reuse any Batch 007 candidate bytes.

## Review cycle

Independent review-fix cycle completed twice. First-cycle findings fixed: final version-provenance bump, invalid whole-number fail-open, reusable empty retired set, canonical-refresh coverage, and parent-path TOCTOU hardening. Repeat review was clean from three independent reviewers at exact head `09f8f6812b377ad8ead1c1d554211668ee3c6414`.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `ruff format --check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- Towncrier draft
- focused integration: 199 passed
- full Python 3.13 suite: 12,645 passed, 123 skipped
- version/provenance: 3 passed

Hosted CI and signing-supervisor checks must be green before ready/merge.