### PR TITLE
Fix YAML retry diagnostics and lower clamp evidence

### DIFF
--- a/changelog.d/generated-yaml-parse-retry-feedback.fixed.md
+++ b/changelog.d/generated-yaml-parse-retry-feedback.fixed.md
@@ -1,0 +1,5 @@
+Report bounded, control-safe generated-YAML parser subtype, line, column, and
+allowlisted delimiter guidance in retry feedback. Read/decode failures remain
+path-free and non-retryable, while excessive YAML nesting fails closed with a
+bounded resource diagnostic instead of being misclassified as source
+attestation.

--- a/changelog.d/lower-bound-clamp-evidence.fixed.md
+++ b/changelog.d/lower-bound-clamp-evidence.fixed.md
@@ -1,0 +1,3 @@
+Recognize exact source-grounded lower boundary clamps of the form
+`max(0, subject - floor)` without treating upper, reversed, shifted, or unrelated
+clamps as boundary evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1664"
+version = "0.2.1665"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1664"
+__version__ = "0.2.1665"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -480,6 +480,20 @@ _APPLY_IDENTITY_SOURCES = frozenset(
 APPLIED_ENCODING_ENCODER_BACKENDS = frozenset({"codex", "openai", "claude"})
 # Machine-generator backends accepted by the protected-content guard.
 APPLIED_ENCODING_GENERATED_BACKENDS = APPLIED_ENCODING_ENCODER_BACKENDS
+_GENERATED_RULESPEC_YAML_LOCATION_MAX = 999_999
+_GENERATED_RULESPEC_YAML_RESOURCE_ISSUE = (
+    "[generated-yaml:resource] generated YAML nesting exceeds safe parser capacity"
+)
+_GENERATED_RULESPEC_YAML_IO_ISSUE = (
+    "[generated-yaml:io] unable to read generated RuleSpec"
+)
+_GENERATED_RULESPEC_YAML_DECODE_ISSUE = (
+    "[generated-yaml:decode] generated RuleSpec text is not decodable"
+)
+_GENERATED_RULESPEC_NONRETRYABLE_PREFIXES = (
+    "[generated-yaml:io]",
+    "[generated-yaml:decode]",
+)
 _MODEL_APPLY_MANIFEST_FIELDS = frozenset(
     {
         "schema_version",
@@ -28490,7 +28504,8 @@ def _encode_attempt_was_validator_rejected(
 ) -> bool:
     """Return whether the attempt reached and failed a retryable validator gate."""
     if outcome.get("status") == "apply_blocked_validation":
-        return True
+        detail = str(outcome.get("apply_error") or "")
+        return not detail.startswith(_GENERATED_RULESPEC_NONRETRYABLE_PREFIXES)
     if outcome.get("apply_requested") is True:
         return False
     return str(getattr(result, "error", "") or "") in {
@@ -29034,6 +29049,29 @@ def _run_encode_attempt(
             outcome["final_success"] = False
             print(f"  apply=blocked_generation:{detail}")
         else:
+            yaml_preflight_issue = _generated_rulespec_yaml_nonparser_issue(
+                result,
+                Path(str(getattr(result, "output_file", "") or "")),
+                output_root=args.output,
+            )
+            if yaml_preflight_issue is not None:
+                retry_validation_issues = (yaml_preflight_issue,)
+                outcome["status"] = "apply_blocked_validation"
+                outcome["overlay_validation_success"] = False
+                outcome["apply_error"] = yaml_preflight_issue
+                _replace_overlay_validation_failures(
+                    outcome,
+                    [yaml_preflight_issue],
+                )
+                outcome["final_success"] = False
+                print(f"  apply=blocked_validation:{yaml_preflight_issue}")
+                return _EncodeAttemptExecution(
+                    result=result,
+                    outcome=outcome,
+                    apply_passed=False,
+                    logged_run=logged_run,
+                    validation_issues=retry_validation_issues,
+                )
 
             def _retry_generated_unsafe_formula_output_deferrals() -> list[str]:
                 nonlocal can_apply, apply_issues, supplemental_files
@@ -39798,7 +39836,7 @@ def _quote_unquoted_source_scalars(*, rules_file: Path) -> list[str]:
     try:
         yaml.safe_load(original)
         return []
-    except (yaml.YAMLError, ValueError):
+    except (RecursionError, yaml.YAMLError, ValueError):
         pass
 
     repaired_lines: list[str] = []
@@ -48902,6 +48940,105 @@ def _source_attestation_binding_issues(
     return issues
 
 
+def _generated_rulespec_yaml_parse_issue(error: yaml.YAMLError) -> str:
+    """Render bounded parser metadata without candidate or exception text."""
+
+    problem = getattr(error, "problem", None)
+    guidance = None
+    if type(problem) is str:
+        guidance = {
+            "mapping values are not allowed here": (
+                "unexpected mapping-value ':' delimiter; quote scalar text containing "
+                "': '"
+            ),
+            "could not find expected ':'": "mapping entry is missing a ':' delimiter",
+            "expected the node content, but found '<stream end>'": (
+                "incomplete YAML node at end of document"
+            ),
+            "expected ',' or '}', but got ':'": (
+                "flow mapping is missing an expected ',' or '}' delimiter"
+            ),
+            "expected ',' or '}', but got '['": (
+                "flow mapping is missing an expected ',' or '}' delimiter before "
+                "a '[' sequence"
+            ),
+            "expected ',' or ']', but got ':'": (
+                "flow sequence is missing an expected ',' or ']' delimiter"
+            ),
+        }.get(problem)
+    subtype = "error"
+    if guidance is None:
+        if isinstance(error, yaml.scanner.ScannerError):
+            subtype = "scanner"
+            guidance = "scanner rejected YAML syntax"
+        elif isinstance(error, yaml.parser.ParserError):
+            subtype = "parser"
+            guidance = "parser rejected YAML structure"
+        elif isinstance(error, yaml.composer.ComposerError):
+            subtype = "composer"
+            guidance = "invalid YAML document structure"
+        elif isinstance(error, yaml.constructor.ConstructorError):
+            subtype = "constructor"
+            guidance = "unsupported YAML value or tag"
+        elif isinstance(error, yaml.reader.ReaderError):
+            subtype = "reader"
+            guidance = "invalid YAML character encoding"
+        else:
+            guidance = "invalid YAML syntax"
+    elif isinstance(error, yaml.scanner.ScannerError):
+        subtype = "scanner"
+    elif isinstance(error, yaml.parser.ParserError):
+        subtype = "parser"
+    elif isinstance(error, yaml.composer.ComposerError):
+        subtype = "composer"
+    elif isinstance(error, yaml.constructor.ConstructorError):
+        subtype = "constructor"
+    elif isinstance(error, yaml.reader.ReaderError):
+        subtype = "reader"
+    problem_mark = getattr(error, "problem_mark", None)
+    line = getattr(problem_mark, "line", None)
+    column = getattr(problem_mark, "column", None)
+    location = ""
+    if (
+        type(line) is int
+        and 0 <= line <= _GENERATED_RULESPEC_YAML_LOCATION_MAX
+        and type(column) is int
+        and 0 <= column <= _GENERATED_RULESPEC_YAML_LOCATION_MAX
+    ):
+        location = f" at line {line + 1}, column {column + 1}"
+    return f"[generated-yaml:{subtype}] invalid YAML{location}: {guidance}"
+
+
+def _generated_rulespec_yaml_nonparser_issue(
+    result,
+    output_file: Path,
+    *,
+    output_root: Path,
+) -> str | None:
+    """Preflight non-parser failures before YAML-reading auto-repair helpers."""
+
+    backend = str(getattr(result, "backend", "") or "").strip().lower()
+    if backend not in APPLIED_ENCODING_ENCODER_BACKENDS:
+        return None
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        # Preserve the normal validation error for a missing or out-of-root path
+        # without opening an untrusted candidate during this early preflight.
+        return None
+    try:
+        yaml.safe_load(output_file.read_text())
+    except yaml.YAMLError:
+        return None
+    except RecursionError:
+        return _GENERATED_RULESPEC_YAML_RESOURCE_ISSUE
+    except OSError:
+        return _GENERATED_RULESPEC_YAML_IO_ISSUE
+    except UnicodeError:
+        return _GENERATED_RULESPEC_YAML_DECODE_ISSUE
+    return None
+
+
 def _stamp_generated_source_attestation_for_apply(result, output_file: Path) -> None:
     """Mechanically bind model output to the resolver's full stored source body."""
 
@@ -48910,10 +49047,14 @@ def _stamp_generated_source_attestation_for_apply(result, output_file: Path) -> 
         return
     try:
         payload = yaml.safe_load(output_file.read_text())
-    except (OSError, UnicodeError, yaml.YAMLError) as exc:
-        raise RuntimeError(
-            f"Cannot stamp source attestation in generated RuleSpec: {output_file}"
-        ) from exc
+    except yaml.YAMLError as exc:
+        raise RuntimeError(_generated_rulespec_yaml_parse_issue(exc)) from None
+    except RecursionError:
+        raise RuntimeError(_GENERATED_RULESPEC_YAML_RESOURCE_ISSUE) from None
+    except OSError:
+        raise RuntimeError(_GENERATED_RULESPEC_YAML_IO_ISSUE) from None
+    except UnicodeError:
+        raise RuntimeError(_GENERATED_RULESPEC_YAML_DECODE_ISSUE) from None
     if not isinstance(payload, dict):
         return
     module = payload.get("module")
@@ -53072,7 +53213,10 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         _stamp_generated_source_attestation_for_apply(result, output_file)
         source_metadata = _generated_result_source_metadata(result)
     except RuntimeError as exc:
-        return False, [f"{relative_output}: {exc}"], {}
+        detail = str(exc)
+        if detail.startswith(_GENERATED_RULESPEC_NONRETRYABLE_PREFIXES):
+            return False, [detail], {}
+        return False, [f"{relative_output}: {detail}"], {}
 
     generated_content = output_file.read_text()
     output_test = _rulespec_test_path(output_file)

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import ast
 import bisect
 import contextlib
+import copy
 import functools
 import heapq
 import itertools
@@ -4571,6 +4572,13 @@ def _analyze_rulespec_payload(
                 extract_numeric_occurrences=extract_numeric_grounding_occurrences,
                 numeric_value_is_grounded=numeric_value_is_grounded,
                 formula_environment=formula_environment,
+                source_bound_constant_occurrences=(
+                    _source_bound_constant_numeric_occurrences(
+                        payload,
+                        corpus_citation_path=corpus_citation_path,
+                        extract_numeric_occurrences=extract_numeric_occurrences,
+                    )
+                ),
                 declared_input_names={
                     str(item.get("name") or "").strip()
                     for item in payload.get("inputs", [])
@@ -4678,6 +4686,37 @@ def _rule_source_excerpt_atoms(
         if isinstance(excerpt, str) and excerpt.strip() and citation_path and path:
             excerpts.append((path, citation_path, excerpt.strip()))
     return excerpts
+
+
+def _source_bound_constant_numeric_occurrences(
+    payload: dict[str, Any],
+    *,
+    corpus_citation_path: str,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> dict[str, tuple[NumericOccurrenceLike, ...]]:
+    """Index constant-rule numerics with formula proof from this source unit."""
+
+    authoritative_path = corpus_citation_path.strip("/").casefold()
+    bound: dict[str, tuple[NumericOccurrenceLike, ...]] = {}
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return bound
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip()
+        if not name:
+            continue
+        occurrences = tuple(
+            occurrence
+            for path, citation_path, excerpt in _rule_source_excerpt_atoms(rule)
+            if re.fullmatch(r"versions(?:\[\d+\])?\.formula", path)
+            and citation_path.strip("/").casefold() == authoritative_path
+            for occurrence in extract_numeric_occurrences(excerpt)
+        )
+        if occurrences:
+            bound[name] = occurrences
+    return bound
 
 
 def _principal_formula_clause_rules(
@@ -11877,6 +11916,7 @@ def _companion_test_issues(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
     formula_environment: dict[str, Any],
+    source_bound_constant_occurrences: dict[str, tuple[NumericOccurrenceLike, ...]],
     declared_input_names: set[str],
 ) -> list[str]:
     issues: list[str] = []
@@ -12057,6 +12097,7 @@ def _companion_test_issues(
             asserted_by_rule=asserted_by_rule,
             numeric_value_is_grounded=numeric_value_is_grounded,
             formula_environment=formula_environment,
+            source_bound_constant_occurrences=source_bound_constant_occurrences,
             extract_numeric_occurrences=extract_numeric_occurrences,
         ):
             continue
@@ -17556,6 +17597,8 @@ def _branch_boundary_test_witnesses(
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     numeric_value_is_grounded: NumericGroundingPredicate,
     formula_environment: dict[str, Any] | None = None,
+    source_bound_constant_occurrences: dict[str, tuple[NumericOccurrenceLike, ...]]
+    | None = None,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None = None,
 ) -> set[tuple[str, str]]:
     witnesses: set[tuple[str, str]] = set()
@@ -17607,6 +17650,9 @@ def _branch_boundary_test_witnesses(
                         boundary,
                         input_names=input_names,
                         formula_environment=(controller_execution.constant_environment),
+                        source_bound_constant_occurrences=(
+                            source_bound_constant_occurrences or {}
+                        ),
                         source_interval=source_interval,
                         source_boolean_polarity=source_boolean_polarity,
                         extract_numeric_occurrences=(extract_numeric_occurrences),
@@ -17690,6 +17736,8 @@ def _branch_boundary_has_test_evidence(
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     numeric_value_is_grounded: NumericGroundingPredicate,
     formula_environment: dict[str, Any] | None = None,
+    source_bound_constant_occurrences: dict[str, tuple[NumericOccurrenceLike, ...]]
+    | None = None,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None = None,
 ) -> bool:
     """Compatibility predicate for callers that do not allocate witnesses."""
@@ -17703,6 +17751,7 @@ def _branch_boundary_has_test_evidence(
             asserted_by_rule=asserted_by_rule,
             numeric_value_is_grounded=numeric_value_is_grounded,
             formula_environment=formula_environment,
+            source_bound_constant_occurrences=source_bound_constant_occurrences,
             extract_numeric_occurrences=extract_numeric_occurrences,
         )
     )
@@ -17714,6 +17763,7 @@ def _formula_execution_binds_boundary(
     *,
     input_names: set[str],
     formula_environment: dict[str, Any],
+    source_bound_constant_occurrences: dict[str, tuple[NumericOccurrenceLike, ...]],
     source_interval: _NumericInterval | None,
     source_boolean_polarity: int,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
@@ -17730,6 +17780,14 @@ def _formula_execution_binds_boundary(
     }
     if input_names & boundary_names:
         return False
+    source_bound_boundary_names = {
+        name
+        for name in boundary_names
+        if any(
+            numeric_value_is_grounded(float(boundary.value), (occurrence,))
+            for occurrence in source_bound_constant_occurrences.get(name, ())
+        )
+    }
     checks: list[tuple[str, bool]] = []
     for step in execution.trace:
         if step.kind not in {"if", "match"}:
@@ -17744,6 +17802,7 @@ def _formula_execution_binds_boundary(
             boundary_names=boundary_names,
             boundary=boundary,
             formula_environment=formula_environment,
+            source_bound_boundary_names=source_bound_boundary_names,
             source_interval=source_interval,
             extract_numeric_occurrences=extract_numeric_occurrences,
             numeric_value_is_grounded=numeric_value_is_grounded,
@@ -17763,6 +17822,7 @@ def _formula_text_has_boundary_comparison(
     source_interval: _NumericInterval | None,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
     numeric_value_is_grounded: NumericGroundingPredicate,
+    source_bound_boundary_names: set[str] | None = None,
 ) -> bool:
     expression = _parse_formula_expression(text)
     if expression is not None:
@@ -17816,6 +17876,8 @@ def _formula_text_has_boundary_comparison(
             boundary_names=boundary_names,
             boundary=boundary,
             formula_environment=formula_environment,
+            source_bound_boundary_names=source_bound_boundary_names or set(),
+            source_interval=source_interval,
             extract_numeric_occurrences=extract_numeric_occurrences,
             numeric_value_is_grounded=numeric_value_is_grounded,
         ):
@@ -17830,12 +17892,31 @@ def _formula_expression_has_boundary_clamp(
     boundary_names: set[str],
     boundary: NumericOccurrenceLike,
     formula_environment: dict[str, Any],
+    source_bound_boundary_names: set[str],
+    source_interval: _NumericInterval,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
     numeric_value_is_grounded: NumericGroundingPredicate,
 ) -> bool:
-    """Recognize a reached progressive ``min(subject, cap)`` boundary."""
+    """Recognize exact upper and lower clamps at a source-stated boundary."""
+
+    boundary_is_strict_lower = bool(
+        source_interval.lower is not None
+        and not source_interval.lower_inclusive
+        and _numeric_occurrences_are_equivalent(source_interval.lower, boundary)
+    )
 
     for node in ast.walk(expression):
+        if boundary_is_strict_lower and _formula_lower_boundary_clamp_matches(
+            node,
+            expression=expression,
+            input_names=input_names,
+            source_bound_boundary_names=source_bound_boundary_names,
+            boundary=boundary,
+            formula_environment=formula_environment,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+        ):
+            return True
         if not (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
@@ -17876,6 +17957,125 @@ def _formula_expression_has_boundary_clamp(
             ):
                 return True
     return False
+
+
+def _formula_lower_boundary_clamp_matches(
+    node: ast.AST,
+    *,
+    expression: ast.expr,
+    input_names: set[str],
+    source_bound_boundary_names: set[str],
+    boundary: NumericOccurrenceLike,
+    formula_environment: dict[str, Any],
+    extract_numeric_occurrences: NumericOccurrenceExtractor | None,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    """Accept only ``max(0, subject - floor)`` at the exact source floor."""
+
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "max"
+        and len(node.args) == 2
+        and not node.keywords
+    ):
+        return False
+    zero, positive_subject = node.args
+    if not (
+        isinstance(zero, ast.Constant)
+        and isinstance(zero.value, (int, float))
+        and not isinstance(zero.value, bool)
+        and zero.value == 0
+    ):
+        zero, positive_subject = positive_subject, zero
+    if not (
+        isinstance(zero, ast.Constant)
+        and isinstance(zero.value, (int, float))
+        and not isinstance(zero.value, bool)
+        and zero.value == 0
+        and isinstance(positive_subject, ast.BinOp)
+        and isinstance(positive_subject.op, ast.Sub)
+        and isinstance(positive_subject.left, ast.Name)
+        and positive_subject.left.id in input_names
+        and not _formula_node_references_names(positive_subject.right, input_names)
+    ):
+        return False
+    floor = positive_subject.right
+    named_floor = (
+        isinstance(floor, ast.Name) and floor.id in source_bound_boundary_names
+    )
+    literal_floor = (
+        isinstance(floor, ast.Constant)
+        and isinstance(floor.value, (int, float))
+        and not isinstance(floor.value, bool)
+    )
+    if not (named_floor or literal_floor):
+        return False
+    floor_value = _formula_node_boundary_value(
+        floor,
+        boundary_names=source_bound_boundary_names,
+        boundary=boundary,
+        formula_environment=formula_environment,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+    return bool(
+        floor_value is not None
+        and numeric_value_is_grounded(float(floor_value), (boundary,))
+        and _formula_node_causally_contributes(
+            expression,
+            node,
+            formula_environment=formula_environment,
+        )
+    )
+
+
+def _formula_node_causally_contributes(
+    expression: ast.expr,
+    target: ast.AST,
+    *,
+    formula_environment: dict[str, Any],
+) -> bool:
+    """Require changing one clamp result to change the reached formula value."""
+
+    target_location = (
+        type(target),
+        getattr(target, "lineno", None),
+        getattr(target, "col_offset", None),
+        getattr(target, "end_lineno", None),
+        getattr(target, "end_col_offset", None),
+    )
+
+    def evaluate_with_replacement(replacement: int) -> Decimal | None:
+        replaced = False
+
+        class ReplaceTarget(ast.NodeTransformer):
+            def generic_visit(self, candidate: ast.AST):
+                nonlocal replaced
+                candidate_location = (
+                    type(candidate),
+                    getattr(candidate, "lineno", None),
+                    getattr(candidate, "col_offset", None),
+                    getattr(candidate, "end_lineno", None),
+                    getattr(candidate, "end_col_offset", None),
+                )
+                if not replaced and candidate_location == target_location:
+                    replaced = True
+                    return ast.copy_location(ast.Constant(replacement), candidate)
+                return super().generic_visit(candidate)
+
+        candidate = ReplaceTarget().visit(copy.deepcopy(expression))
+        if not replaced:
+            return None
+        return _rulespec_runtime_decimal(
+            _evaluate_condition_expression(candidate, formula_environment)
+        )
+
+    zero_value = evaluate_with_replacement(0)
+    one_value = evaluate_with_replacement(1)
+    return bool(
+        zero_value is not None and one_value is not None and zero_value != one_value
+    )
 
 
 def _formula_clamp_preserves_boundary_offset(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1664"
+ENCODER_VERSION = "0.2.1665"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import tomllib
+import traceback
 from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
@@ -13190,6 +13191,144 @@ class TestCmdEncode:
             "initial_model": DEFAULT_OPENAI_MODEL,
             "escalation_model": DEFAULT_OPENAI_ESCALATION_MODEL,
         }
+
+    @pytest.mark.parametrize(
+        "issue",
+        (
+            "[generated-yaml:io] unable to read generated RuleSpec",
+            "[generated-yaml:decode] generated RuleSpec text is not decodable",
+        ),
+    )
+    def test_encode_does_not_retry_noncorrectable_generated_yaml_io_failure(
+        self, issue, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+        )
+
+        exit_code, generated, validated, mock_run, _mock_validate, mock_apply = (
+            self._run_validator_escalation_case(args, [(False, [issue])])
+        )
+
+        assert exit_code == 1
+        assert generated == [DEFAULT_OPENAI_MODEL]
+        assert validated == [DEFAULT_OPENAI_MODEL]
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs["validation_retry_feedback"] == ()
+        assert mock_run.call_args.kwargs["validation_retry_candidate"] is None
+        mock_apply.assert_not_called()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["status"] == "apply_blocked_validation"
+        assert run.outcome["apply_error"] == issue
+        assert "generation_retry_blocked" not in run.outcome
+
+    @pytest.mark.parametrize(
+        ("malformed", "expected_issue"),
+        (
+            (
+                """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+  - name: taxpayer_age_credit
+    kind: derived
+    versions:
+      - formula: {if taxpayer_is_aged: 40 else [0]}
+""",
+                "[generated-yaml:parser] invalid YAML at line 9, column 48: "
+                "flow mapping is missing an expected ',' or '}' delimiter before "
+                "a '[' sequence",
+            ),
+            (
+                "root: " + ("[ " * 500) + "0" + (" ]" * 500) + "\n",
+                "[generated-yaml:resource] generated YAML nesting exceeds safe "
+                "parser capacity",
+            ),
+        ),
+    )
+    def test_encode_retries_malformed_yaml_with_unchanged_candidate_then_applies_valid(
+        self, malformed, expected_issue, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+        )
+        generated_attempts = 0
+        applied_contents: list[str] = []
+        valid = "format: rulespec/v1\nrules: []\n"
+
+        def generate(**kwargs):
+            nonlocal generated_attempts
+            generated_attempts += 1
+            if generated_attempts == 1:
+                assert kwargs["validation_retry_feedback"] == ()
+                assert kwargs["validation_retry_candidate"] is None
+            else:
+                assert kwargs["validation_retry_feedback"] == (expected_issue,)
+                candidate = kwargs["validation_retry_candidate"]
+                assert candidate is not None
+                assert candidate.rulespec == malformed
+                assert candidate.tests == "[]\n"
+            backend, model = kwargs["runner_specs"][0].split(":", 1)
+            result = self._make_eval_result(True)
+            result.backend = backend
+            result.model = model
+            result.runner = f"{backend}-{model}"
+            result.generation_prompt_sha256 = f"prompt-{generated_attempts}"
+            output_file = (
+                args.output / result.runner / "statutes" / "26" / "1" / "j" / "2.yaml"
+            )
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_text(malformed if generated_attempts == 1 else valid)
+            output_file.with_suffix(".test.yaml").write_text("[]\n")
+            result.output_file = str(output_file)
+            return [result]
+
+        def validate(result, **_kwargs):
+            try:
+                _stamp_generated_source_attestation_for_apply(
+                    result, Path(result.output_file)
+                )
+            except RuntimeError as exc:
+                assert Path(result.output_file).read_text() == malformed
+                return False, [str(exc)], {}
+            return True, [], {}
+
+        def apply(result, **_kwargs):
+            content = Path(result.output_file).read_text()
+            applied_contents.append(content)
+            assert yaml.safe_load(content)["format"] == "rulespec/v1"
+            return [args.policy_repo_path / "us/statutes/26/1/j/2.yaml"]
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", side_effect=generate) as model,
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=validate,
+            ),
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                side_effect=apply,
+            ) as apply_call,
+            patch.dict(os.environ, TEST_APPLY_SIGNING_ENV, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        assert generated_attempts == 2
+        assert model.call_count == 2
+        apply_call.assert_called_once()
+        assert len(applied_contents) == 1
+        assert malformed not in applied_contents[0]
 
     def test_encode_contract_rejection_retries_with_exact_context_before_apply(
         self, tmp_path
@@ -41824,6 +41963,415 @@ rules:
         assert len(issues) == 1
         assert issues[0].startswith("regulations/18-nycrr/387/12/f/3/v/c.yaml: ")
         assert "dropped existing source_relation" in issues[0]
+
+    def test_apply_overlay_reports_unquoted_colon_yaml_parse_failure(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(
+            "axiom_encode.cli._stamp_generated_source_attestation_for_apply",
+            _stamp_generated_source_attestation_for_apply,
+        )
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-ky"
+        relative = Path("policies/income_tax/schedule_before_credits.yaml")
+        generated = output_root / "openai-test-model" / relative
+        generated.parent.mkdir(parents=True)
+        malformed = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+  - name: taxpayer_age_credit
+    kind: derived
+    versions:
+      - formula: if taxpayer_is_aged: 40 else: 0
+"""
+        generated.write_text(malformed)
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="openai-test-model",
+            backend="openai",
+            source_attestation=_complete_source_attestation(
+                "us-ky/statute/krs/141.020/document-1"
+            ),
+        )
+
+        ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            local_corpus_release=MagicMock(),
+        )
+
+        assert ok is False
+        assert issues == [
+            f"{relative}: [generated-yaml:scanner] invalid YAML at line 9, "
+            "column 37: unexpected mapping-value ':' delimiter; quote scalar "
+            "text containing ': '"
+        ]
+        assert supplemental == {}
+        assert generated.read_text() == malformed
+
+    def test_apply_overlay_reports_batch009_flow_mapping_parser_failure(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(
+            "axiom_encode.cli._stamp_generated_source_attestation_for_apply",
+            _stamp_generated_source_attestation_for_apply,
+        )
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-ky"
+        relative = Path("policies/income_tax/schedule_before_credits.yaml")
+        generated = output_root / "openai-test-model" / relative
+        generated.parent.mkdir(parents=True)
+        malformed = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+  - name: taxpayer_age_credit
+    kind: derived
+    versions:
+      - formula: {if taxpayer_is_aged: 40 else [0]}
+"""
+        generated.write_text(malformed)
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="openai-test-model",
+            backend="openai",
+            source_attestation=_complete_source_attestation(
+                "us-ky/statute/krs/141.020/document-1"
+            ),
+        )
+
+        ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            local_corpus_release=MagicMock(),
+        )
+
+        assert ok is False
+        assert issues == [
+            f"{relative}: [generated-yaml:parser] invalid YAML at line 9, "
+            "column 48: flow mapping is missing an expected ',' or '}' delimiter "
+            "before a '[' sequence"
+        ]
+        assert supplemental == {}
+        assert generated.read_text() == malformed
+
+    def test_apply_overlay_reports_deep_yaml_resource_failure(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(
+            "axiom_encode.cli._stamp_generated_source_attestation_for_apply",
+            _stamp_generated_source_attestation_for_apply,
+        )
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-ky"
+        relative = Path("policies/income_tax/deep.yaml")
+        generated = output_root / "openai-test-model" / relative
+        generated.parent.mkdir(parents=True)
+        deep_yaml = "root: " + ("[ " * 500) + "0" + (" ]" * 500) + "\n"
+        generated.write_text(deep_yaml)
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="openai-test-model",
+            backend="openai",
+            source_attestation=_complete_source_attestation(),
+        )
+
+        ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            local_corpus_release=MagicMock(),
+        )
+
+        assert ok is False
+        assert issues == [
+            f"{relative}: [generated-yaml:resource] generated YAML nesting exceeds "
+            "safe parser capacity"
+        ]
+        assert supplemental == {}
+        assert generated.read_text() == deep_yaml
+
+    @pytest.mark.parametrize(
+        ("malformed", "subtype"),
+        (
+            ("formula: if x: 1 else: 0\n", "scanner"),
+            ("formula: {if x: 1 else: 0}\n", "parser"),
+            ("---\na: 1\n---\nb: 2\n", "composer"),
+            ("a: !unknown b\n", "constructor"),
+            ("a: \ud800\n", "reader"),
+        ),
+    )
+    def test_generated_yaml_diagnostic_reports_honest_parser_subtype(
+        self, malformed, subtype, tmp_path
+    ):
+        captured_error = None
+        try:
+            yaml.safe_load(malformed)
+        except yaml.YAMLError as parse_error:
+            captured_error = parse_error
+        else:
+            raise AssertionError("fixture must raise a YAML parser exception")
+        output_file = tmp_path / "generated.yaml"
+        output_file.write_text("format: rulespec/v1\nrules: []\n")
+        result = SimpleNamespace(backend="openai")
+
+        with (
+            patch("axiom_encode.cli.yaml.safe_load", side_effect=captured_error),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            _stamp_generated_source_attestation_for_apply(result, output_file)
+
+        diagnostic = str(exc_info.value)
+        assert diagnostic.startswith(f"[generated-yaml:{subtype}] invalid YAML")
+        assert len(diagnostic) <= 1024
+
+    def test_source_attestation_failure_remains_distinct_from_yaml_parse_failure(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(
+            "axiom_encode.cli._stamp_generated_source_attestation_for_apply",
+            _stamp_generated_source_attestation_for_apply,
+        )
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-ky"
+        relative = Path("policies/income_tax/schedule_before_credits.yaml")
+        generated = output_root / "openai-test-model" / relative
+        generated.parent.mkdir(parents=True)
+        valid_yaml = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules: []
+"""
+        generated.write_text(valid_yaml)
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="openai-test-model",
+            backend="openai",
+            source_attestation=None,
+        )
+
+        ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            local_corpus_release=MagicMock(),
+        )
+
+        assert ok is False
+        assert issues == [
+            f"{relative}: Cannot apply a model-generated RuleSpec without resolver "
+            "source_attestation"
+        ]
+        assert supplemental == {}
+        assert generated.read_text() == valid_yaml
+
+    def test_generated_yaml_parse_failure_is_structural_bounded_and_nonleaking(
+        self, tmp_path
+    ):
+        output_file = tmp_path / "generated.yaml"
+        output_file.write_text("format: rulespec/v1\nrules: []\n")
+        result = SimpleNamespace(backend="openai")
+
+        class PoisonedYamlError(yaml.YAMLError):
+            def __str__(self):
+                raise AssertionError("raw parser exception was stringified")
+
+            def __repr__(self):
+                raise AssertionError("raw parser exception was represented")
+
+        secret = "SECRET_CANDIDATE_LINE\x1b\u202e"
+        parse_error = PoisonedYamlError()
+        parse_error.problem = secret + ("x" * 2_000)
+        parse_error.problem_mark = SimpleNamespace(
+            line=4,
+            column=6,
+            name=str(output_file),
+            buffer=f"rules:\n  - formula: {secret}\n",
+            snippet=secret,
+        )
+
+        with patch("axiom_encode.cli.yaml.safe_load", side_effect=parse_error):
+            with pytest.raises(RuntimeError) as exc_info:
+                _stamp_generated_source_attestation_for_apply(result, output_file)
+
+        diagnostic = str(exc_info.value)
+        assert diagnostic == (
+            "[generated-yaml:error] invalid YAML at line 5, column 7: "
+            "invalid YAML syntax"
+        )
+        rendered_traceback = "".join(traceback.format_exception(exc_info.value))
+        assert secret not in diagnostic
+        assert secret not in rendered_traceback
+        assert str(output_file) not in diagnostic
+        assert str(output_file) not in rendered_traceback
+        assert len(diagnostic) <= 1024
+        assert exc_info.value.__cause__ is None
+        assert exc_info.value.__suppress_context__ is True
+
+        import axiom_encode.cli as cli_module
+
+        issue = f"policies/income_tax/example.yaml: {diagnostic}"
+        outcome = {"apply_error": issue}
+        cli_module._replace_overlay_validation_failures(outcome, [issue])
+        failed_attempt = cli_module._FailedEncodeAttempt(
+            result=SimpleNamespace(
+                metrics=SimpleNamespace(compile_issues=[], ci_issues=[])
+            ),
+            error="Generated RuleSpec failed CI validation",
+            validation_issues=(issue,),
+        )
+        prompt_feedback = cli_module._encode_validation_retry_feedback([failed_attempt])
+        workflow_surfaces = json.dumps(
+            {
+                "issue": issue,
+                "outcome": outcome,
+                "prompt_feedback": prompt_feedback,
+                "traceback": rendered_traceback,
+            },
+            sort_keys=True,
+        )
+        assert "[generated-yaml:error]" in workflow_surfaces
+        assert secret not in workflow_surfaces
+        assert str(output_file) not in workflow_surfaces
+
+    @pytest.mark.parametrize(
+        ("failure", "expected_diagnostic"),
+        (
+            (
+                OSError("SECRET_PATH /private/generated.yaml"),
+                "[generated-yaml:io] unable to read generated RuleSpec",
+            ),
+            (
+                UnicodeError("SECRET_SOURCE could not decode"),
+                "[generated-yaml:decode] generated RuleSpec text is not decodable",
+            ),
+        ),
+    )
+    def test_generated_yaml_read_failures_remain_nonparser_failures(
+        self, failure, expected_diagnostic, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(
+            "axiom_encode.cli._stamp_generated_source_attestation_for_apply",
+            _stamp_generated_source_attestation_for_apply,
+        )
+        output_root = tmp_path / "out"
+        output_file = output_root / "openai-test-model" / "policies/example.yaml"
+        output_file.parent.mkdir(parents=True)
+        original = "format: rulespec/v1\nrules: []\n"
+        output_file.write_text(original)
+        result = SimpleNamespace(
+            backend="openai",
+            runner="openai-test-model",
+            output_file=str(output_file),
+            source_attestation=_complete_source_attestation(),
+        )
+
+        with (
+            patch.object(Path, "read_text", side_effect=failure),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            _stamp_generated_source_attestation_for_apply(result, output_file)
+
+        diagnostic = str(exc_info.value)
+        rendered_traceback = "".join(traceback.format_exception(exc_info.value))
+        assert diagnostic == expected_diagnostic
+        assert str(output_file) not in diagnostic
+        assert "SECRET_" not in diagnostic
+        assert "SECRET_" not in rendered_traceback
+        assert str(output_file) not in rendered_traceback
+        assert exc_info.value.__cause__ is None
+        assert exc_info.value.__suppress_context__ is True
+        assert output_file.read_bytes().decode() == original
+
+        with patch.object(Path, "read_text", side_effect=failure):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=tmp_path / "rulespec-us" / "us-ky",
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                local_corpus_release=MagicMock(),
+            )
+
+        assert ok is False
+        assert issues == [expected_diagnostic]
+        assert supplemental == {}
+        outcome = {
+            "status": "apply_blocked_validation",
+            "apply_error": issues[0],
+        }
+        import axiom_encode.cli as cli_module
+
+        assert not cli_module._encode_attempt_was_validator_rejected(result, outcome)
+        workflow_surfaces = json.dumps(
+            {
+                "issues": issues,
+                "outcome": outcome,
+                "prompt_feedback": (),
+                "traceback": rendered_traceback,
+            },
+            sort_keys=True,
+        )
+        assert "SECRET_" not in workflow_surfaces
+        assert str(output_file) not in workflow_surfaces
+
+    def test_generated_yaml_preflight_does_not_read_out_of_root_candidate(
+        self, tmp_path
+    ):
+        import axiom_encode.cli as cli_module
+
+        output_root = tmp_path / "out"
+        outside_file = tmp_path / "outside.yaml"
+        outside_file.write_text("format: rulespec/v1\nrules: []\n")
+        result = SimpleNamespace(
+            backend="openai",
+            runner="openai-test-model",
+            output_file=str(outside_file),
+        )
+
+        with patch.object(
+            Path,
+            "read_text",
+            side_effect=AssertionError("out-of-root candidate was opened"),
+        ):
+            issue = cli_module._generated_rulespec_yaml_nonparser_issue(
+                result,
+                outside_file,
+                output_root=output_root,
+            )
+
+        assert issue is None
+
+    @pytest.mark.parametrize(
+        "failure",
+        (
+            MemoryError("resource exhausted"),
+            KeyboardInterrupt("interrupted"),
+            SystemExit("stopped"),
+        ),
+    )
+    def test_generated_yaml_process_failures_propagate(self, failure, tmp_path):
+        output_file = tmp_path / "generated.yaml"
+        original = "format: rulespec/v1\nrules: []\n"
+        output_file.write_text(original)
+        result = SimpleNamespace(backend="openai")
+        with (
+            patch.object(Path, "read_text", side_effect=failure),
+            pytest.raises(type(failure)) as exc_info,
+        ):
+            _stamp_generated_source_attestation_for_apply(result, output_file)
+
+        assert exc_info.value is failure
+        assert output_file.read_bytes().decode() == original
 
     def test_apply_overlay_validation_aggregates_structured_issues(self, tmp_path):
         output_root = tmp_path / "out"

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1664"
+ENCODER_VERSION = "0.2.1665"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1664"
+ENCODER_VERSION = "0.2.1665"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1664"
+ENCODER_VERSION = "0.2.1665"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1664"
+ENCODER_VERSION = "0.2.1665"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1664"
+ENCODER_VERSION = "0.2.1665"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1664"
+ENCODER_VERSION = "0.2.1665"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6216,7 +6216,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1664"')
+        .startswith('__version__ = "0.2.1665"')
     )
 
 
@@ -6448,13 +6448,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1664"
+    assert encoder_package["version"] == "0.2.1665"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1664"
+    assert project["project"]["version"] == "0.2.1665"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1664"')
+        .startswith('__version__ = "0.2.1665"')
     )
 
 
@@ -6716,13 +6716,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1664"
+    assert encoder_package["version"] == "0.2.1665"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1664"
+    assert project["project"]["version"] == "0.2.1665"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1664"')
+        .startswith('__version__ = "0.2.1665"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1664"
+ENCODER_VERSION = "0.2.1665"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1406,6 +1406,275 @@ def test_progressive_min_clamp_binds_matching_subtracted_offset():
     )
 
 
+@pytest.mark.parametrize("floor_expression", ("bracket_floor", "5000"))
+def test_progressive_max_clamp_binds_exact_source_lower_boundary(
+    floor_expression: str,
+):
+    source = "Five percent of taxable income in excess of $5000."
+    boundary = EN_NUMERIC_OCCURRENCE_EXTRACTOR(source)[0]
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert completeness_module._formula_text_has_boundary_comparison(
+        f"rate * max(0, taxable_income - {floor_expression})",
+        allow_complement_relation=False,
+        input_names={"taxable_income"},
+        boundary_names={"bracket_floor"},
+        boundary=boundary,
+        formula_environment={"rate": 0.05, "bracket_floor": 5000},
+        source_bound_boundary_names={"bracket_floor"},
+        source_interval=interval,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
+def test_progressive_max_clamp_binds_full_formula_witness():
+    source = "Five percent of taxable income in excess of 5000 dollars."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-zz/statute/2
+rules:
+  - name: bracket_floor
+    kind: parameter
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-zz/statute/2
+              excerpt: Five percent of taxable income in excess of 5000 dollars.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5000
+  - name: rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.05
+  - name: tax
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-zz/statute/2
+              excerpt: Five percent of taxable income in excess of 5000 dollars.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: rate * max(0, taxable_income - bracket_floor)
+"""
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-zz/statute/2",
+        test_cases=[
+            {
+                "name": "income below floor",
+                "period": "2026-01-01",
+                "input": {"taxable_income": 4999},
+                "output": {"tax": 0},
+            },
+            {
+                "name": "income at floor",
+                "period": "2026-01-01",
+                "input": {"taxable_income": 5000},
+                "output": {"tax": 0},
+            },
+            {
+                "name": "income above floor",
+                "period": "2026-01-01",
+                "input": {"taxable_income": 5001},
+                "output": {"tax": 0.05},
+            },
+        ],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "formula", "5000")
+
+
+@pytest.mark.parametrize(
+    ("formula", "expected_outputs"),
+    (
+        (
+            "taxable_income + 0 * rate + 0 * max(0, taxable_income - bracket_floor)",
+            (4999, 5000, 5001),
+        ),
+        (
+            "min(0, max(0, taxable_income - bracket_floor))",
+            (0, 0, 0),
+        ),
+        (
+            "rate * max(0, taxable_income - unrelated_floor)",
+            (0, 0, 0.05),
+        ),
+    ),
+)
+def test_progressive_max_clamp_rejects_noncausal_or_unproven_full_witness(
+    formula: str,
+    expected_outputs: tuple[float, float, float],
+):
+    source = "Five percent of taxable income in excess of 5000 dollars."
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-zz/statute/2
+rules:
+  - name: bracket_floor
+    kind: parameter
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-zz/statute/2
+              excerpt: Five percent of taxable income in excess of 5000 dollars.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5000
+  - name: unrelated_floor
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5000
+  - name: rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.05
+  - name: tax
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-zz/statute/2
+              excerpt: Five percent of taxable income in excess of 5000 dollars.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: {formula}
+"""
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-zz/statute/2",
+        test_cases=[
+            {
+                "name": name,
+                "period": "2026-01-01",
+                "input": {"taxable_income": income},
+                "output": {"tax": expected},
+            }
+            for name, income, expected in zip(
+                ("below floor", "at floor", "above floor"),
+                (4999, 5000, 5001),
+                expected_outputs,
+                strict=True,
+            )
+        ],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "boundary input", "5000")
+
+
+@pytest.mark.parametrize(
+    "formula",
+    (
+        "rate * max(0, bracket_floor - taxable_income)",
+        "rate * max(0, taxable_income - unrelated_floor)",
+        "rate * max(0, taxable_income - (bracket_floor + 100))",
+        "rate * max(0, taxable_income - 4999)",
+        "rate * max(0, (2 * taxable_income) - bracket_floor)",
+        "rate * max(taxable_income, bracket_floor)",
+    ),
+)
+def test_progressive_max_clamp_rejects_nonexact_lower_boundary_shape(
+    formula: str,
+):
+    source = "Five percent of taxable income in excess of $5000."
+    boundary = EN_NUMERIC_OCCURRENCE_EXTRACTOR(source)[0]
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        formula,
+        allow_complement_relation=False,
+        input_names={"taxable_income"},
+        boundary_names={"bracket_floor"},
+        boundary=boundary,
+        formula_environment={
+            "rate": 0.05,
+            "bracket_floor": 5000,
+            "unrelated_floor": 5000,
+        },
+        source_bound_boundary_names={"bracket_floor"},
+        source_interval=interval,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Taxable income not in excess of $5000 is taxed at five percent.",
+        "Taxable income of at least $5000 is taxed at five percent.",
+    ),
+)
+def test_progressive_max_clamp_rejects_non_strict_lower_source_boundary(
+    source: str,
+):
+    boundary = EN_NUMERIC_OCCURRENCE_EXTRACTOR(source)[0]
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "rate * max(0, taxable_income - bracket_floor)",
+        allow_complement_relation=False,
+        input_names={"taxable_income"},
+        boundary_names={"bracket_floor"},
+        boundary=boundary,
+        formula_environment={"rate": 0.05, "bracket_floor": 5000},
+        source_bound_boundary_names={"bracket_floor"},
+        source_interval=interval,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
 def test_progressive_min_clamp_rejects_unrelated_cap():
     source = "Taxable income not in excess of $500 is taxed at two percent."
     boundary = EN_NUMERIC_OCCURRENCE_EXTRACTOR(source)[0]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1664"
+version = "0.2.1665"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- classify malformed generated RuleSpec YAML with bounded, honest parser subtypes, one-based locations, and fixed allowlisted guidance without exposing candidate bytes or exception-controlled path/source fields
- keep source-attestation failures distinct; retry parser/resource failures, while path-free read/decode failures stop without asking the model to correct a host-side problem
- validate the output path before the early YAML resource preflight so an out-of-root candidate is never opened
- recognize only exact strict-lower `max(0, direct_input - floor)` evidence whose clamp causally affects the reached formula; named floors must be proven against the authoritative source unit
- bump axiom-encode to 0.2.1665 and add changelog fragments

## Safety contract

Generated-YAML diagnostics do not stringify or represent parser exceptions and do not consume mark name, buffer, snippet, candidate source, or absolute paths. Raw exception chaining is suppressed at the workflow boundary. `MemoryError`, `KeyboardInterrupt`, and `SystemExit` still propagate. Rejected candidate and companion-test bytes are forwarded unchanged for model-correctable retries, and only the valid retry candidate can reach apply.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`: passed
- `python -m compileall -q src/axiom_encode scripts`: passed
- generated-YAML parser/retry focus: 17 passed, 1,197 deselected
- progressive lower-clamp focus: 14 passed, 5,444 deselected
- full `tests/test_source_completeness.py`: 5,458 passed
- full repository pre-commit run before the review fixes: 12,659 passed, 123 skipped; sole failure was the expected HEAD provenance check while the version bump was uncommitted
- post-amend version provenance check: 1 passed
- hosted Python 3.13 test suite: passed
- hosted lint/format: passed
- hosted Linux signing supervisor integration/security: passed
- hosted macOS signing supervisor integration/security: passed

## Review state

The review-fix cycle is complete at exact head `12a94d60e6ca7eb98e1775be2709f4d0562dd997`: two independent re-reviews found no actionable defects after the prior findings were fixed. This PR remains draft and unmerged pending the owner's readiness decision.
