### PR TITLE
Suppress telemetry for hermetic tests via sys.modules detection

### DIFF
--- a/changelog.d/hermetic-test-telemetry-suppression.fixed.md
+++ b/changelog.d/hermetic-test-telemetry-suppression.fixed.md
@@ -1,0 +1,1 @@
+Encode telemetry is suppressed for all in-process test invocations via `sys.modules` detection, not just the `PYTEST_CURRENT_TEST` env marker: hermetic tests that clear `os.environ` were reporting fixture runs to the production ops dashboard through the credential-free ingest path. Telemetry tests opt back in explicitly with `AXIOM_ENCODE_TELEMETRY=on` against mocked transports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1669"
+version = "0.2.1670"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1669"
+__version__ = "0.2.1670"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -366,7 +366,7 @@ from .legacy_replacement_overlay import (
 from .legacy_replacement_overlay import (
     stage_legacy_replacement_overlay as _stage_legacy_replacement_overlay,
 )
-from .live_run_telemetry import LiveRunTelemetry
+from .live_run_telemetry import LiveRunTelemetry, telemetry_blocked_for_tests
 from .oracles.policyengine.pending import (
     PendingDeclarationError,
     apply_pending_to_report,
@@ -57724,9 +57724,10 @@ def _eval_repair_manifest_path(result) -> Path | None:
 def _sync_run_to_supabase_if_configured(
     run: EncodingRun, *, db_path: Path = DEFAULT_DB
 ) -> dict[str, bool]:
-    if os.environ.get("PYTEST_CURRENT_TEST"):
+    if telemetry_blocked_for_tests():
         # Developer machines carry write credentials in their shell env; a
-        # pytest fixture run must never reach the real dashboard.
+        # pytest fixture run must never reach the real dashboard. Checked
+        # via sys.modules too — hermetic tests clear os.environ.
         return {"configured": False, "run": False, "session": False}
     if not (
         os.environ.get("AXIOM_ENCODE_SUPABASE_URL")

--- a/src/axiom_encode/live_run_telemetry.py
+++ b/src/axiom_encode/live_run_telemetry.py
@@ -41,6 +41,7 @@ INGEST_TIMEOUT_SECONDS = 10.0
 
 _CI_ENV_VARS = ("CI", "GITHUB_ACTIONS", "BUILDKITE", "CIRCLECI")
 _TELEMETRY_OFF_VALUES = {"off", "0", "false", "disabled"}
+_TELEMETRY_ON_VALUES = {"on", "1", "true"}
 
 
 def _utcnow() -> str:
@@ -66,18 +67,30 @@ def runner_identity() -> dict:
     }
 
 
+def running_under_tests() -> bool:
+    """Test-suite invocations of the encode path must never reach the real
+    dashboard. The env marker alone is not enough: hermetic tests clear
+    os.environ (in-process) or spawn the CLI with scrubbed envs, so the
+    in-process signal is the pytest module itself.
+    """
+    return "pytest" in sys.modules or bool(os.environ.get("PYTEST_CURRENT_TEST"))
+
+
+def telemetry_blocked_for_tests() -> bool:
+    """True when test detection should suppress telemetry. The explicit
+    `AXIOM_ENCODE_TELEMETRY=on` override bypasses detection — used by
+    telemetry tests exercising the (mocked) transports, never in
+    production config."""
+    override = os.environ.get("AXIOM_ENCODE_TELEMETRY", "").strip().lower()
+    return override not in _TELEMETRY_ON_VALUES and running_under_tests()
+
+
 def telemetry_mode() -> str:
     """Resolve the transport: 'direct', 'ingest', or 'off'."""
-    # Test-suite invocations of the encode path must never reach the real
-    # dashboard: developer machines carry write credentials in their shell
-    # environment, so credential presence alone cannot distinguish a real
-    # encode from a pytest fixture run.
-    if os.environ.get("PYTEST_CURRENT_TEST"):
+    override = os.environ.get("AXIOM_ENCODE_TELEMETRY", "").strip().lower()
+    if override in _TELEMETRY_OFF_VALUES:
         return "off"
-    if (
-        os.environ.get("AXIOM_ENCODE_TELEMETRY", "").strip().lower()
-        in _TELEMETRY_OFF_VALUES
-    ):
+    if telemetry_blocked_for_tests():
         return "off"
     if os.environ.get("AXIOM_ENCODE_SUPABASE_URL") and os.environ.get(
         "AXIOM_ENCODE_SUPABASE_SECRET_KEY"

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1669"
+ENCODER_VERSION = "0.2.1670"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14672,6 +14672,9 @@ rules:
                 {
                     "AXIOM_ENCODE_SUPABASE_URL": "https://example.supabase.co",
                     "AXIOM_ENCODE_SUPABASE_SECRET_KEY": "secret",
+                    # Deliberate opt-in past in-test suppression: both sync
+                    # transports below are mocked.
+                    "AXIOM_ENCODE_TELEMETRY": "on",
                 },
                 clear=True,
             ),

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1669"
+ENCODER_VERSION = "0.2.1670"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1669"
+ENCODER_VERSION = "0.2.1670"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_live_run_telemetry.py
+++ b/tests/test_live_run_telemetry.py
@@ -21,16 +21,15 @@ def _mock_client():
 def _configured_env(monkeypatch):
     monkeypatch.setenv("AXIOM_ENCODE_SUPABASE_URL", "https://example.supabase.co")
     monkeypatch.setenv("AXIOM_ENCODE_SUPABASE_SECRET_KEY", "secret")
-    # These tests exercise the enabled path with a mocked client; lift the
-    # pytest guard that would otherwise force telemetry off.
-    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    # These tests exercise the enabled path with mocked transports; the
+    # explicit "on" override is the only way past the in-test detection.
+    monkeypatch.setenv("AXIOM_ENCODE_TELEMETRY", "on")
 
 
 def _ingest_env(monkeypatch):
     monkeypatch.delenv("AXIOM_ENCODE_SUPABASE_URL", raising=False)
     monkeypatch.delenv("AXIOM_ENCODE_SUPABASE_SECRET_KEY", raising=False)
-    monkeypatch.delenv("AXIOM_ENCODE_TELEMETRY", raising=False)
-    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("AXIOM_ENCODE_TELEMETRY", "on")
 
 
 def _mock_urlopen(status=204):
@@ -74,8 +73,17 @@ class TestTelemetryMode:
         assert telemetry_mode() == "off"
         monkeypatch.setenv("AXIOM_ENCODE_TELEMETRY", "false")
         assert telemetry_mode() == "off"
+        # Without the explicit "on" override, in-process test detection wins
+        # even when hermetic tests have scrubbed every env marker: the
+        # pytest module itself is the signal.
         monkeypatch.delenv("AXIOM_ENCODE_TELEMETRY")
-        monkeypatch.setenv("PYTEST_CURRENT_TEST", "tests/test_x.py::test_y")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        assert telemetry_mode() == "off"
+
+    def test_explicit_off_beats_explicit_on_semantics(self, monkeypatch):
+        _ingest_env(monkeypatch)
+        assert telemetry_mode() == "ingest"
+        monkeypatch.setenv("AXIOM_ENCODE_TELEMETRY", "disabled")
         assert telemetry_mode() == "off"
 
 
@@ -87,7 +95,7 @@ class TestLiveRunTelemetry:
                 citation="us/statute/26/32",
                 backend="codex",
                 model="gpt-5.5",
-                encoder_version="0.2.1669",
+                encoder_version="0.2.1670",
             ) as live:
                 live.set_attempt(2, "gpt-5.5-max")
                 live.finish("completed", run_id="abc12345")

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1669"
+ENCODER_VERSION = "0.2.1670"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1669"
+ENCODER_VERSION = "0.2.1670"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1669"
+ENCODER_VERSION = "0.2.1670"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1669"
+ENCODER_VERSION = "0.2.1670"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6216,7 +6216,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1669"')
+        .startswith('__version__ = "0.2.1670"')
     )
 
 
@@ -6448,13 +6448,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1669"
+    assert encoder_package["version"] == "0.2.1670"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1669"
+    assert project["project"]["version"] == "0.2.1670"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1669"')
+        .startswith('__version__ = "0.2.1670"')
     )
 
 
@@ -6716,13 +6716,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1669"
+    assert encoder_package["version"] == "0.2.1670"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1669"
+    assert project["project"]["version"] == "0.2.1670"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1669"')
+        .startswith('__version__ = "0.2.1670"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1669"
+ENCODER_VERSION = "0.2.1670"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1669"
+version = "0.2.1670"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## What

Follow-up to #1473/#1474, caught in production: after telemetry went default-on, CI test suites wrote fixture rows (`26 USC 1(j)(2)`) to the live ops board through the credential-free ingest path. The pytest guard only checked `PYTEST_CURRENT_TEST`, which hermetic tests wipe (`patch.dict(os.environ, {...}, clear=True)` in-process, scrubbed envs for spawned CLIs).

- `running_under_tests()` now also checks `"pytest" in sys.modules` — a signal env scrubbing cannot remove — and both telemetry guards (live announce + completion sync) share it.
- `AXIOM_ENCODE_TELEMETRY=on` is an explicit bypass for tests that deliberately exercise the (mocked) sync/telemetry paths; the telemetry suite and `test_encode_syncs_when_credentials_are_configured` use it.
- Explicit `off` still wins over everything.

Remaining exposure: a *subprocess*-spawned CLI under a scrubbed env has neither marker in-process — but it also has a fresh interpreter without pytest imported only if genuinely spawned; those tests should set `AXIOM_ENCODE_TELEMETRY=off` in their constructed envs if they exercise encode paths. The fixture rows observed all came from in-process invocations, which this closes.

## Testing

62 tests across the telemetry, sync, and affected cli suites pass locally; fixture rows cleaned from the production table. Version 0.2.1670 with pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)