### PR TITLE
Harden source gate and clamp evidence

### DIFF
--- a/changelog.d/source-gate-clamp-witness-hardening.fixed.md
+++ b/changelog.d/source-gate-clamp-witness-hardening.fixed.md
@@ -1,0 +1,3 @@
+Require proof-bound, version-aligned execution evidence for same-source condition
+gates and lower-bound clamps, rejecting opaque aggregate statuses, borrowed or
+shadow clamp witnesses, and unbounded dependency expansion.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1670"
+version = "0.2.1671"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1670"
+__version__ = "0.2.1671"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -32,6 +32,7 @@ from typing import Any, Mapping, Protocol
 
 import yaml
 
+from axiom_encode.harness.proof_validator import _normalize_atom_path
 from axiom_encode.statute import (
     CitationParts,
     normalize_rulespec_path_segment,
@@ -161,6 +162,36 @@ class _FormulaExecution:
     evaluated_value: tuple[str, str] | None
     evaluates_to_zero: bool
     constant_environment: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _SourceConditionClause:
+    """One exact source proposition owned by a formula proof excerpt."""
+
+    branch_path: tuple[str, ...]
+    start: int
+    end: int
+    text: str
+
+
+@dataclass(frozen=True)
+class _TerminalGateAlternative:
+    """Terminal facts used by one active formula path and temporal partition."""
+
+    names: frozenset[str]
+    start: str | None
+    end: str | None
+    resolved: bool = True
+
+
+@dataclass(frozen=True)
+class _TerminalGateEvidence:
+    """Semantic evidence from one terminal with fail-closed polarity metadata."""
+
+    entities: frozenset[str]
+    predicates: frozenset[str]
+    polarity_conflict: bool
+    explicit_name_polarities: frozenset[tuple[str, bool]] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -4357,6 +4388,15 @@ def _analyze_rulespec_payload(
     )
     issues: list[str] = []
     issues.extend(imprecise_deferrals)
+    issues.extend(
+        _opaque_same_source_condition_input_issues(
+            payload,
+            source_text=source_text,
+            branches=branches,
+            principal_rules=principal_rules,
+            corpus_citation_path=corpus_citation_path,
+        )
+    )
 
     for branch in branches:
         if _path_covered(
@@ -4562,6 +4602,11 @@ def _analyze_rulespec_payload(
         issues.extend(
             _companion_test_issues(
                 principal_rules,
+                parameter_rules={
+                    name: rule
+                    for name, rule in named_rules.items()
+                    if str(rule.get("kind") or "").strip().lower() == "parameter"
+                },
                 principal_rule_paths=principal_rule_paths,
                 principal_formula_clause_rules=principal_formula_clause_rules,
                 formula_branches=formula_branches,
@@ -4654,13 +4699,26 @@ def _rule_source_excerpts(rule: dict[str, Any]) -> Iterable[tuple[str, str]]:
     )
 
 
+_PROOF_ATOM_PATH_INDEX_PATTERN = re.compile(r"\[\s*(\d+)\s*\]")
+
+
+def _formula_proof_version_index(path: str) -> int | None:
+    """Normalize a formula proof path the same way as proof validation."""
+
+    normalized = re.sub(r"\s+", "", str(path)).strip().rstrip(".")
+    normalized = _PROOF_ATOM_PATH_INDEX_PATTERN.sub(r"[\1]", normalized)
+    normalized = re.sub(r"^versions\.", "versions[0].", normalized)
+    match = re.match(r"^versions\[(\d+)\]\.formula\b", normalized)
+    return int(match.group(1)) if match is not None else None
+
+
 def _rule_formula_source_excerpts(
     rule: dict[str, Any],
 ) -> Iterable[tuple[str, str]]:
     return tuple(
         (citation_path, excerpt)
         for path, citation_path, excerpt in _rule_source_excerpt_atoms(rule)
-        if re.fullmatch(r"versions(?:\[\d+\])?\.formula", path)
+        if _formula_proof_version_index(path) is not None
     )
 
 
@@ -4677,7 +4735,11 @@ def _rule_source_excerpt_atoms(
     excerpts: list[tuple[str, str, str]] = []
     for atom in atoms:
         source = atom.get("source") if isinstance(atom, dict) else None
-        path = str(atom.get("path") or "").strip() if isinstance(atom, dict) else ""
+        path = (
+            _normalize_atom_path(str(atom.get("path") or ""))
+            if isinstance(atom, dict)
+            else ""
+        )
         excerpt = source.get("excerpt") if isinstance(source, dict) else None
         citation_path = (
             str(source.get("corpus_citation_path") or "").strip()
@@ -11802,18 +11864,1644 @@ _DIRECT_LOCAL_INPUT_NONNEGATIVE_CLAMP = re.compile(
     r"\bmax\s*\(\s*(?:0+(?:\.0+)?)\s*,\s*"
     r"(?P<input>[A-Za-z_][A-Za-z0-9_]*)\s*\)"
 )
+_NEGATIVE_LOCAL_INPUT_CLAMP_DIAGNOSTIC_LIMIT = 8
 
 
-def _rule_formula_identifiers(rule: Mapping[str, Any]) -> set[str]:
-    identifiers: set[str] = set()
+_SOURCE_EXPLICIT_CONDITION_DIAGNOSTIC_LIMIT = 8
+_SOURCE_EXPLICIT_CONDITION_EXPANSION_LIMIT = 64
+_SOURCE_EXPLICIT_CONDITION_DEPENDENCY_NODE_LIMIT = 128
+_SOURCE_EXPLICIT_CONDITION_DEPENDENCY_DEPTH_LIMIT = (
+    _SOURCE_EXPLICIT_CONDITION_DEPENDENCY_NODE_LIMIT + 1
+)
+_SOURCE_EXPLICIT_CONDITION_AST_DEPTH_LIMIT = 32
+_SOURCE_GATE_ENTITIES = frozenset(
+    {
+        "applicant",
+        "child",
+        "claimant",
+        "individual",
+        "parent",
+        "person",
+        "spouse",
+        "taxpayer",
+        "widow",
+        "widower",
+    }
+)
+_SOURCE_GATE_STOPWORDS = frozenset(
+    {
+        "a",
+        "additional",
+        "all",
+        "an",
+        "and",
+        "another",
+        "any",
+        "apply",
+        "applies",
+        "are",
+        "as",
+        "at",
+        "be",
+        "been",
+        "before",
+        "being",
+        "by",
+        "close",
+        "credit",
+        "dollar",
+        "each",
+        "for",
+        "from",
+        "had",
+        "has",
+        "have",
+        "if",
+        "in",
+        "is",
+        "kentucky",
+        "no",
+        "nor",
+        "not",
+        "of",
+        "on",
+        "or",
+        "otherwise",
+        "provided",
+        "taxable",
+        "than",
+        "that",
+        "the",
+        "then",
+        "to",
+        "under",
+        "unless",
+        "was",
+        "were",
+        "when",
+        "whose",
+        "with",
+        "without",
+        "year",
+    }
+)
+_SOURCE_GATE_PREDICATE_LANGUAGE = re.compile(
+    r"\b(?:is|are|was|were|has|have|had|file|files|filed|filing|made|"
+    r"attain(?:ed|s)?|own(?:ed|s)?|employ(?:ed|ment)?|work(?:ed|ing|s)?|"
+    r"insur(?:ed|ance)|live(?:d|s)?|resid(?:e|ed|es|ent|ence)|"
+    r"receive(?:d|s)?|earn(?:ed|ing|ings|s)?|support(?:ed|ing|s)?|"
+    r"qualif(?:y|ied|ies)|meet(?:s)?|exceed(?:ed|s)?)\b",
+    flags=re.IGNORECASE,
+)
+_SOURCE_GATE_NOMINAL_PREDICATES = frozenset(
+    {"age", "blind", "dependent", "income", "insurance", "married", "resident"}
+)
+_SOURCE_GATE_POLARITY_PREDICATES = frozenset({"no_income", "not_dependent"})
+_SOURCE_GATE_UNKNOWN_POLARITY_PREDICATES = frozenset(
+    {"unknown_income", "unknown_dependent"}
+)
+_SOURCE_GATE_POLARITY_BASE = {
+    "no_income": "income",
+    "not_dependent": "dependent",
+    "unknown_income": "income",
+    "unknown_dependent": "dependent",
+}
+_SOURCE_GATE_ADMINISTRATIVE_PREDICATES = frozenset(
+    {
+        "administrative",
+        "complete",
+        "document",
+        "record",
+        "review",
+        "scan",
+        "signoff",
+        "status",
+        "supervisor",
+        "workflow",
+    }
+)
+_SOURCE_INDEPENDENT_CONDITION_BOUNDARY = re.compile(
+    r",\s+(?:and|or)\s+(?=(?:(?:the|a|an|each|any|every|no|taxpayer|claimant|"
+    r"applicant|person|individual)\b|(?:is|are|was|were|has|have|had)\b)"
+    r"[^,;.!?]{0,120}\b(?:if|when|unless|provided\s+that)\b)",
+    flags=re.IGNORECASE,
+)
+
+
+def _source_gate_normalized_token(token: str) -> str:
+    normalized = re.sub(r"['’]s$", "", token.casefold())
+    aliases = {
+        "abode": "resident",
+        "aged": "age",
+        "attained": "attain",
+        "blindness": "blind",
+        "dependence": "dependent",
+        "dependency": "dependent",
+        "earning": "income",
+        "employed": "employ",
+        "employment": "employ",
+        "filed": "file",
+        "filing": "file",
+        "home": "home",
+        "house": "home",
+        "insured": "insurance",
+        "made": "file",
+        "owned": "own",
+        "ownership": "own",
+        "residence": "resident",
+        "working": "employ",
+    }
+    if normalized in aliases:
+        return aliases[normalized]
+    if (
+        len(normalized) > 4
+        and normalized.endswith("s")
+        and not normalized.endswith("ss")
+    ):
+        normalized = normalized[:-1]
+    return aliases.get(normalized, normalized)
+
+
+def _source_gate_semantic_tokens(text: str) -> frozenset[str]:
+    tokens = {
+        normalized
+        for token in re.findall(r"[A-Za-z][A-Za-z'-]*", text)
+        if (normalized := _source_gate_normalized_token(token.strip("'-")))
+        and normalized not in _SOURCE_GATE_STOPWORDS
+        and len(normalized) > 1
+    }
+    for base_predicate, negative in _source_gate_predicate_polarities(text).items():
+        if negative is None:
+            polarity_predicate = f"unknown_{base_predicate}"
+        else:
+            polarity_predicate = (
+                "no_income" if base_predicate == "income" else "not_dependent"
+            )
+        tokens.discard(base_predicate)
+        tokens.discard(f"unknown_{base_predicate}")
+        if negative is None:
+            tokens.add(polarity_predicate)
+        else:
+            tokens.add(polarity_predicate if negative else base_predicate)
+    return frozenset(tokens)
+
+
+_SOURCE_GATE_PREDICATE_SCAN_LIMIT = 16
+_SOURCE_GATE_CONTRACTION_REPLACEMENTS = {
+    "aren't": "are not",
+    "aren’t": "are not",
+    "arent": "are not",
+    "aren t": "are not",
+    "can't": "can not",
+    "can’t": "can not",
+    "cannot": "can not",
+    "cant": "can not",
+    "can t": "can not",
+    "didn't": "did not",
+    "didn’t": "did not",
+    "didnt": "did not",
+    "didn t": "did not",
+    "doesn't": "does not",
+    "doesn’t": "does not",
+    "doesnt": "does not",
+    "doesn t": "does not",
+    "don't": "do not",
+    "don’t": "do not",
+    "dont": "do not",
+    "don t": "do not",
+    "hadn't": "had not",
+    "hadn’t": "had not",
+    "hadnt": "had not",
+    "hadn t": "had not",
+    "hasn't": "has not",
+    "hasn’t": "has not",
+    "hasnt": "has not",
+    "hasn t": "has not",
+    "haven't": "have not",
+    "haven’t": "have not",
+    "havent": "have not",
+    "haven t": "have not",
+    "isn't": "is not",
+    "isn’t": "is not",
+    "isnt": "is not",
+    "isn t": "is not",
+    "wasn't": "was not",
+    "wasn’t": "was not",
+    "wasnt": "was not",
+    "wasn t": "was not",
+    "weren't": "were not",
+    "weren’t": "were not",
+    "werent": "were not",
+    "weren t": "were not",
+}
+
+
+def _normalized_source_gate_polarity_text(text: str) -> str:
+    """Normalize identifier separators and bounded English contractions."""
+
+    normalized = re.sub(r"_+", " ", text.casefold())
+    for contraction, replacement in _SOURCE_GATE_CONTRACTION_REPLACEMENTS.items():
+        normalized = re.sub(
+            rf"\b{re.escape(contraction)}\b",
+            replacement,
+            normalized,
+        )
+    normalized = re.sub(r"\bnot\s+only\b", "only", normalized)
+    return re.sub(r"\s+", " ", normalized).strip()
+
+
+@dataclass(frozen=True)
+class _SourceGatePredicateReading:
+    base_predicate: str
+    negative: bool | None
+
+
+_SOURCE_GATE_WORD = re.compile(r"[a-z]+|0")
+_SOURCE_GATE_CLAUSE_BOUNDARY = re.compile(
+    r"[;.!?]+|\b(?:whereas|however|but|although|though)\b",
+)
+_SOURCE_GATE_ENTITY_PATTERN = (
+    "(?:" + "|".join(map(re.escape, sorted(_SOURCE_GATE_ENTITIES))) + ")"
+)
+_SOURCE_GATE_INDEPENDENT_COORDINATION = re.compile(
+    r"\b(?:and|or|nor)\b(?=\s+(?:(?:the|a|an)\s+)?"
+    rf"(?:{_SOURCE_GATE_ENTITY_PATTERN}|it)\b)",
+)
+_SOURCE_GATE_CONJUNCTIVE_SEPARATOR = re.compile(
+    r"\b(?:and|nor)\b",
+    flags=re.IGNORECASE,
+)
+_SOURCE_GATE_YET = re.compile(r"\byet\b", flags=re.IGNORECASE)
+_SOURCE_GATE_YET_PREFIX_CHARACTER_LIMIT = 32
+_SOURCE_GATE_YET_SUBJECT_CHARACTER_LIMIT = 96
+_SOURCE_GATE_YET_SUBJECT_TOKEN_LIMIT = 8
+_SOURCE_GATE_YET_PRONOUNS = frozenset({"he", "it", "she", "they"})
+_SOURCE_GATE_AMBIGUOUS_YET_MARKER = "sourcegateambiguousyet"
+_SOURCE_GATE_INCOME_BASES = frozenset({"income", "earning", "earnings"})
+_SOURCE_GATE_INCOME_BLOCKERS = frozenset(
+    {
+        "document",
+        "documentation",
+        "evidence",
+        "proof",
+        "record",
+        "report",
+        "reported",
+        "reporting",
+        "reports",
+        "tax",
+        "taxed",
+        "taxes",
+    }
+)
+_SOURCE_GATE_DEPENDENT_BLOCKERS = frozenset(
+    {
+        "live",
+        "lived",
+        "lives",
+        "living",
+        "report",
+        "reported",
+        "reporting",
+        "reports",
+        "responsible",
+        "responsibility",
+    }
+)
+_SOURCE_GATE_INCOME_MODIFIERS = (
+    r"(?:(?:adjusted|annual|earned|federal|gross|kentucky|state|taxable|total)\s+)*"
+)
+_SOURCE_GATE_INCOME_NEGATIVE_PATTERNS = (
+    rf"(?:no|zero|0|nil)\s+{_SOURCE_GATE_INCOME_MODIFIERS}(?:income|earnings?)",
+    rf"devoid\s+of\s+{_SOURCE_GATE_INCOME_MODIFIERS}(?:income|earnings?)",
+    rf"without\s+{_SOURCE_GATE_INCOME_MODIFIERS}(?:income|earnings?)",
+    rf"(?:an?\s+)?absence\s+of\s+{_SOURCE_GATE_INCOME_MODIFIERS}"
+    rf"(?:income|earnings?)",
+    rf"lack(?:s|ed|ing)?\s+{_SOURCE_GATE_INCOME_MODIFIERS}(?:income|earnings?)",
+    rf"never\s+(?:has|have|had|receive(?:d|s)?|earn(?:ed|s)?)\s+"
+    rf"{_SOURCE_GATE_INCOME_MODIFIERS}(?:income|earnings?)",
+    rf"fail(?:s|ed)?\s+to\s+(?:receive|earn)\s+"
+    rf"{_SOURCE_GATE_INCOME_MODIFIERS}(?:income|earnings?)",
+    rf"(?:do|does|did|has|have|had)\s+not\s+"
+    rf"(?:have|receive|earn)\s+{_SOURCE_GATE_INCOME_MODIFIERS}"
+    rf"(?:income|earnings?)",
+    rf"not\s+in\s+receipt\s+of\s+{_SOURCE_GATE_INCOME_MODIFIERS}"
+    rf"(?:income|earnings?)",
+)
+_SOURCE_GATE_INCOME_POSITIVE_PATTERNS = (
+    rf"(?:has|have|had|receive(?:d|s)?|earn(?:ed|s)?)\s+"
+    rf"{_SOURCE_GATE_INCOME_MODIFIERS}(?:income|earnings?)",
+)
+_SOURCE_GATE_INCOME_NEGATION_MARKERS = frozenset(
+    {
+        "0",
+        "absence",
+        "devoid",
+        "fail",
+        "failed",
+        "fails",
+        "lack",
+        "lacked",
+        "lacking",
+        "lacks",
+        "never",
+        "nil",
+        "no",
+        "not",
+        "without",
+        "zero",
+    }
+)
+_SOURCE_GATE_DEPENDENT_OBJECT = (
+    r"(?:(?:a|an|another|any|other|the)\s+)?"
+    r"(?:(?:other|taxpayer|taxpayers|taxpayer\s+s)\s+)*dependent"
+)
+_SOURCE_GATE_DEPENDENT_NEGATIVE_PATTERNS = (
+    rf"(?:is|are|was|were)\s+not\s+{_SOURCE_GATE_DEPENDENT_OBJECT}",
+    rf"(?:can\s+not|unable\s+to|ineligible\s+to)\s+be\s+claimed\s+"
+    rf"(?:as\s+)?"
+    rf"{_SOURCE_GATE_DEPENDENT_OBJECT}",
+    rf"not\s+eligible\s+to\s+be\s+claimed\s+(?:as\s+)?"
+    rf"{_SOURCE_GATE_DEPENDENT_OBJECT}",
+)
+_SOURCE_GATE_DEPENDENT_POSITIVE_PATTERNS = (
+    rf"(?:is|are|was|were)\s+{_SOURCE_GATE_DEPENDENT_OBJECT}",
+    rf"(?:(?:is|are|was|were)\s+)?claimed\s+(?:as\s+)?"
+    rf"{_SOURCE_GATE_DEPENDENT_OBJECT}",
+    rf"(?:can\s+be|eligible\s+to\s+be)\s+claimed\s+(?:as\s+)?"
+    rf"{_SOURCE_GATE_DEPENDENT_OBJECT}",
+)
+_SOURCE_GATE_DEPENDENT_NEGATION_MARKERS = frozenset(
+    {"cannot", "ineligible", "not", "unable"}
+)
+
+
+def _source_gate_polarity_clauses(text: str) -> tuple[str, ...]:
+    normalized = _normalized_source_gate_polarity_text(text)
+    normalized = _SOURCE_GATE_CLAUSE_BOUNDARY.sub("\n", normalized)
+    normalized = _SOURCE_GATE_INDEPENDENT_COORDINATION.sub("\n", normalized)
+    normalized = _source_gate_replace_guarded_yet(
+        normalized,
+        independent_replacement="\n",
+        ambiguous_replacement=f"\n{_SOURCE_GATE_AMBIGUOUS_YET_MARKER} ",
+    )
+    return tuple(
+        clause.strip(" ,:") for clause in normalized.splitlines() if clause.strip(" ,:")
+    )
+
+
+def _source_gate_yet_classification(text: str, match: re.Match[str]) -> str:
+    """Classify one bounded temporal, independent, or ambiguous ``yet``."""
+
+    prefix = text[
+        max(0, match.start() - _SOURCE_GATE_YET_PREFIX_CHARACTER_LIMIT) : match.start()
+    ]
+    prefix_tokens = _SOURCE_GATE_WORD.findall(prefix.casefold())
+    suffix = text[match.end() :]
+    if prefix_tokens and prefix_tokens[-1] == "not":
+        return "temporal"
+    if re.match(r"^\s+to\b", suffix, flags=re.IGNORECASE):
+        return "temporal"
+    subject_tokens = _SOURCE_GATE_WORD.findall(
+        suffix[:_SOURCE_GATE_YET_SUBJECT_CHARACTER_LIMIT].casefold()
+    )[:_SOURCE_GATE_YET_SUBJECT_TOKEN_LIMIT]
+    if (_SOURCE_GATE_ENTITIES | _SOURCE_GATE_YET_PRONOUNS).intersection(subject_tokens):
+        return "independent"
+    return "ambiguous"
+
+
+def _source_gate_replace_guarded_yet(
+    text: str,
+    *,
+    independent_replacement: str,
+    ambiguous_replacement: str,
+) -> str:
+    """Replace bounded adversatives and poison ambiguous continuations."""
+
+    pieces: list[str] = []
+    prior_end = 0
+    for match in _SOURCE_GATE_YET.finditer(text):
+        classification = _source_gate_yet_classification(text, match)
+        if classification == "temporal":
+            continue
+        if classification == "ambiguous":
+            replacement = ambiguous_replacement
+        else:
+            replacement = independent_replacement
+        pieces.extend((text[prior_end : match.start()], replacement))
+        prior_end = match.end()
+    pieces.append(text[prior_end:])
+    return "".join(pieces)
+
+
+def _source_gate_split_conjunctive_conditions(text: str) -> list[str]:
+    """Split conjunctions and the same bounded adversative boundaries."""
+
+    with_yet_boundaries = _source_gate_replace_guarded_yet(
+        text,
+        independent_replacement="\n",
+        ambiguous_replacement=f"\n{_SOURCE_GATE_AMBIGUOUS_YET_MARKER} ",
+    )
+    return [
+        part
+        for line in with_yet_boundaries.splitlines()
+        for part in _SOURCE_GATE_CONJUNCTIVE_SEPARATOR.split(line)
+    ]
+
+
+def _source_gate_unwrap_negation(tokens: list[str]) -> tuple[list[str], int]:
+    """Remove only clause-leading sentential negations and return their parity."""
+
+    parity = 0
+    while tokens:
+        wrapper_length = 0
+        if tokens[:3] == ["not", "true", "that"]:
+            wrapper_length = 3
+        elif tokens[:4] == ["not", "the", "case", "that"]:
+            wrapper_length = 4
+        elif tokens[:5] == ["it", "is", "not", "true", "that"]:
+            wrapper_length = 5
+        elif tokens[:6] == ["it", "is", "not", "the", "case", "that"]:
+            wrapper_length = 6
+        if not wrapper_length:
+            break
+        parity ^= 1
+        tokens = tokens[wrapper_length:]
+    return tokens, parity
+
+
+def _source_gate_tail_match_start(
+    tokens: Sequence[str],
+    *,
+    end: int,
+    patterns: Sequence[str],
+) -> int | None:
+    start = max(0, end - _SOURCE_GATE_PREDICATE_SCAN_LIMIT)
+    tail = " ".join(tokens[start : end + 1])
+    starts: list[int] = []
+    for pattern in patterns:
+        match = re.search(rf"(?P<construct>{pattern})$", tail)
+        if match is None:
+            continue
+        starts.append(start + tail[: match.start("construct")].count(" "))
+    return max(starts, default=None)
+
+
+def _source_gate_local_blocked(
+    tokens: Sequence[str],
+    *,
+    index: int,
+    blockers: frozenset[str],
+) -> bool:
+    before = tokens[max(0, index - 4) : index]
+    after = tokens[index + 1 : index + 4]
+    return bool(blockers.intersection(before) or blockers.intersection(after))
+
+
+def _source_gate_has_temporal_yet_prefix(
+    tokens: Sequence[str],
+    *,
+    construct_start: int,
+) -> bool:
+    temporal_prefix = " ".join(tokens[max(0, construct_start - 8) : construct_start])
+    return bool(
+        re.search(
+            r"(?:\bnot\s+yet(?:\s+[a-z]+){0,3}|"
+            r"\b(?:has|have|had)\s+yet\s+to(?:\s+be)?)\s*$",
+            temporal_prefix,
+        )
+    )
+
+
+def _source_gate_income_reading(
+    tokens: Sequence[str],
+    *,
+    index: int,
+    wrapper_parity: int,
+    out_of_window_negation: bool,
+    has_temporal_yet: bool,
+) -> _SourceGatePredicateReading | None:
+    if _source_gate_local_blocked(
+        tokens,
+        index=index,
+        blockers=_SOURCE_GATE_INCOME_BLOCKERS,
+    ):
+        return _SourceGatePredicateReading("income", None)
+    prefix_start = max(0, index - _SOURCE_GATE_PREDICATE_SCAN_LIMIT)
+    if out_of_window_negation:
+        return _SourceGatePredicateReading("income", None)
+    negative_start = _source_gate_tail_match_start(
+        tokens,
+        end=index,
+        patterns=_SOURCE_GATE_INCOME_NEGATIVE_PATTERNS,
+    )
+    if negative_start is not None:
+        direct_outer = negative_start > 0 and tokens[negative_start - 1] == "not"
+        return _SourceGatePredicateReading(
+            "income",
+            not bool(wrapper_parity ^ direct_outer),
+        )
+    positive_start = _source_gate_tail_match_start(
+        tokens,
+        end=index,
+        patterns=_SOURCE_GATE_INCOME_POSITIVE_PATTERNS,
+    )
+    if positive_start is not None:
+        if (
+            _source_gate_has_temporal_yet_prefix(
+                tokens,
+                construct_start=positive_start,
+            )
+            or has_temporal_yet
+        ):
+            return _SourceGatePredicateReading("income", None)
+        return _SourceGatePredicateReading("income", bool(wrapper_parity))
+    local_prefix = tokens[prefix_start:index]
+    if _SOURCE_GATE_INCOME_NEGATION_MARKERS.intersection(local_prefix):
+        return _SourceGatePredicateReading("income", None)
+    if index + 1 < len(tokens) and tokens[index + 1] == "fact":
+        return None
+    return _SourceGatePredicateReading("income", None)
+
+
+def _source_gate_dependent_reading(
+    tokens: Sequence[str],
+    *,
+    index: int,
+    wrapper_parity: int,
+    out_of_window_negation: bool,
+    has_temporal_yet: bool,
+) -> _SourceGatePredicateReading | None:
+    if _source_gate_local_blocked(
+        tokens,
+        index=index,
+        blockers=_SOURCE_GATE_DEPENDENT_BLOCKERS,
+    ):
+        return _SourceGatePredicateReading("dependent", None)
+    prefix_start = max(0, index - _SOURCE_GATE_PREDICATE_SCAN_LIMIT)
+    if out_of_window_negation:
+        return _SourceGatePredicateReading("dependent", None)
+    negative_start = _source_gate_tail_match_start(
+        tokens,
+        end=index,
+        patterns=_SOURCE_GATE_DEPENDENT_NEGATIVE_PATTERNS,
+    )
+    if negative_start is not None:
+        direct_outer = negative_start > 0 and tokens[negative_start - 1] == "not"
+        return _SourceGatePredicateReading(
+            "dependent",
+            not bool(wrapper_parity ^ direct_outer),
+        )
+    positive_start = _source_gate_tail_match_start(
+        tokens,
+        end=index,
+        patterns=_SOURCE_GATE_DEPENDENT_POSITIVE_PATTERNS,
+    )
+    if positive_start is not None:
+        if (
+            _source_gate_has_temporal_yet_prefix(
+                tokens,
+                construct_start=positive_start,
+            )
+            or has_temporal_yet
+        ):
+            return _SourceGatePredicateReading("dependent", None)
+        return _SourceGatePredicateReading("dependent", bool(wrapper_parity))
+    local_prefix = tokens[prefix_start:index]
+    if _SOURCE_GATE_DEPENDENT_NEGATION_MARKERS.intersection(local_prefix):
+        return _SourceGatePredicateReading("dependent", None)
+    if index + 1 < len(tokens) and tokens[index + 1] == "fact":
+        return None
+    return _SourceGatePredicateReading("dependent", None)
+
+
+def _source_gate_predicate_readings(
+    text: str,
+) -> tuple[_SourceGatePredicateReading, ...]:
+    readings: list[_SourceGatePredicateReading] = []
+    for clause in _source_gate_polarity_clauses(text):
+        clause_tokens, wrapper_parity = _source_gate_unwrap_negation(
+            _SOURCE_GATE_WORD.findall(clause)
+        )
+        has_ambiguous_yet = _SOURCE_GATE_AMBIGUOUS_YET_MARKER in clause_tokens
+        # Independent and ambiguous uses were replaced before tokenization, so
+        # every literal ``yet`` remaining in this clause is temporal state.
+        has_temporal_yet = "yet" in clause_tokens
+        income_negation_prefix = [0]
+        dependent_negation_prefix = [0]
+        for token in clause_tokens:
+            income_negation_prefix.append(
+                income_negation_prefix[-1]
+                + int(token in _SOURCE_GATE_INCOME_NEGATION_MARKERS)
+            )
+            dependent_negation_prefix.append(
+                dependent_negation_prefix[-1]
+                + int(token in _SOURCE_GATE_DEPENDENT_NEGATION_MARKERS)
+            )
+        for index, token in enumerate(clause_tokens):
+            reading: _SourceGatePredicateReading | None = None
+            prefix_start = max(0, index - _SOURCE_GATE_PREDICATE_SCAN_LIMIT)
+            if token in _SOURCE_GATE_INCOME_BASES:
+                reading = _source_gate_income_reading(
+                    clause_tokens,
+                    index=index,
+                    wrapper_parity=wrapper_parity,
+                    out_of_window_negation=(income_negation_prefix[prefix_start] > 0),
+                    has_temporal_yet=has_temporal_yet,
+                )
+            elif token in {"dependence", "dependency", "dependent"}:
+                reading = _source_gate_dependent_reading(
+                    clause_tokens,
+                    index=index,
+                    wrapper_parity=wrapper_parity,
+                    out_of_window_negation=(
+                        dependent_negation_prefix[prefix_start] > 0
+                    ),
+                    has_temporal_yet=has_temporal_yet,
+                )
+            if reading is not None:
+                if has_ambiguous_yet:
+                    reading = _SourceGatePredicateReading(
+                        reading.base_predicate,
+                        None,
+                    )
+                readings.append(reading)
+    return tuple(readings)
+
+
+def _source_gate_predicate_polarities(text: str) -> dict[str, bool | None]:
+    grouped: dict[str, list[bool | None]] = {}
+    for reading in _source_gate_predicate_readings(text):
+        grouped.setdefault(reading.base_predicate, []).append(reading.negative)
+    polarities: dict[str, bool | None] = {}
+    for base_predicate, values in grouped.items():
+        known = {value for value in values if value is not None}
+        polarities[base_predicate] = (
+            next(iter(known)) if None not in values and len(known) == 1 else None
+        )
+    return polarities
+
+
+def _source_gate_explicit_polarities(text: str) -> dict[str, bool]:
+    """Return unambiguous base-predicate polarity, where true means negative."""
+
+    return {
+        base_predicate: negative
+        for base_predicate, negative in _source_gate_predicate_polarities(text).items()
+        if negative is not None
+    }
+
+
+def _source_conjunctive_fact_gates(
+    text: str,
+) -> tuple[tuple[frozenset[str], frozenset[str]], ...]:
+    """Return distinct entity/predicate signatures from one condition."""
+
+    conditional = re.search(
+        r"\b(?:if|when|provided\s+that|unless)\b(?P<body>.+)",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    if conditional is None:
+        return ()
+    body = conditional.group("body")
+    segments = _source_gate_split_conjunctive_conditions(body)
+    if len(segments) < 2:
+        return ()
+    gates: list[tuple[frozenset[str], frozenset[str]]] = []
+    inherited_entities: frozenset[str] = frozenset()
+    for segment in segments:
+        tokens = _source_gate_semantic_tokens(segment)
+        explicit_entities = tokens & _SOURCE_GATE_ENTITIES
+        is_subject_continuation = bool(
+            re.match(
+                r"^[\s,]*(?:if\s+)?(?:is|are|was|were|has|have|had)\b",
+                segment,
+                flags=re.IGNORECASE,
+            )
+        )
+        if explicit_entities and not is_subject_continuation:
+            inherited_entities = explicit_entities
+        entities = (
+            explicit_entities | inherited_entities
+            if is_subject_continuation
+            else explicit_entities or inherited_entities
+        )
+        predicates = tokens - _SOURCE_GATE_ENTITIES
+        if not predicates:
+            continue
+        if not (
+            _SOURCE_GATE_PREDICATE_LANGUAGE.search(segment)
+            or predicates
+            & (
+                _SOURCE_GATE_NOMINAL_PREDICATES
+                | _SOURCE_GATE_POLARITY_PREDICATES
+                | _SOURCE_GATE_UNKNOWN_POLARITY_PREDICATES
+            )
+        ):
+            continue
+        gates.append((entities, predicates))
+    return tuple(gates) if len(gates) >= 2 else ()
+
+
+def _source_conjunctive_fact_gate_count(text: str) -> int:
+    """Count distinct predicate/entity occurrences in one condition."""
+
+    return len(_source_conjunctive_fact_gates(text))
+
+
+def _rule_cited_source_paths(
+    rule: Mapping[str, Any],
+    *,
+    branches: Sequence[SourceStructureBranch],
+    corpus_citation_path: str,
+) -> set[tuple[str, ...]]:
+    source = str(rule.get("source") or "").strip()
+    paths = _paths_from_source_reference(
+        source,
+        corpus_citation_path=corpus_citation_path,
+    )
+    if paths:
+        return paths
+    krs_section = re.search(r"/krs/(?P<section>[^/]+)", corpus_citation_path, re.I)
+    if krs_section is None or not re.search(
+        rf"\bKRS\s+{re.escape(krs_section.group('section'))}\b",
+        source,
+        flags=re.IGNORECASE,
+    ):
+        return set()
+    suffix = source[re.search(r"\bKRS\b", source, re.I).end() :]
+    candidates = {
+        branch.path
+        for branch in branches
+        if branch.path
+        and all(
+            re.search(
+                rf"(?:\(\s*{re.escape(part)}\s*\)|\b{re.escape(part)}[.)])", suffix
+            )
+            for part in branch.path
+        )
+    }
+    if not candidates:
+        return {()}
+    maximum_depth = max(map(len, candidates))
+    return {path for path in candidates if len(path) == maximum_depth}
+
+
+def _source_proposition_bounds(text: str, start: int, end: int) -> tuple[int, int]:
+    boundaries = [0, len(text)]
+    boundaries.extend(
+        match.end()
+        for match in re.finditer(
+            r";|[.!?](?=\s+(?:[A-Z(]|\d+\s*[.)]))",
+            text,
+        )
+    )
+    boundaries.extend(
+        match.start() for match in _SOURCE_INDEPENDENT_CONDITION_BOUNDARY.finditer(text)
+    )
+    ordered = sorted(set(boundaries))
+    return (
+        max(position for position in ordered if position <= start),
+        min(position for position in ordered if position >= end),
+    )
+
+
+def _source_condition_clauses_owned_by_excerpt(
+    excerpt: str,
+    *,
+    rule: Mapping[str, Any],
+    source_text: str,
+    branches: Sequence[SourceStructureBranch],
+    corpus_citation_path: str,
+) -> tuple[tuple[_SourceConditionClause, ...], bool]:
+    """Resolve exact proof text to rule-cited propositions, reporting ambiguity."""
+
+    excerpt_text = _collapse_text(excerpt)
+    if not excerpt_text:
+        return (), False
+    pattern = re.compile(
+        r"\s+".join(re.escape(part) for part in excerpt_text.split()),
+        flags=re.IGNORECASE,
+    )
+    matches = tuple(pattern.finditer(source_text))
+    if not matches:
+        return (), False
+    cited_paths = _rule_cited_source_paths(
+        rule,
+        branches=branches,
+        corpus_citation_path=corpus_citation_path,
+    )
+
+    def containing_branch(start: int, end: int) -> SourceStructureBranch | None:
+        candidates = [
+            branch for branch in branches if branch.start <= start and end <= branch.end
+        ]
+        return max(
+            candidates,
+            key=lambda branch: (len(branch.path), -(branch.end - branch.start)),
+            default=None,
+        )
+
+    located = [(match, containing_branch(*match.span())) for match in matches]
+    restricted = [
+        (match, branch)
+        for match, branch in located
+        if not cited_paths
+        or any(
+            path == ()
+            or branch is not None
+            and len(branch.path) >= len(path)
+            and branch.path[: len(path)] == path
+            for path in cited_paths
+        )
+    ]
+    citation_mismatch = bool(cited_paths and located and not restricted)
+    selected = restricted or located
+    clauses: dict[tuple[tuple[str, ...], int, int], _SourceConditionClause] = {}
+    for match, branch in selected:
+        branch_path = branch.path if branch is not None else ()
+        container_start = branch.start if branch is not None else 0
+        container_text = branch.text if branch is not None else source_text
+        local_start = match.start() - container_start
+        local_end = match.end() - container_start
+        proposition_start, proposition_end = _source_proposition_bounds(
+            container_text,
+            local_start,
+            local_end,
+        )
+        absolute_start = container_start + proposition_start
+        absolute_end = container_start + proposition_end
+        identity = (branch_path, absolute_start, absolute_end)
+        clauses[identity] = _SourceConditionClause(
+            branch_path,
+            absolute_start,
+            absolute_end,
+            container_text[proposition_start:proposition_end].strip(" ;,"),
+        )
+    ordered = tuple(
+        clauses[key]
+        for key in sorted(clauses, key=lambda item: (item[1], item[2], item[0]))
+    )
+    return ordered, citation_mismatch or len(ordered) != 1
+
+
+def _effective_formula_version_intervals(
+    rule: Mapping[str, Any],
+) -> tuple[tuple[int, str, str | None, str | None], ...]:
+    """Return unambiguous intervals in which each formula version is selected."""
+
     versions = rule.get("versions")
-    if not isinstance(versions, list):
-        return identifiers
-    for version in versions:
-        formula = version.get("formula") if isinstance(version, dict) else None
-        if isinstance(formula, str):
-            identifiers.update(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", formula))
-    return identifiers
+    if (
+        not isinstance(versions, list)
+        or len(versions) > _TEMPORAL_WITNESS_VERSION_LIMIT
+    ):
+        return ()
+    formulas = [
+        (index, version, str(version.get("formula")))
+        for index, version in enumerate(versions)
+        if isinstance(version, dict) and version.get("formula") is not None
+    ]
+    if not formulas:
+        return ()
+    has_temporal_metadata = any(
+        str(version.get("effective_from") or "").strip()
+        or str(version.get("effective_to") or "").strip()
+        for _index, version, _formula in formulas
+    )
+    if not has_temporal_metadata:
+        if len(formulas) != 1:
+            return ()
+        index, _version, formula = formulas[0]
+        return ((index, formula, None, None),)
+
+    starts: list[str] = []
+    for _index, version, _formula in formulas:
+        start = str(version.get("effective_from") or "").strip()
+        end = str(version.get("effective_to") or "").strip()
+        if (
+            not _is_iso_calendar_date(start)
+            or (end and not _is_iso_calendar_date(end))
+            or (end and end < start)
+        ):
+            return ()
+        starts.append(start)
+    if len(set(starts)) != len(starts):
+        return ()
+
+    intervals: list[tuple[int, str, str | None, str | None]] = []
+    for index, version, formula in formulas:
+        start = str(version.get("effective_from") or "").strip()
+        explicit_end = str(version.get("effective_to") or "").strip() or None
+        next_start = min((value for value in starts if value > start), default=None)
+        selected_end = explicit_end
+        if next_start is not None:
+            superseded_end = _shift_iso_date(next_start, -1)
+            if superseded_end is None:
+                return ()
+            selected_end = min(
+                (
+                    value
+                    for value in (explicit_end, superseded_end)
+                    if value is not None
+                ),
+                default=None,
+            )
+        if selected_end is not None and selected_end < start:
+            continue
+        intervals.append((index, formula, start, selected_end))
+    return tuple(intervals)
+
+
+def _formula_intervals_overlap(
+    left_start: str | None,
+    left_end: str | None,
+    right_start: str | None,
+    right_end: str | None,
+) -> bool:
+    return not (
+        left_end is not None
+        and right_start is not None
+        and left_end < right_start
+        or right_end is not None
+        and left_start is not None
+        and right_end < left_start
+    )
+
+
+def _formula_interval_intersection(
+    left_start: str | None,
+    left_end: str | None,
+    right_start: str | None,
+    right_end: str | None,
+) -> tuple[str | None, str | None] | None:
+    if not _formula_intervals_overlap(
+        left_start,
+        left_end,
+        right_start,
+        right_end,
+    ):
+        return None
+    starts = [value for value in (left_start, right_start) if value is not None]
+    ends = [value for value in (left_end, right_end) if value is not None]
+    return (max(starts, default=None), min(ends, default=None))
+
+
+def _terminal_gate_evidence(
+    payload: Mapping[str, Any],
+) -> dict[str, _TerminalGateEvidence]:
+    evidence: dict[str, _TerminalGateEvidence] = {}
+
+    def build(name: str, description: str = "") -> _TerminalGateEvidence:
+        name_text = name.replace("_", " ")
+        name_tokens = _source_gate_semantic_tokens(name_text)
+        description_tokens = _source_gate_semantic_tokens(description)
+        name_polarities = _source_gate_predicate_polarities(name_text)
+        description_polarities = _source_gate_predicate_polarities(description)
+        polarity_conflict = (
+            None in name_polarities.values()
+            or None in description_polarities.values()
+            or any(
+                predicate in description_polarities
+                and description_polarities[predicate] != negative
+                for predicate, negative in name_polarities.items()
+            )
+        )
+        effective_polarities = description_polarities | name_polarities
+        tokens = set(name_tokens | description_tokens)
+        for base_predicate, negative in effective_polarities.items():
+            if negative is None:
+                polarity_predicate = f"unknown_{base_predicate}"
+            else:
+                polarity_predicate = (
+                    "no_income" if base_predicate == "income" else "not_dependent"
+                )
+            tokens.discard(base_predicate)
+            tokens.discard(f"unknown_{base_predicate}")
+            if negative is None:
+                tokens.add(polarity_predicate)
+            else:
+                tokens.add(polarity_predicate if negative else base_predicate)
+        return _TerminalGateEvidence(
+            frozenset(tokens) & _SOURCE_GATE_ENTITIES,
+            frozenset(tokens) - _SOURCE_GATE_ENTITIES,
+            polarity_conflict,
+            frozenset(
+                (base_predicate, negative)
+                for base_predicate, negative in name_polarities.items()
+                if negative is not None
+            ),
+        )
+
+    for item in payload.get("inputs", ()) or ():
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name:
+            continue
+        evidence[name] = build(name, str(item.get("description") or ""))
+    for item in payload.get("imports", ()) or ():
+        if not isinstance(item, str) or "#" not in item:
+            continue
+        name = item.rsplit("#", 1)[-1].strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            continue
+        evidence[name] = build(name)
+    return evidence
+
+
+def _terminal_names_corroborate_source_gates(
+    names: frozenset[str],
+    gates: tuple[tuple[frozenset[str], frozenset[str]], ...],
+    *,
+    terminal_evidence: Mapping[str, _TerminalGateEvidence],
+    neutral_polarity_imports: frozenset[str] = frozenset(),
+) -> bool:
+    """Require a distinct semantically related terminal for every source gate."""
+
+    if not gates:
+        return True
+    if (
+        len(gates) > _SOURCE_EXPLICIT_CONDITION_EXPANSION_LIMIT
+        or len(names) > _SOURCE_EXPLICIT_CONDITION_EXPANSION_LIMIT
+    ):
+        return False
+    repeated_predicates = [
+        frozenset().union(
+            *(
+                predicates & other_predicates
+                for other_index, (_entities, other_predicates) in enumerate(gates)
+                if other_index != index
+            )
+        )
+        for index, (_entities, predicates) in enumerate(gates)
+    ]
+    candidates: list[tuple[str, ...]] = []
+    for index, (entities, predicates) in enumerate(gates):
+        if predicates & _SOURCE_GATE_UNKNOWN_POLARITY_PREDICATES:
+            candidates.append(())
+            continue
+        matches: list[str] = []
+        for name in sorted(names):
+            evidence = terminal_evidence.get(
+                name,
+                _TerminalGateEvidence(frozenset(), frozenset(), True),
+            )
+            if evidence.polarity_conflict:
+                continue
+            terminal_entities = evidence.entities
+            terminal_predicates = evidence.predicates
+            source_administrative = predicates & _SOURCE_GATE_ADMINISTRATIVE_PREDICATES
+            terminal_administrative = (
+                terminal_predicates & _SOURCE_GATE_ADMINISTRATIVE_PREDICATES
+            )
+            if terminal_administrative and not (
+                terminal_administrative & source_administrative
+            ):
+                continue
+            is_neutral_import_fact = False
+            polarity_mismatch = False
+            for base_predicate, negative_predicate in (
+                ("income", "no_income"),
+                ("dependent", "not_dependent"),
+            ):
+                source_negative = negative_predicate in predicates
+                source_positive = base_predicate in predicates
+                if not source_negative and not source_positive:
+                    continue
+                terminal_negative = negative_predicate in terminal_predicates
+                terminal_positive = base_predicate in terminal_predicates
+                explicit_name_polarities = dict(evidence.explicit_name_polarities)
+                neutral_for_base = (
+                    source_negative
+                    and name in neutral_polarity_imports
+                    and "fact" in terminal_predicates
+                    and base_predicate not in explicit_name_polarities
+                    and terminal_positive
+                )
+                is_neutral_import_fact |= neutral_for_base
+                if source_negative:
+                    polarity_mismatch |= not terminal_negative and not neutral_for_base
+                else:
+                    polarity_mismatch |= terminal_negative or not terminal_positive
+            if polarity_mismatch:
+                continue
+            predicate_overlap = predicates & terminal_predicates
+            if is_neutral_import_fact:
+                predicate_overlap |= {
+                    _SOURCE_GATE_POLARITY_BASE[predicate]
+                    for predicate in predicates & _SOURCE_GATE_POLARITY_PREDICATES
+                } & terminal_predicates
+            entity_overlap = entities & terminal_entities
+            if not predicate_overlap:
+                continue
+            if len(predicate_overlap) < 2 and not entity_overlap:
+                continue
+            if repeated_predicates[index] and entities and not entity_overlap:
+                continue
+            matches.append(name)
+        candidates.append(tuple(matches))
+    if any(not values for values in candidates):
+        return False
+    order = sorted(range(len(gates)), key=lambda index: (len(candidates[index]), index))
+
+    matched_gate_by_terminal: dict[str, int] = {}
+
+    def augment(gate_index: int, seen: set[str]) -> bool:
+        for name in candidates[gate_index]:
+            if name in seen:
+                continue
+            seen.add(name)
+            previous_gate = matched_gate_by_terminal.get(name)
+            if previous_gate is None or augment(previous_gate, seen):
+                matched_gate_by_terminal[name] = gate_index
+                return True
+        return False
+
+    return all(augment(gate_index, set()) for gate_index in order)
+
+
+def _opaque_same_source_condition_input_issues(
+    payload: Mapping[str, Any],
+    *,
+    source_text: str,
+    branches: Sequence[SourceStructureBranch],
+    principal_rules: Mapping[str, dict[str, Any]],
+    corpus_citation_path: str,
+) -> list[str]:
+    """Reject terminal selectors that collapse explicit same-source fact gates."""
+
+    inputs = payload.get("inputs")
+    declared_inputs = {
+        str(item.get("name") or "").strip()
+        for item in inputs or ()
+        if isinstance(item, dict) and str(item.get("name") or "").strip()
+    }
+    imported_names = {
+        str(item).rsplit("#", 1)[-1].strip()
+        for item in payload.get("imports", ()) or ()
+        if isinstance(item, str)
+        and "#" in item
+        and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", item.rsplit("#", 1)[-1].strip())
+    }
+    named_rules = {
+        str(rule.get("name") or "").strip(): rule
+        for rule in payload.get("rules", ()) or ()
+        if isinstance(rule, dict) and str(rule.get("name") or "").strip()
+    }
+    terminal_evidence = _terminal_gate_evidence(payload)
+
+    authoritative_path = corpus_citation_path.strip("/").casefold()
+    numeric_or_judgment_dtypes = {
+        "count",
+        "decimal",
+        "integer",
+        "judgment",
+        "money",
+        "rate",
+    }
+    interval_cache = {
+        name: _effective_formula_version_intervals(rule)
+        for name, rule in named_rules.items()
+    }
+    selector_cache: dict[tuple[str, bool], tuple[frozenset[str], ...]] = {}
+    source_gate_cache: dict[
+        tuple[tuple[str, ...], int, int],
+        tuple[tuple[frozenset[str], frozenset[str]], ...],
+    ] = {}
+    expansion_cache: dict[
+        tuple[str, int, str | None, str | None],
+        tuple[_TerminalGateAlternative, ...],
+    ] = {}
+    dependency_budget_cache: dict[
+        tuple[str, str, bool, str | None, str | None], bool
+    ] = {}
+
+    def formula_selector_groups(
+        formula: str,
+        *,
+        include_result_leaves: bool,
+    ) -> tuple[frozenset[str], ...]:
+        key = (formula, include_result_leaves)
+        if key not in selector_cache:
+            selector_cache[key] = _formula_control_selector_name_groups(
+                formula,
+                include_result_leaves=include_result_leaves,
+            )
+        return selector_cache[key]
+
+    def source_clause_gates(
+        clause: _SourceConditionClause,
+    ) -> tuple[tuple[frozenset[str], frozenset[str]], ...]:
+        identity = (clause.branch_path, clause.start, clause.end)
+        if identity not in source_gate_cache:
+            source_gate_cache[identity] = _source_conjunctive_fact_gates(clause.text)
+        return source_gate_cache[identity]
+
+    def dependency_expansion_is_bounded(
+        root_name: str,
+        formula: str,
+        *,
+        include_result_leaves: bool,
+        start: str | None,
+        end: str | None,
+    ) -> bool:
+        """Bound the temporally reachable dependency graph before recursion."""
+
+        cache_key = (root_name, formula, include_result_leaves, start, end)
+        if cache_key in dependency_budget_cache:
+            return dependency_budget_cache[cache_key]
+        initial_names = frozenset().union(
+            *formula_selector_groups(
+                formula,
+                include_result_leaves=include_result_leaves,
+            )
+        )
+        pending = [
+            (False, name, start, end) for name in sorted(initial_names, reverse=True)
+        ]
+        dependencies: set[str] = set()
+        active_names = {root_name}
+        completed_states: set[tuple[str, str | None, str | None]] = set()
+        while pending:
+            exiting, name, dependency_start, dependency_end = pending.pop()
+            state = (name, dependency_start, dependency_end)
+            if exiting:
+                active_names.remove(name)
+                completed_states.add(state)
+                continue
+            if (
+                state in completed_states
+                or name in declared_inputs
+                or name in imported_names
+            ):
+                continue
+            dependency = named_rules.get(name)
+            if dependency is None:
+                dependency_budget_cache[cache_key] = False
+                return False
+            if name in active_names:
+                dependency_budget_cache[cache_key] = False
+                return False
+            dependencies.add(name)
+            if len(dependencies) > _SOURCE_EXPLICIT_CONDITION_DEPENDENCY_NODE_LIMIT:
+                dependency_budget_cache[cache_key] = False
+                return False
+            dependency_includes_leaves = str(
+                dependency.get("dtype") or ""
+            ).strip().lower() in {"judgment", "boolean", "bool"}
+            child_states: set[tuple[str, str | None, str | None]] = set()
+            for (
+                _index,
+                dependency_formula,
+                version_start,
+                version_end,
+            ) in interval_cache.get(name, ()):
+                overlap = _formula_interval_intersection(
+                    dependency_start,
+                    dependency_end,
+                    version_start,
+                    version_end,
+                )
+                if overlap is None:
+                    continue
+                for group in formula_selector_groups(
+                    dependency_formula,
+                    include_result_leaves=dependency_includes_leaves,
+                ):
+                    derived_dependencies = {
+                        selector_name
+                        for selector_name in group
+                        if selector_name not in declared_inputs
+                        and selector_name not in imported_names
+                    }
+                    if any(
+                        selector_name not in named_rules
+                        for selector_name in derived_dependencies
+                    ):
+                        dependency_budget_cache[cache_key] = False
+                        return False
+                    child_states.update(
+                        (selector_name, overlap[0], overlap[1])
+                        for selector_name in derived_dependencies
+                    )
+            active_names.add(name)
+            pending.append((True, name, dependency_start, dependency_end))
+            pending.extend(
+                (False, child_name, child_start, child_end)
+                for child_name, child_start, child_end in sorted(
+                    child_states,
+                    key=lambda value: (
+                        value[0],
+                        value[1] or "",
+                        value[2] or "~",
+                    ),
+                    reverse=True,
+                )
+            )
+        dependency_budget_cache[cache_key] = True
+        return True
+
+    def bounded_alternatives(
+        values: Iterable[_TerminalGateAlternative],
+        *,
+        fallback_start: str | None,
+        fallback_end: str | None,
+    ) -> tuple[_TerminalGateAlternative, ...]:
+        unique = sorted(
+            set(values),
+            key=lambda value: (
+                value.resolved,
+                value.start or "",
+                value.end or "~",
+                len(value.names),
+                tuple(sorted(value.names)),
+            ),
+        )
+        minimal = [
+            value
+            for value in unique
+            if not any(
+                candidate.start == value.start
+                and candidate.end == value.end
+                and candidate.resolved == value.resolved
+                and candidate.names < value.names
+                for candidate in unique
+            )
+        ]
+        if len(minimal) <= _SOURCE_EXPLICIT_CONDITION_EXPANSION_LIMIT:
+            return tuple(minimal)
+        return tuple(
+            (
+                *minimal[: _SOURCE_EXPLICIT_CONDITION_EXPANSION_LIMIT - 1],
+                _TerminalGateAlternative(
+                    frozenset(),
+                    fallback_start,
+                    fallback_end,
+                    False,
+                ),
+            )
+        )
+
+    def expand_name(
+        name: str,
+        *,
+        start: str | None,
+        end: str | None,
+        stack: frozenset[str],
+    ) -> tuple[_TerminalGateAlternative, ...]:
+        if name in declared_inputs or name in imported_names:
+            return (_TerminalGateAlternative(frozenset({name}), start, end),)
+        if name in stack:
+            return (_TerminalGateAlternative(frozenset(), start, end, False),)
+        if len(stack) >= _SOURCE_EXPLICIT_CONDITION_DEPENDENCY_DEPTH_LIMIT:
+            return (_TerminalGateAlternative(frozenset(), start, end, False),)
+        dependency = named_rules.get(name)
+        if dependency is None:
+            return (_TerminalGateAlternative(frozenset(), start, end, False),)
+        choices: list[_TerminalGateAlternative] = []
+        saw_overlap = False
+        for version_index, formula, version_start, version_end in interval_cache.get(
+            name, ()
+        ):
+            overlap = _formula_interval_intersection(
+                start,
+                end,
+                version_start,
+                version_end,
+            )
+            if overlap is None:
+                continue
+            saw_overlap = True
+            overlap_start, overlap_end = overlap
+            key = (
+                name,
+                version_index,
+                overlap_start,
+                overlap_end,
+            )
+            # Preflight proves the dependency graph acyclic, so an otherwise
+            # identical expansion does not depend on its traversal path.
+            cached = expansion_cache.get(key)
+            if cached is None:
+                cached = expand_formula(
+                    formula,
+                    start=overlap_start,
+                    end=overlap_end,
+                    stack=stack | {name},
+                    include_result_leaves=(
+                        str(dependency.get("dtype") or "").strip().lower()
+                        in {"judgment", "boolean", "bool"}
+                    ),
+                )
+                expansion_cache[key] = cached
+            choices.extend(cached)
+        if not saw_overlap:
+            return (_TerminalGateAlternative(frozenset(), start, end, False),)
+        return bounded_alternatives(
+            choices,
+            fallback_start=start,
+            fallback_end=end,
+        )
+
+    def expand_formula(
+        formula: str,
+        *,
+        start: str | None,
+        end: str | None,
+        stack: frozenset[str],
+        include_result_leaves: bool,
+    ) -> tuple[_TerminalGateAlternative, ...]:
+        expanded_groups: list[_TerminalGateAlternative] = []
+        for selector_group in formula_selector_groups(
+            formula,
+            include_result_leaves=include_result_leaves,
+        ):
+            choices: tuple[_TerminalGateAlternative, ...] = (
+                _TerminalGateAlternative(frozenset(), start, end),
+            )
+            for selector_name in sorted(selector_group):
+                selector_choices = expand_name(
+                    selector_name,
+                    start=start,
+                    end=end,
+                    stack=stack,
+                )
+                combined: list[_TerminalGateAlternative] = []
+                for left in choices:
+                    for right in selector_choices:
+                        overlap = _formula_interval_intersection(
+                            left.start,
+                            left.end,
+                            right.start,
+                            right.end,
+                        )
+                        if overlap is None:
+                            continue
+                        combined.append(
+                            _TerminalGateAlternative(
+                                left.names | right.names,
+                                overlap[0],
+                                overlap[1],
+                                left.resolved and right.resolved,
+                            )
+                        )
+                choices = bounded_alternatives(
+                    combined,
+                    fallback_start=start,
+                    fallback_end=end,
+                )
+            expanded_groups.extend(choices)
+        return bounded_alternatives(
+            expanded_groups,
+            fallback_start=start,
+            fallback_end=end,
+        )
+
+    proof_excerpts: dict[str, dict[int, tuple[str, ...]]] = {}
+    for rule_name, rule in named_rules.items():
+        formula_versions = interval_cache.get(rule_name, ())
+        formula_indexes = {index for index, _formula, _start, _end in formula_versions}
+        by_version: dict[int, list[str]] = {}
+        for path, citation_path, excerpt in _rule_source_excerpt_atoms(rule):
+            if citation_path.strip("/").casefold() != authoritative_path:
+                continue
+            indexed = re.fullmatch(r"versions\[(\d+)\]\.formula", path)
+            if indexed is not None:
+                version_index = int(indexed.group(1))
+                if version_index in formula_indexes:
+                    by_version.setdefault(version_index, []).append(excerpt)
+                continue
+            if path == "versions.formula" and len(formula_indexes) == 1:
+                by_version.setdefault(next(iter(formula_indexes)), []).append(excerpt)
+        proof_excerpts[rule_name] = {
+            index: tuple(dict.fromkeys(excerpts))
+            for index, excerpts in by_version.items()
+        }
+
+    findings: list[tuple[str, int, int, frozenset[str]]] = []
+    for rule_name, rule in sorted(principal_rules.items()):
+        if (
+            str(rule.get("dtype") or "").strip().lower()
+            not in numeric_or_judgment_dtypes
+        ):
+            continue
+        for version_index, formula, start, end in interval_cache.get(rule_name, ()):
+            excerpts = proof_excerpts.get(rule_name, {}).get(version_index, ())
+            gate_sets: dict[
+                tuple[tuple[str, ...], int, int],
+                tuple[tuple[frozenset[str], frozenset[str]], ...],
+            ] = {}
+            ambiguous_ownership = False
+            for excerpt in excerpts:
+                owned_clauses, ambiguous = _source_condition_clauses_owned_by_excerpt(
+                    excerpt,
+                    rule=rule,
+                    source_text=source_text,
+                    branches=branches,
+                    corpus_citation_path=corpus_citation_path,
+                )
+                excerpt_has_gates = False
+                for clause in owned_clauses:
+                    gates = source_clause_gates(clause)
+                    if len(gates) < 2:
+                        continue
+                    excerpt_has_gates = True
+                    gate_sets[(clause.branch_path, clause.start, clause.end)] = gates
+                ambiguous_ownership |= ambiguous and excerpt_has_gates
+            gate_count = max((len(gates) for gates in gate_sets.values()), default=0)
+            if gate_count < 2:
+                continue
+            include_result_leaves = str(rule.get("dtype") or "").strip().lower() in {
+                "judgment",
+                "boolean",
+                "bool",
+            }
+            selector_groups = formula_selector_groups(
+                formula,
+                include_result_leaves=include_result_leaves,
+            )
+            direct_selectors = frozenset().union(*selector_groups)
+            if dependency_expansion_is_bounded(
+                rule_name,
+                formula,
+                include_result_leaves=include_result_leaves,
+                start=start,
+                end=end,
+            ):
+                terminal_choices = expand_formula(
+                    formula,
+                    start=start,
+                    end=end,
+                    stack=frozenset({rule_name}),
+                    include_result_leaves=include_result_leaves,
+                )
+            else:
+                terminal_choices = (
+                    _TerminalGateAlternative(frozenset(), start, end, False),
+                )
+            if not terminal_choices:
+                # A formula that is provably inactive on every path cannot grant
+                # the source benefit while bypassing its factual conditions.
+                continue
+            failing_choices = [
+                choice
+                for choice in terminal_choices
+                if not choice.resolved
+                or any(
+                    not _terminal_names_corroborate_source_gates(
+                        choice.names,
+                        gates,
+                        terminal_evidence=terminal_evidence,
+                        neutral_polarity_imports=frozenset(imported_names),
+                    )
+                    for gates in gate_sets.values()
+                )
+            ]
+            if not failing_choices and not ambiguous_ownership:
+                continue
+            least_supported = min(
+                failing_choices or terminal_choices,
+                key=lambda value: (
+                    value.resolved,
+                    len(value.names),
+                    tuple(sorted(value.names)),
+                ),
+            )
+            findings.append(
+                (
+                    rule_name,
+                    version_index,
+                    gate_count,
+                    direct_selectors | least_supported.names,
+                )
+            )
+    if not findings:
+        return []
+
+    findings.sort(key=lambda item: (item[0], item[1], tuple(sorted(item[3]))))
+    rendered = [
+        f"`{rule_name}` versions[{version_index}] "
+        f"({_bounded_identifier_feedback(tuple(evidence_names)) or 'no resolved fact selectors'} "
+        f"for {gate_count} source gates)"
+        for rule_name, version_index, gate_count, evidence_names in findings[
+            :_SOURCE_EXPLICIT_CONDITION_DIAGNOSTIC_LIMIT
+        ]
+    ]
+    if len(findings) > _SOURCE_EXPLICIT_CONDITION_DIAGNOSTIC_LIMIT:
+        rendered.append(
+            f"... ({len(findings) - _SOURCE_EXPLICIT_CONDITION_DIAGNOSTIC_LIMIT} "
+            "additional formula versions omitted)"
+        )
+    return [
+        "[complete-source-unit:source-explicit-conditions] Derived formula "
+        "version(s) delegate multiple conjunctive factual gates stated in their "
+        "exact authoritative source clause to too few terminal local inputs or "
+        f"canonical imports: {'; '.join(rendered)}. Encode the source-stated facts "
+        "as distinct local inputs or canonical imports, combine them in a "
+        "source-proved derived Judgment, and test each gate. Reserve aggregate "
+        "boundary statuses for source-atomic or externally determined conditions."
+    ]
 
 
 def _direct_local_input_clamps(
@@ -11836,35 +13524,565 @@ def _direct_local_input_clamps(
     return clamped
 
 
+def _selected_rule_formula_is_local_rule_alias(
+    rule: dict[str, Any],
+    *,
+    case: dict[str, Any],
+    principal_rule_names: set[str],
+) -> bool:
+    """Return whether the case-selected formula is a bare local-rule alias."""
+
+    formula = _rule_formula_text_for_case(rule, case)
+    if formula is None:
+        return False
+    return (
+        isinstance(expression := _parse_formula_expression(formula), ast.Name)
+        and expression.id in principal_rule_names
+    )
+
+
+_CLAMP_STRUCTURAL_LEAF_LIMIT = 64
+_CLAMP_TEMPORAL_CONTEXT_LIMIT = 128
+
+
+def _formula_structural_leaves(formula: str) -> tuple[str, ...] | None:
+    """Expand bounded control flow into every computational formula leaf.
+
+    Clamp claimant competition must see an inactive computation branch before
+    the case selector chooses another branch. Returning ``None`` fails closed
+    when a malformed or oversized branch tree cannot be inspected completely.
+    """
+
+    leaves: set[str] = set()
+
+    def expand(text: str, *, depth: int = 0) -> bool:
+        if depth > 32:
+            return False
+        selected_text = text.strip()
+        node = _first_formula_branch_node(selected_text)
+        if node is None:
+            if _rule_text_has_branching_formula(selected_text) or not (
+                _formula_leaf_has_executable_syntax(selected_text)
+            ):
+                return False
+            leaves.add(selected_text)
+            return len(leaves) <= _CLAMP_STRUCTURAL_LEAF_LIMIT
+        if not all(
+            _formula_text_has_executable_branch_tree(selector)
+            for selector in node.selectors
+        ) or not all(
+            _formula_text_has_executable_branch_tree(choice) for choice in node.choices
+        ):
+            return False
+        for choice in node.choices:
+            selected_body = textwrap.dedent(choice).strip()
+            if not selected_body or not expand(
+                selected_text[: node.start] + selected_body + selected_text[node.end :],
+                depth=depth + 1,
+            ):
+                return False
+        return True
+
+    return tuple(sorted(leaves)) if expand(formula) else None
+
+
+def _selected_formula_structural_source_branches(
+    rule: dict[str, Any],
+    *,
+    case: dict[str, Any],
+    formula_branches: Sequence[SourceStructureBranch],
+    source_formula_intervals: Mapping[
+        SourceStructureBranch,
+        _NumericInterval | None,
+    ],
+    formula_environment: dict[str, Any],
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> tuple[SourceStructureBranch, ...]:
+    """Find selected-version source computations without trusting ownership."""
+
+    formula = _rule_formula_text_for_case(rule, case)
+    if formula is None:
+        return ()
+    leaves = _formula_structural_leaves(formula)
+    if leaves is None:
+        return tuple(formula_branches)
+    constant_environment = _formula_environment_for_case(formula_environment, case)
+    candidate_executions = tuple(
+        _FormulaExecution(
+            trace=(),
+            leaf=leaf,
+            evaluated_value=None,
+            evaluates_to_zero=False,
+            constant_environment=constant_environment,
+        )
+        for leaf in leaves
+    )
+    executions = tuple(
+        execution
+        for execution in candidate_executions
+        if _formula_execution_leaf_is_computational(execution)
+    )
+    return tuple(
+        branch
+        for branch in formula_branches
+        if any(
+            _formula_execution_matches_source_branch(
+                execution,
+                branch,
+                interval=source_formula_intervals[branch],
+                formula_environment=formula_environment,
+                execution_environment=constant_environment,
+                extract_numeric_occurrences=extract_numeric_occurrences,
+                numeric_value_is_grounded=numeric_value_is_grounded,
+            )
+            for execution in executions
+        )
+    )
+
+
 def _negative_local_input_clamp_test_issues(
     principal_rules: dict[str, dict[str, Any]],
     *,
+    parameter_rules: Mapping[str, dict[str, Any]],
+    principal_formula_clause_rules: dict[SourceStructureBranch, set[str]],
+    formula_branches: Sequence[SourceStructureBranch],
     cases: Sequence[dict[str, Any]],
     declared_input_names: set[str],
+    formula_environment: dict[str, Any],
+    corpus_citation_path: str,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
 ) -> list[str]:
     """Require negative evidence for direct max(0, local_input) clamps."""
 
-    dependencies = {
-        name: _rule_formula_identifiers(rule) & principal_rules.keys()
-        for name, rule in principal_rules.items()
+    principal_rule_names = set(principal_rules)
+    source_formula_intervals = {
+        branch: _formula_branch_interval(
+            branch,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+        for branch in formula_branches
     }
-    issues: list[str] = []
-    for owner, rule in principal_rules.items():
-        for input_name in sorted(
-            _direct_local_input_clamps(rule, declared_input_names)
-        ):
-            downstream = {
-                candidate
-                for candidate in principal_rules
-                if candidate != owner
-                and _formula_rule_depends_on(
-                    candidate,
-                    owner,
-                    dependencies=dependencies,
+    source_formula_branches_by_rule = {
+        name: tuple(
+            branch
+            for branch in formula_branches
+            if name in principal_formula_clause_rules.get(branch, set())
+        )
+        for name in principal_rules
+    }
+    selected_dependencies_by_period: dict[str, dict[str, set[str]]] = {}
+    selected_source_branches_by_period: dict[
+        str,
+        dict[str, tuple[SourceStructureBranch, ...]],
+    ] = {}
+    selected_structural_source_branches_by_period: dict[
+        str,
+        dict[str, tuple[SourceStructureBranch, ...]],
+    ] = {}
+    asserted_dependencies_by_case: dict[int, dict[str, Any]] = {}
+    execution_environments_by_case: dict[int, dict[str, Any] | None] = {}
+
+    def selected_period_context(
+        case: dict[str, Any],
+    ) -> tuple[
+        dict[str, set[str]],
+        dict[str, tuple[SourceStructureBranch, ...]],
+        dict[str, tuple[SourceStructureBranch, ...]],
+    ]:
+        """Cache selected dependencies, competitors, and proof owners."""
+
+        period = _normalized_case_period(case)
+        if period not in selected_dependencies_by_period:
+            selected_dependencies_by_period[period] = {
+                name: (
+                    set(_FORMULA_IDENTIFIER.findall(formula)) & principal_rule_names
+                    if (formula := _rule_formula_text_for_case(rule, case)) is not None
+                    else set()
+                )
+                for name, rule in principal_rules.items()
+            }
+            selected_source_branches_by_period[period] = {
+                name: tuple(
+                    branch
+                    for branch in owned_branches
+                    if _selected_principal_formula_has_exact_source_proof(
+                        principal_rules[name],
+                        case=case,
+                        branch=branch,
+                        corpus_citation_path=corpus_citation_path,
+                    )
+                )
+                for name, owned_branches in source_formula_branches_by_rule.items()
+                if owned_branches
+                and not _selected_rule_formula_is_local_rule_alias(
+                    principal_rules[name],
+                    case=case,
+                    principal_rule_names=principal_rule_names,
                 )
             }
-            principal_outputs = downstream or {owner}
-            witnessed = False
+            selected_structural_source_branches_by_period[period] = {
+                name: tuple(
+                    dict.fromkeys(
+                        (
+                            *_selected_formula_structural_source_branches(
+                                rule,
+                                case=case,
+                                formula_branches=formula_branches,
+                                source_formula_intervals=source_formula_intervals,
+                                formula_environment=formula_environment,
+                                extract_numeric_occurrences=(
+                                    extract_numeric_occurrences
+                                ),
+                                numeric_value_is_grounded=numeric_value_is_grounded,
+                            ),
+                            *selected_source_branches_by_period[period].get(name, ()),
+                        )
+                    )
+                )
+                for name, rule in principal_rules.items()
+                if not _selected_rule_formula_is_local_rule_alias(
+                    rule,
+                    case=case,
+                    principal_rule_names=principal_rule_names,
+                )
+                and _rule_formula_text_for_case(rule, case) is not None
+            }
+        return (
+            selected_dependencies_by_period[period],
+            selected_structural_source_branches_by_period[period],
+            selected_source_branches_by_period[period],
+        )
+
+    all_version_dependencies = {
+        name: set(_FORMULA_IDENTIFIER.findall(_rule_formula_text(rule)))
+        & principal_rule_names
+        for name, rule in principal_rules.items()
+    }
+    parameter_rule_names = set(parameter_rules)
+
+    def bounded_dependency_closure(
+        seeds: Iterable[str],
+        *,
+        dependencies: Mapping[str, set[str]],
+    ) -> set[str] | None:
+        """Return a bounded principal dependency closure or fail closed."""
+
+        closure: set[str] = set()
+        pending = list(seeds)
+        while pending:
+            current = pending.pop()
+            if current in closure:
+                continue
+            closure.add(current)
+            if len(closure) > _CLAMP_TEMPORAL_CONTEXT_LIMIT:
+                return None
+            pending.extend(dependencies.get(current, set()) - closure)
+        return closure
+
+    def temporal_control_names(
+        rule_formulas: Iterable[tuple[dict[str, Any], str]],
+    ) -> set[str] | None:
+        """Return bounded temporal parameter selectors or fail closed.
+
+        Parameter aliases are already flattened into ``formula_environment``;
+        retaining the selected alias version and value therefore also captures
+        changes in a transitive parameter dependency.  A referenced parameter
+        missing from that environment is ambiguous (including cyclic or
+        oversized alias graphs), so it cannot safely share a clamp witness.
+        """
+
+        selector_names: set[str] = set()
+
+        def clamp_formula_control_names(
+            rule: dict[str, Any],
+            formula: str,
+        ) -> set[str] | None:
+            names: set[str] = set()
+            inspect_boolean_leaf = str(rule.get("dtype") or "").strip().lower() in {
+                "bool",
+                "boolean",
+                "judgment",
+            }
+
+            def inspect(text: str, *, depth: int = 0) -> bool:
+                if depth > 32:
+                    return False
+                node = _first_formula_branch_node(text)
+                if node is None:
+                    if inspect_boolean_leaf:
+                        names.update(_formula_exception_selector_names(text))
+                    return True
+                for selector in node.selectors:
+                    names.update(_exception_condition_names(selector))
+                if not all(
+                    inspect(textwrap.dedent(choice).strip(), depth=depth + 1)
+                    for choice in node.choices
+                ):
+                    return False
+                remainder = text[: node.start] + text[node.end :]
+                return not remainder.strip() or inspect(remainder, depth=depth + 1)
+
+            return names if inspect(formula) else None
+
+        for rule, formula in rule_formulas:
+            formula_selector_names = clamp_formula_control_names(rule, formula)
+            if formula_selector_names is None:
+                return None
+            selector_names.update(formula_selector_names)
+            if len(selector_names) > _CLAMP_TEMPORAL_CONTEXT_LIMIT:
+                return None
+        referenced_parameters = selector_names & parameter_rule_names
+        if any(name not in formula_environment for name in referenced_parameters):
+            return None
+        temporal_names = {
+            name
+            for name in referenced_parameters
+            if isinstance(formula_environment[name], _TemporalFormulaValue)
+        }
+        return (
+            temporal_names
+            if len(temporal_names) <= _CLAMP_TEMPORAL_CONTEXT_LIMIT
+            else None
+        )
+
+    def selected_temporal_control_topology(
+        case: dict[str, Any],
+        *,
+        topology_names: set[str],
+    ) -> tuple[tuple[str, int, str, str], ...] | None:
+        """Identify selected temporal parameter controls for one topology."""
+
+        rule_formulas: list[tuple[dict[str, Any], str]] = []
+        for name in topology_names:
+            rule = principal_rules[name]
+            formula = _rule_formula_text_for_case(rule, case)
+            if formula is None:
+                return None
+            rule_formulas.append((rule, formula))
+        control_names = temporal_control_names(rule_formulas)
+        if control_names is None:
+            return None
+        selected: list[tuple[str, int, str, str]] = []
+        for name in sorted(control_names):
+            temporal_value = formula_environment[name]
+            indexes = _selected_temporal_version_indexes(temporal_value, case)
+            if len(indexes) != 1:
+                return None
+            index = indexes[0]
+            value = temporal_value.versions[index][2]
+            selected.append((name, index, type(value).__name__, repr(value)))
+        return tuple(selected)
+
+    def clamp_context(
+        case: dict[str, Any],
+        *,
+        owner: str,
+        rule: dict[str, Any],
+        input_name: str,
+    ) -> (
+        tuple[
+            tuple[Any, ...],
+            set[str],
+            dict[str, tuple[SourceStructureBranch, ...]],
+            bool,
+        ]
+        | None
+    ):
+        """Return one selected temporal claimant topology for a direct clamp."""
+
+        selected_formula = _rule_formula_text_for_case(rule, case)
+        if selected_formula is None or not any(
+            match.group("input") == input_name
+            for match in _DIRECT_LOCAL_INPUT_NONNEGATIVE_CLAMP.finditer(
+                selected_formula
+            )
+        ):
+            return None
+        (
+            selected_dependencies,
+            selected_structural_source_branches,
+            selected_source_branches,
+        ) = selected_period_context(case)
+        competing_downstream = {
+            candidate
+            for candidate, owned_branches in selected_structural_source_branches.items()
+            if owned_branches
+            and candidate != owner
+            and _formula_rule_depends_on(
+                candidate,
+                owner,
+                dependencies=selected_dependencies,
+            )
+        }
+        downstream_branch_owners: dict[SourceStructureBranch, set[str]] = {}
+        for candidate in competing_downstream:
+            for branch in selected_structural_source_branches[candidate]:
+                downstream_branch_owners.setdefault(branch, set()).add(candidate)
+        unambiguous_downstream_source_branches = {
+            candidate: tuple(
+                branch
+                for branch in selected_source_branches[candidate]
+                if len(downstream_branch_owners.get(branch, ())) == 1
+            )
+            for candidate in competing_downstream & set(selected_source_branches)
+        }
+        downstream = {
+            candidate
+            for candidate, owned_branches in (
+                unambiguous_downstream_source_branches.items()
+            )
+            if owned_branches
+        }
+        principal_outputs = downstream if competing_downstream else {owner}
+
+        topology_names = bounded_dependency_closure(
+            {owner, *competing_downstream},
+            dependencies=selected_dependencies,
+        )
+        if topology_names is None:
+            return ((), set(), {}, False)
+        temporal_control_topology = selected_temporal_control_topology(
+            case,
+            topology_names=topology_names,
+        )
+        if temporal_control_topology is None:
+            return ((), set(), {}, False)
+        dependency_topology = tuple(
+            (
+                name,
+                _selected_rule_formula_version_index(principal_rules[name], case),
+                _rule_formula_text_for_case(principal_rules[name], case),
+                tuple(sorted(selected_dependencies.get(name, set()) & topology_names)),
+            )
+            for name in sorted(topology_names)
+        )
+        claimant_topology = tuple(
+            (
+                candidate,
+                selected_structural_source_branches[candidate],
+                selected_source_branches.get(candidate, ()),
+            )
+            for candidate in sorted(competing_downstream)
+        )
+        return (
+            (
+                dependency_topology,
+                claimant_topology,
+                temporal_control_topology,
+            ),
+            principal_outputs,
+            unambiguous_downstream_source_branches,
+            True,
+        )
+
+    def temporal_context_cases(owner: str) -> tuple[dict[str, str], ...] | None:
+        """Return bounded representatives for owner/downstream change segments."""
+
+        potential_claimants = {
+            name
+            for name in principal_rules
+            if name == owner
+            or _formula_rule_depends_on(
+                name,
+                owner,
+                dependencies=all_version_dependencies,
+            )
+        }
+        potentially_relevant = bounded_dependency_closure(
+            potential_claimants,
+            dependencies=all_version_dependencies,
+        )
+        if potentially_relevant is None:
+            return None
+        all_version_rule_formulas: list[tuple[dict[str, Any], str]] = []
+        for name in potentially_relevant:
+            rule = principal_rules[name]
+            versions = rule.get("versions")
+            if not isinstance(versions, list):
+                return None
+            all_version_rule_formulas.extend(
+                (rule, str(version["formula"]))
+                for version in versions
+                if isinstance(version, dict) and version.get("formula") is not None
+            )
+        all_version_temporal_controls = temporal_control_names(
+            all_version_rule_formulas
+        )
+        if all_version_temporal_controls is None:
+            return None
+        change_points = {
+            period
+            for case in cases
+            if _is_iso_calendar_date(period := _normalized_case_period(case))
+        }
+        for name in potentially_relevant:
+            versions = principal_rules[name].get("versions")
+            if not isinstance(versions, list):
+                continue
+            for version in versions:
+                if not isinstance(version, dict) or version.get("formula") is None:
+                    continue
+                start = str(version.get("effective_from") or "").strip()
+                end = str(version.get("effective_to") or "").strip()
+                if _is_iso_calendar_date(start):
+                    change_points.add(start)
+                if (
+                    end
+                    and _is_iso_calendar_date(end)
+                    and (after_end := _shift_iso_date(end, 1)) is not None
+                ):
+                    change_points.add(after_end)
+                if len(change_points) > _CLAMP_TEMPORAL_CONTEXT_LIMIT:
+                    return None
+        for name in all_version_temporal_controls:
+            temporal_value = formula_environment[name]
+            for start, end, _value in temporal_value.versions:
+                if not _is_iso_calendar_date(start) or (
+                    end and not _is_iso_calendar_date(end)
+                ):
+                    return None
+                change_points.add(start)
+                if end and (after_end := _shift_iso_date(end, 1)) is not None:
+                    change_points.add(after_end)
+                if len(change_points) > _CLAMP_TEMPORAL_CONTEXT_LIMIT:
+                    return None
+        return tuple({"period": point} for point in sorted(change_points))
+
+    missing_clamps: set[tuple[str, str]] = set()
+    for owner, rule in principal_rules.items():
+        clamped_inputs = _direct_local_input_clamps(rule, declared_input_names)
+        if not clamped_inputs:
+            continue
+        context_cases = temporal_context_cases(owner)
+        for input_name in sorted(clamped_inputs):
+            if context_cases is None:
+                missing_clamps.add((owner, input_name))
+                continue
+            required_contexts: set[tuple[Any, ...]] = set()
+            unresolved_context = False
+            for context_case in context_cases:
+                context = clamp_context(
+                    context_case,
+                    owner=owner,
+                    rule=rule,
+                    input_name=input_name,
+                )
+                if context is None:
+                    continue
+                context_key, _outputs, _branches, resolved = context
+                if not resolved:
+                    unresolved_context = True
+                    break
+                required_contexts.add(context_key)
+            if unresolved_context:
+                missing_clamps.add((owner, input_name))
+                continue
+            if not required_contexts:
+                missing_clamps.add((owner, input_name))
+                continue
+            witnessed_contexts: set[tuple[Any, ...]] = set()
             for case in cases:
                 inputs = case.get("input")
                 if not isinstance(inputs, dict):
@@ -11880,28 +14098,127 @@ def _negative_local_input_clamp_test_issues(
                     continue
                 if not _is_iso_calendar_date(_normalized_case_period(case)):
                     continue
-                selected_formula = _rule_formula_text_for_case(rule, case)
-                if selected_formula is None or not any(
-                    match.group("input") == input_name
-                    for match in _DIRECT_LOCAL_INPUT_NONNEGATIVE_CLAMP.finditer(
-                        selected_formula
-                    )
-                ):
+                context = clamp_context(
+                    case,
+                    owner=owner,
+                    rule=rule,
+                    input_name=input_name,
+                )
+                if context is None:
+                    continue
+                (
+                    context_key,
+                    principal_outputs,
+                    unambiguous_branches,
+                    resolved,
+                ) = context
+                if not resolved:
                     continue
                 outputs = _test_case_output_names(case)
-                if owner in outputs and outputs & principal_outputs:
-                    witnessed = True
-                    break
-            if witnessed:
+                if owner not in outputs:
+                    continue
+                case_key = id(case)
+                if case_key not in asserted_dependencies_by_case:
+                    asserted_dependencies_by_case[case_key] = (
+                        _case_asserted_dependency_environment(
+                            principal_rules,
+                            case,
+                            formula_environment=formula_environment,
+                        )
+                    )
+                dependency_environment = asserted_dependencies_by_case[case_key]
+                if owner not in dependency_environment:
+                    continue
+                for principal_output in sorted(outputs & principal_outputs):
+                    if principal_output == owner:
+                        witnessed_contexts.add(context_key)
+                        break
+                    asserted_principal_value = dependency_environment.get(
+                        principal_output,
+                        _UNRESOLVED_CONDITION_VALUE,
+                    )
+                    if asserted_principal_value is _UNRESOLVED_CONDITION_VALUE:
+                        continue
+                    execution = _case_formula_execution(
+                        principal_rules[principal_output],
+                        case,
+                        formula_environment=formula_environment,
+                        dependency_environment=dependency_environment,
+                    )
+                    if execution is None:
+                        continue
+                    executed_principal_value = _formula_execution_runtime_value(
+                        execution
+                    )
+                    if (
+                        executed_principal_value is _UNRESOLVED_CONDITION_VALUE
+                        or not _formula_runtime_values_equal(
+                            executed_principal_value,
+                            asserted_principal_value,
+                        )
+                    ):
+                        continue
+                    if case_key not in execution_environments_by_case:
+                        execution_environments_by_case[case_key] = (
+                            _case_formula_identifier_environment(
+                                case,
+                                formula_environment=formula_environment,
+                                dependency_environment=dependency_environment,
+                            )
+                        )
+                    execution_environment = execution_environments_by_case[case_key]
+                    if execution_environment is None:
+                        continue
+                    if not any(
+                        _formula_execution_matches_source_branch(
+                            execution,
+                            branch,
+                            interval=source_formula_intervals[branch],
+                            formula_environment=formula_environment,
+                            execution_environment=execution_environment,
+                            extract_numeric_occurrences=extract_numeric_occurrences,
+                            numeric_value_is_grounded=numeric_value_is_grounded,
+                        )
+                        for branch in unambiguous_branches[principal_output]
+                    ):
+                        continue
+                    reached_rules = _asserted_reached_rule_executions(
+                        principal_rules[principal_output],
+                        execution,
+                        case=case,
+                        principal_rules=principal_rules,
+                        formula_environment=formula_environment,
+                        dependency_environment=dependency_environment,
+                    )
+                    if any(
+                        reached_rule is principal_rules[owner]
+                        for reached_rule, _reached_execution in reached_rules[1:]
+                    ):
+                        witnessed_contexts.add(context_key)
+                        break
+            if required_contexts <= witnessed_contexts:
                 continue
-            issues.append(
-                "[complete-source-unit:tests] Direct nonnegative clamp "
-                f"`max(0, {input_name})` in `{owner}` requires an executed "
-                f"companion case with `{input_name}` below zero that asserts "
-                f"the clamped rule `{owner}` and a principal output depending "
-                "on it. A zero-valued case does not exercise the negative clamp."
-            )
-    return issues
+            missing_clamps.add((owner, input_name))
+    if not missing_clamps:
+        return []
+    ordered_clamps = sorted(missing_clamps)
+    shown_clamps = ordered_clamps[:_NEGATIVE_LOCAL_INPUT_CLAMP_DIAGNOSTIC_LIMIT]
+    rendered_clamps = ", ".join(
+        f"`max(0, {input_name})` in `{owner}`" for owner, input_name in shown_clamps
+    )
+    omitted = len(ordered_clamps) - len(shown_clamps)
+    omission = f" ({omitted} additional clamps omitted)" if omitted else ""
+    return [
+        "[complete-source-unit:tests] Direct nonnegative clamp companion "
+        f"evidence is missing for {rendered_clamps}{omission}. Each requires "
+        "an executed companion case in every distinct selected temporal "
+        "owner/downstream claimant context, with the input below zero, that "
+        "asserts the clamped rule and, when downstream consumers exist, an "
+        "unambiguous authoritative principal output with selected-version "
+        "formula proof whose matching assertion and selected formula path "
+        "reach it through a resolved dependency chain. A zero-valued case "
+        "does not exercise the negative clamp."
+    ]
 
 
 def _formula_rule_depends_on(
@@ -11926,6 +14243,7 @@ def _formula_rule_depends_on(
 def _companion_test_issues(
     principal_rules: dict[str, dict[str, Any]],
     *,
+    parameter_rules: Mapping[str, dict[str, Any]],
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
     principal_formula_clause_rules: dict[SourceStructureBranch, set[str]],
     formula_branches: Sequence[SourceStructureBranch],
@@ -11978,8 +14296,15 @@ def _companion_test_issues(
     issues.extend(
         _negative_local_input_clamp_test_issues(
             principal_rules,
+            parameter_rules=parameter_rules,
+            principal_formula_clause_rules=principal_formula_clause_rules,
+            formula_branches=formula_branches,
             cases=cases,
             declared_input_names=declared_input_names,
+            formula_environment=formula_environment,
+            corpus_citation_path=corpus_citation_path,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+            numeric_value_is_grounded=numeric_value_is_grounded,
         )
     )
     for name, asserted_cases in asserted_by_rule.items():
@@ -12936,9 +15261,9 @@ def _selected_principal_formula_proves_branch(
     branch_text = _normalized_formula_clause_text(branch.text)
     normalized_citation_path = corpus_citation_path.strip("/").lower()
     matching_atoms = {
-        (int(match.group(1)), citation_path.strip("/").lower())
+        (version_index, citation_path.strip("/").lower())
         for path, citation_path, excerpt in _rule_source_excerpt_atoms(rule)
-        if (match := re.fullmatch(r"versions\[(\d+)\]\.formula", path)) is not None
+        if (version_index := _formula_proof_version_index(path)) is not None
         and (excerpt_text := _normalized_formula_clause_text(excerpt))
         and (excerpt_text in branch_text or branch_text in excerpt_text)
     }
@@ -12951,6 +15276,31 @@ def _selected_principal_formula_proves_branch(
     }
     selected_index = _selected_rule_formula_version_index(rule, case)
     return selected_index is not None and selected_index in matching_indexes
+
+
+def _selected_principal_formula_has_exact_source_proof(
+    rule: dict[str, Any],
+    *,
+    case: dict[str, Any],
+    branch: SourceStructureBranch,
+    corpus_citation_path: str,
+) -> bool:
+    """Require normalized same-source formula proof on the selected version."""
+
+    selected_index = _selected_rule_formula_version_index(rule, case)
+    if selected_index is None:
+        return False
+    branch_text = _normalized_formula_clause_text(branch.text)
+    normalized_citation_path = corpus_citation_path.strip("/").casefold()
+    return any(
+        version_index == selected_index
+        and citation_path.strip("/").casefold() == normalized_citation_path
+        and (excerpt_text := _normalized_formula_clause_text(excerpt))
+        and (excerpt_text in branch_text or branch_text in excerpt_text)
+        and source_states_explicit_computation(excerpt)
+        for path, citation_path, excerpt in _rule_source_excerpt_atoms(rule)
+        if (version_index := _formula_proof_version_index(path)) is not None
+    )
 
 
 def _formula_leaf_temporal_bindings(
@@ -22180,7 +24530,12 @@ def _formula_execution_reaches_selector(
 def _rule_exception_selector_names(rule: dict[str, Any]) -> set[str]:
     """Return formula identifiers used as boolean control selectors."""
 
-    formula_text = _rule_formula_text(rule)
+    return _formula_exception_selector_names(_rule_formula_text(rule))
+
+
+def _formula_exception_selector_names(formula_text: str) -> set[str]:
+    """Return boolean-control identifiers from one formula text."""
+
     selector_names: set[str] = set()
 
     def record(name: str) -> None:
@@ -22230,6 +24585,221 @@ def _rule_exception_selector_names(rule: dict[str, Any]) -> set[str]:
 
     inspect(formula_text)
     return selector_names
+
+
+def _formula_control_selector_name_groups(
+    formula_text: str,
+    *,
+    include_result_leaves: bool = False,
+) -> tuple[frozenset[str], ...]:
+    """Return every active control path, omitting constant-inactive leaves."""
+
+    def bounded_groups(
+        values: Iterable[frozenset[str]],
+    ) -> tuple[frozenset[str], ...]:
+        unique = sorted(
+            set(values), key=lambda value: (len(value), tuple(sorted(value)))
+        )
+        minimal = [
+            value
+            for value in unique
+            if not any(candidate < value for candidate in unique)
+        ]
+        if len(minimal) <= _SOURCE_EXPLICIT_CONDITION_EXPANSION_LIMIT:
+            return tuple(minimal)
+        return tuple(
+            dict.fromkeys(
+                (
+                    *minimal[: _SOURCE_EXPLICIT_CONDITION_EXPANSION_LIMIT - 1],
+                    frozenset(),
+                )
+            )
+        )
+
+    def node_names(expression: ast.AST) -> frozenset[str]:
+        function_names = {
+            node.func.id
+            for node in ast.walk(expression)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        return frozenset(
+            node.id
+            for node in ast.walk(expression)
+            if isinstance(node, ast.Name)
+            and node.id.lower() not in {"true", "false", "holds", "not_holds"}
+            and node.id not in function_names
+        )
+
+    def combine(
+        left: tuple[frozenset[str], ...],
+        right: tuple[frozenset[str], ...],
+    ) -> tuple[frozenset[str], ...]:
+        if not left or not right:
+            return ()
+        return bounded_groups(a | b for a in left for b in right)
+
+    def outcome_groups(
+        expression: ast.expr,
+        *,
+        truth: bool,
+        depth: int = 0,
+    ) -> tuple[frozenset[str], ...]:
+        if depth > _SOURCE_EXPLICIT_CONDITION_AST_DEPTH_LIMIT:
+            return (frozenset(),)
+        if isinstance(expression, ast.Constant):
+            return (frozenset(),) if bool(expression.value) is truth else ()
+        if isinstance(expression, ast.Name):
+            if expression.id.lower() in {"true", "false"}:
+                value = expression.id.lower() == "true"
+                return (frozenset(),) if value is truth else ()
+            return (frozenset({expression.id}),)
+        if isinstance(expression, ast.UnaryOp) and isinstance(expression.op, ast.Not):
+            return outcome_groups(
+                expression.operand,
+                truth=not truth,
+                depth=depth + 1,
+            )
+        if isinstance(expression, ast.BoolOp):
+            values = tuple(expression.values)
+            if isinstance(expression.op, ast.And):
+                if truth:
+                    groups: tuple[frozenset[str], ...] = (frozenset(),)
+                    for value in values:
+                        groups = combine(
+                            groups,
+                            outcome_groups(value, truth=True, depth=depth + 1),
+                        )
+                    return groups
+                alternatives: list[frozenset[str]] = []
+                prefix: tuple[frozenset[str], ...] = (frozenset(),)
+                for value in values:
+                    alternatives.extend(
+                        combine(
+                            prefix,
+                            outcome_groups(value, truth=False, depth=depth + 1),
+                        )
+                    )
+                    prefix = combine(
+                        prefix,
+                        outcome_groups(value, truth=True, depth=depth + 1),
+                    )
+                    if not prefix:
+                        break
+                return bounded_groups(alternatives)
+            if isinstance(expression.op, ast.Or):
+                if not truth:
+                    groups = (frozenset(),)
+                    for value in values:
+                        groups = combine(
+                            groups,
+                            outcome_groups(value, truth=False, depth=depth + 1),
+                        )
+                    return groups
+                alternatives = []
+                prefix = (frozenset(),)
+                for value in values:
+                    alternatives.extend(
+                        combine(
+                            prefix,
+                            outcome_groups(value, truth=True, depth=depth + 1),
+                        )
+                    )
+                    prefix = combine(
+                        prefix,
+                        outcome_groups(value, truth=False, depth=depth + 1),
+                    )
+                    if not prefix:
+                        break
+                return bounded_groups(alternatives)
+        if (
+            isinstance(expression, ast.Call)
+            and isinstance(expression.func, ast.Name)
+            and len(expression.args) == 1
+            and not expression.keywords
+            and expression.func.id in {"holds", "not_holds"}
+        ):
+            return outcome_groups(
+                expression.args[0],
+                truth=truth if expression.func.id == "holds" else not truth,
+                depth=depth + 1,
+            )
+        return (node_names(expression),)
+
+    def condition_groups(
+        condition: str,
+        *,
+        truth: bool,
+    ) -> tuple[frozenset[str], ...]:
+        expression = _parse_formula_expression(condition)
+        if expression is None:
+            names = frozenset(_exception_condition_names(condition))
+            return (names,)
+        return outcome_groups(expression, truth=truth)
+
+    def inspect(
+        text: str,
+        *,
+        include_leaves: bool,
+        depth: int = 0,
+    ) -> tuple[frozenset[str], ...]:
+        if depth > 32:
+            return (frozenset(),)
+        node = _first_formula_branch_node(text)
+        if node is None:
+            value = _evaluate_formula_selector(text, {})
+            number = _rulespec_runtime_decimal(value)
+            if value is False or number is not None and number == 0:
+                return ()
+            if not include_leaves:
+                return (frozenset(),)
+            expression = _parse_formula_expression(text)
+            return (
+                outcome_groups(expression, truth=True)
+                if expression is not None
+                else (frozenset(),)
+            )
+
+        choice_groups: list[frozenset[str]] = []
+        for choice_index, choice in enumerate(node.choices):
+            if node.kind == "if":
+                selector_groups: tuple[frozenset[str], ...] = (frozenset(),)
+                for selector_index, selector in enumerate(node.selectors):
+                    selector_groups = combine(
+                        selector_groups,
+                        condition_groups(
+                            selector,
+                            truth=(
+                                choice_index < len(node.selectors)
+                                and selector_index == choice_index
+                            ),
+                        ),
+                    )
+                    if not selector_groups or selector_index >= choice_index:
+                        break
+            else:
+                selector_groups = (
+                    frozenset().union(
+                        *(
+                            _exception_condition_names(selector)
+                            for selector in node.selectors
+                        )
+                    ),
+                )
+            selected_text = (
+                text[: node.start] + textwrap.dedent(choice).strip() + text[node.end :]
+            )
+            nested_groups = inspect(
+                selected_text,
+                include_leaves=include_leaves,
+                depth=depth + 1,
+            )
+            choice_groups.extend(combine(selector_groups, nested_groups))
+        return bounded_groups(choice_groups)
+
+    return inspect(
+        formula_text,
+        include_leaves=include_result_leaves,
+    )
 
 
 def _exception_condition_names(condition: str) -> set[str]:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1670"
+ENCODER_VERSION = "0.2.1671"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1670"
+ENCODER_VERSION = "0.2.1671"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1670"
+ENCODER_VERSION = "0.2.1671"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_live_run_telemetry.py
+++ b/tests/test_live_run_telemetry.py
@@ -95,7 +95,7 @@ class TestLiveRunTelemetry:
                 citation="us/statute/26/32",
                 backend="codex",
                 model="gpt-5.5",
-                encoder_version="0.2.1670",
+                encoder_version="0.2.1671",
             ) as live:
                 live.set_attempt(2, "gpt-5.5-max")
                 live.finish("completed", run_id="abc12345")

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1670"
+ENCODER_VERSION = "0.2.1671"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1670"
+ENCODER_VERSION = "0.2.1671"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1670"
+ENCODER_VERSION = "0.2.1671"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1670"
+ENCODER_VERSION = "0.2.1671"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6216,7 +6216,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1670"')
+        .startswith('__version__ = "0.2.1671"')
     )
 
 
@@ -6448,13 +6448,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1670"
+    assert encoder_package["version"] == "0.2.1671"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1670"
+    assert project["project"]["version"] == "0.2.1671"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1670"')
+        .startswith('__version__ = "0.2.1671"')
     )
 
 
@@ -6716,13 +6716,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1670"
+    assert encoder_package["version"] == "0.2.1671"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1670"
+    assert project["project"]["version"] == "0.2.1671"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1670"')
+        .startswith('__version__ = "0.2.1671"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1670"
+ENCODER_VERSION = "0.2.1671"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -106,6 +106,2290 @@ def _pipeline_issues(
     )
 
 
+KY_SPOUSE_CREDIT_SOURCE = """\
+(3) (a) The following tax credits apply:
+5. An additional forty dollars ($40) credit for the taxpayer's spouse if a
+separate return is made by the taxpayer and if the taxpayer's spouse has
+attained the age of sixty-five before the close of the taxable year, and has
+no Kentucky gross income and is not the dependent of another taxpayer;
+7. An additional forty dollars ($40) credit for the taxpayer's spouse if a
+separate return is made by the taxpayer and if the taxpayer's spouse is blind,
+and has no Kentucky gross income and is not the dependent of another taxpayer.
+"""
+KY_CITATION_PATH = "us-ky/statute/krs/141.020/document-1"
+
+
+def _ky_formula_proof(
+    excerpt: str,
+    *,
+    kind: str = "formula",
+) -> dict[str, object]:
+    return {
+        "proof": {
+            "atoms": [
+                {
+                    "path": "versions[0].formula",
+                    "kind": kind,
+                    "source": {
+                        "corpus_citation_path": KY_CITATION_PATH,
+                        "excerpt": excerpt,
+                    },
+                }
+            ]
+        }
+    }
+
+
+def _ky_derived_rule(
+    name: str,
+    *,
+    source: str,
+    formula: str,
+    excerpt: str,
+    dtype: str = "Money",
+) -> dict[str, object]:
+    rule: dict[str, object] = {
+        "name": name,
+        "kind": "derived",
+        "entity": "TaxUnit",
+        "dtype": dtype,
+        "period": "Year",
+        "source": source,
+        "metadata": _ky_formula_proof(excerpt),
+        "versions": [{"effective_from": "2026-01-01", "formula": formula}],
+    }
+    if dtype == "Money":
+        rule["unit"] = "USD"
+    return rule
+
+
+def _ky_boolean_input(name: str, description: str) -> dict[str, str]:
+    return {
+        "name": name,
+        "entity": "TaxUnit",
+        "dtype": "Boolean",
+        "period": "Year",
+        "description": description,
+    }
+
+
+def _ky_spouse_credit_payload(*, decomposed: bool) -> dict[str, object]:
+    amount = {
+        "name": "spouse_credit_amount",
+        "kind": "parameter",
+        "dtype": "Money",
+        "period": "Year",
+        "unit": "USD",
+        "source": "KRS 141.020(3)(a)5.",
+        "metadata": _ky_formula_proof(
+            "An additional forty dollars ($40) credit for the taxpayer's spouse",
+            kind="amount",
+        ),
+        "versions": [{"effective_from": "2026-01-01", "formula": "40"}],
+    }
+    age_excerpt = (
+        "An additional forty dollars ($40) credit for the taxpayer's spouse "
+        "if a separate return is made by the taxpayer"
+    )
+    if decomposed:
+        condition = "spouse_age_credit_applies"
+        rules = [
+            amount,
+            _ky_derived_rule(
+                condition,
+                source="KRS 141.020(3)(a)5.",
+                dtype="Judgment",
+                formula=(
+                    "taxpayer_files_separate_return "
+                    "and spouse_has_attained_age_sixty_five "
+                    "and spouse_has_no_kentucky_gross_income "
+                    "and spouse_is_not_another_taxpayers_dependent"
+                ),
+                excerpt=KY_SPOUSE_CREDIT_SOURCE.split("7.", 1)[0].split("5.", 1)[1],
+            ),
+        ]
+        inputs = [
+            _ky_boolean_input(name, description)
+            for name, description in (
+                ("taxpayer_files_separate_return", "The taxpayer files separately."),
+                ("spouse_has_attained_age_sixty_five", "The spouse is age 65."),
+                ("spouse_has_no_kentucky_gross_income", "The spouse has no income."),
+                (
+                    "spouse_is_not_another_taxpayers_dependent",
+                    "The spouse is not another taxpayer's dependent.",
+                ),
+            )
+        ]
+    else:
+        condition = "spouse_age_credit_conditions_hold"
+        rules = [amount]
+        inputs = [
+            _ky_boolean_input(
+                "spouse_age_credit_conditions_hold",
+                "All conditions in KRS 141.020(3)(a)5 hold.",
+            ),
+            _ky_boolean_input(
+                "spouse_blindness_credit_conditions_hold",
+                "All conditions in KRS 141.020(3)(a)7 hold.",
+            ),
+        ]
+    rules.append(
+        _ky_derived_rule(
+            "spouse_age_credit",
+            source="KRS 141.020(3)(a)5.",
+            formula=f"if {condition}: spouse_credit_amount else: 0",
+            excerpt=age_excerpt,
+        )
+    )
+    if not decomposed:
+        rules.append(
+            _ky_derived_rule(
+                "spouse_blindness_credit",
+                source="KRS 141.020(3)(a)7.",
+                formula=(
+                    "if spouse_blindness_credit_conditions_hold: "
+                    "spouse_credit_amount else: 0"
+                ),
+                excerpt=(age_excerpt + " and if the taxpayer's spouse is blind"),
+            )
+        )
+    return {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": rules,
+        "inputs": inputs,
+    }
+
+
+def _ky_fact_gate_analysis(
+    fact_clause: str,
+    *,
+    terminal_name: str,
+    terminal_description: str,
+    imported: bool = False,
+):
+    source = (
+        "A forty dollar ($40) credit applies if the taxpayer files a separate "
+        f"return and {fact_clause}."
+    )
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": [
+            _ky_derived_rule(
+                "income_gate_credit",
+                source="KRS 141.020",
+                formula=(
+                    f"if taxpayer_files_separate_return and {terminal_name}: 40 else: 0"
+                ),
+                excerpt=source.rstrip("."),
+            )
+        ],
+        "inputs": [
+            _ky_boolean_input(
+                "taxpayer_files_separate_return",
+                "The taxpayer files a separate return.",
+            ),
+        ]
+        + (
+            [] if imported else [_ky_boolean_input(terminal_name, terminal_description)]
+        ),
+    }
+    if imported:
+        payload["imports"] = [f"us-ky:statutes/facts#{terminal_name}"]
+    return _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+
+def _ky_income_gate_analysis(
+    income_clause: str,
+    *,
+    terminal_name: str,
+    terminal_description: str,
+):
+    return _ky_fact_gate_analysis(
+        f"the spouse {income_clause}",
+        terminal_name=terminal_name,
+        terminal_description=terminal_description,
+    )
+
+
+def test_rejects_aggregate_boolean_for_same_source_spouse_credit_gates():
+    content = yaml.safe_dump(
+        _ky_spouse_credit_payload(decomposed=False),
+        sort_keys=False,
+    )
+    result = _analyze(
+        content,
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "spouse_age_credit_conditions_hold",
+    )
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "spouse_blindness_credit_conditions_hold",
+    )
+    assert any(
+        "source-explicit-conditions" in issue
+        for issue in _pipeline_issues(
+            content,
+            KY_SPOUSE_CREDIT_SOURCE,
+            corpus_citation_path=KY_CITATION_PATH,
+            test_cases=[],
+        )
+    )
+
+
+def test_rejects_aggregate_boolean_hidden_behind_same_source_judgment():
+    payload = _ky_spouse_credit_payload(decomposed=False)
+    spouse_age_credit = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit"
+    )
+    spouse_age_credit["versions"][0]["formula"] = (
+        "if spouse_age_credit_applies: spouse_credit_amount else: 0"
+    )
+    payload["rules"].insert(
+        -2,
+        {
+            "name": "spouse_age_credit_applies",
+            "kind": "derived",
+            "entity": "TaxUnit",
+            "dtype": "Judgment",
+            "period": "Year",
+            "source": "KRS 141.020(3)(a)5.",
+            "metadata": _ky_formula_proof(
+                "An additional forty dollars ($40) credit for the taxpayer's "
+                "spouse if a separate return is made by the taxpayer"
+            ),
+            "versions": [
+                {
+                    "effective_from": "2026-01-01",
+                    "formula": "spouse_age_credit_conditions_hold",
+                }
+            ],
+        },
+    )
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "spouse_age_credit_applies",
+        "spouse_age_credit_conditions_hold",
+    )
+
+
+def test_accepts_decomposed_facts_for_same_source_spouse_credit_gates():
+    result = _analyze(
+        yaml.safe_dump(_ky_spouse_credit_payload(decomposed=True), sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+@pytest.mark.parametrize(
+    "proof_path",
+    ("versions.formula", " versions [ 0 ] . formula "),
+)
+def test_formula_proof_path_normalization_cannot_bypass_source_gates(proof_path):
+    payload = _ky_spouse_credit_payload(decomposed=False)
+    spouse_age_credit = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit"
+    )
+    spouse_age_credit["metadata"]["proof"]["atoms"][0]["path"] = proof_path
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "spouse_age_credit_conditions_hold",
+    )
+
+
+def test_negative_source_gates_reject_positive_opposites():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    applies = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit_applies"
+    )
+    applies["versions"][0]["formula"] = (
+        "taxpayer_files_separate_return "
+        "and spouse_has_attained_age_sixty_five "
+        "and spouse_has_kentucky_gross_income "
+        "and spouse_is_another_taxpayers_dependent"
+    )
+    payload["inputs"] = [
+        _ky_boolean_input(name, description)
+        for name, description in (
+            ("taxpayer_files_separate_return", "The taxpayer files separately."),
+            ("spouse_has_attained_age_sixty_five", "The spouse is age 65."),
+            ("spouse_has_kentucky_gross_income", "The spouse has income."),
+            (
+                "spouse_is_another_taxpayers_dependent",
+                "The spouse is another taxpayer's dependent.",
+            ),
+        )
+    ]
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions")
+
+
+def test_positive_executable_name_cannot_borrow_negative_description_polarity():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    applies = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit_applies"
+    )
+    applies["versions"][0]["formula"] = (
+        "taxpayer_files_separate_return "
+        "and spouse_has_attained_age_sixty_five "
+        "and spouse_has_kentucky_gross_income "
+        "and spouse_is_not_another_taxpayers_dependent"
+    )
+    income_input = next(
+        item
+        for item in payload["inputs"]
+        if item["name"] == "spouse_has_no_kentucky_gross_income"
+    )
+    income_input["name"] = "spouse_has_kentucky_gross_income"
+    income_input["description"] = "The spouse has no Kentucky gross income."
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions")
+
+
+@pytest.mark.parametrize(
+    ("income_clause", "positive_name", "positive_description"),
+    (
+        (
+            "does not receive Kentucky gross income",
+            "spouse_receives_kentucky_gross_income",
+            "The spouse receives Kentucky gross income.",
+        ),
+        (
+            "does not earn Kentucky gross income",
+            "spouse_earns_kentucky_gross_income",
+            "The spouse earns Kentucky gross income.",
+        ),
+        (
+            "is without Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+        (
+            "doesn't receive Kentucky gross income",
+            "spouse_receives_kentucky_gross_income",
+            "The spouse receives Kentucky gross income.",
+        ),
+        (
+            "lacks Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+        (
+            "lack Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+        (
+            "has zero Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+        (
+            "has an absence of Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+        (
+            "is not in receipt of Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+        (
+            "never receives Kentucky gross income",
+            "spouse_receives_kentucky_gross_income",
+            "The spouse receives Kentucky gross income.",
+        ),
+        (
+            "fails to receive Kentucky gross income",
+            "spouse_receives_kentucky_gross_income",
+            "The spouse receives Kentucky gross income.",
+        ),
+        (
+            "has no earnings",
+            "spouse_has_earnings",
+            "The spouse has earnings.",
+        ),
+        (
+            "has 0 Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+        (
+            "has nil Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+        (
+            "is devoid of Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+    ),
+)
+def test_negative_income_source_forms_reject_positive_opposites(
+    income_clause: str,
+    positive_name: str,
+    positive_description: str,
+):
+    result = _ky_income_gate_analysis(
+        income_clause,
+        terminal_name=positive_name,
+        terminal_description=positive_description,
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", positive_name)
+
+
+@pytest.mark.parametrize(
+    ("income_clause", "negative_name", "negative_description"),
+    (
+        (
+            "does not receive Kentucky gross income",
+            "spouse_does_not_receive_kentucky_gross_income",
+            "The spouse does not receive Kentucky gross income.",
+        ),
+        (
+            "does not earn Kentucky gross income",
+            "spouse_does_not_earn_kentucky_gross_income",
+            "The spouse does not earn Kentucky gross income.",
+        ),
+        (
+            "is without Kentucky gross income",
+            "spouse_is_without_kentucky_gross_income",
+            "The spouse is without Kentucky gross income.",
+        ),
+        (
+            "doesn't receive Kentucky gross income",
+            "spouse_doesn_t_receive_kentucky_gross_income",
+            "The spouse doesn't receive Kentucky gross income.",
+        ),
+        (
+            "lacks Kentucky gross income",
+            "spouse_lacks_kentucky_gross_income",
+            "The spouse lacks Kentucky gross income.",
+        ),
+        (
+            "lack Kentucky gross income",
+            "spouse_lack_kentucky_gross_income",
+            "The spouse lacks Kentucky gross income.",
+        ),
+        (
+            "has zero Kentucky gross income",
+            "spouse_has_zero_kentucky_gross_income",
+            "The spouse has zero Kentucky gross income.",
+        ),
+        (
+            "has an absence of Kentucky gross income",
+            "spouse_has_an_absence_of_kentucky_gross_income",
+            "The spouse has an absence of Kentucky gross income.",
+        ),
+        (
+            "is not in receipt of Kentucky gross income",
+            "spouse_is_not_in_receipt_of_kentucky_gross_income",
+            "The spouse is not in receipt of Kentucky gross income.",
+        ),
+        (
+            "never receives Kentucky gross income",
+            "spouse_never_receives_kentucky_gross_income",
+            "The spouse never receives Kentucky gross income.",
+        ),
+        (
+            "fails to receive Kentucky gross income",
+            "spouse_fails_to_receive_kentucky_gross_income",
+            "The spouse fails to receive Kentucky gross income.",
+        ),
+        (
+            "has no earnings",
+            "spouse_has_no_earnings",
+            "The spouse has no earnings.",
+        ),
+        (
+            "has 0 Kentucky gross income",
+            "spouse_has_0_kentucky_gross_income",
+            "The spouse has 0 Kentucky gross income.",
+        ),
+        (
+            "has nil Kentucky gross income",
+            "spouse_has_nil_kentucky_gross_income",
+            "The spouse has nil Kentucky gross income.",
+        ),
+        (
+            "is devoid of Kentucky gross income",
+            "spouse_is_devoid_of_kentucky_gross_income",
+            "The spouse is devoid of Kentucky gross income.",
+        ),
+    ),
+)
+def test_negative_income_source_forms_accept_matching_terminals(
+    income_clause: str,
+    negative_name: str,
+    negative_description: str,
+):
+    result = _ky_income_gate_analysis(
+        income_clause,
+        terminal_name=negative_name,
+        terminal_description=negative_description,
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_not_only_does_not_negate_positive_income_description():
+    result = _ky_income_gate_analysis(
+        "has Kentucky gross income",
+        terminal_name="spouse_income_fact",
+        terminal_description="The spouse not only has Kentucky gross income.",
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+@pytest.mark.parametrize(
+    ("dependent_clause", "negative_name", "negative_description"),
+    (
+        (
+            "cannot be claimed as another taxpayer's dependent",
+            "spouse_cannot_be_claimed_as_another_taxpayers_dependent",
+            "The spouse cannot be claimed as another taxpayer's dependent.",
+        ),
+        (
+            "can't be claimed as another taxpayer's dependent",
+            "spouse_can_t_be_claimed_as_another_taxpayers_dependent",
+            "The spouse can't be claimed as another taxpayer's dependent.",
+        ),
+        (
+            "is ineligible to be claimed as another taxpayer's dependent",
+            "spouse_is_ineligible_to_be_claimed_as_another_taxpayers_dependent",
+            ("The spouse is ineligible to be claimed as another taxpayer's dependent."),
+        ),
+        (
+            "is unable to be claimed as another taxpayer's dependent",
+            "spouse_is_unable_to_be_claimed_as_another_taxpayers_dependent",
+            ("The spouse is unable to be claimed as another taxpayer's dependent."),
+        ),
+    ),
+)
+def test_negative_dependent_source_forms_accept_matching_terminals(
+    dependent_clause: str,
+    negative_name: str,
+    negative_description: str,
+):
+    result = _ky_fact_gate_analysis(
+        f"the spouse {dependent_clause}",
+        terminal_name=negative_name,
+        terminal_description=negative_description,
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+@pytest.mark.parametrize(
+    "dependent_clause",
+    (
+        "cannot be claimed as another taxpayer's dependent",
+        "can't be claimed as another taxpayer's dependent",
+        "is ineligible to be claimed as another taxpayer's dependent",
+        "is unable to be claimed as another taxpayer's dependent",
+    ),
+)
+def test_negative_dependent_source_forms_reject_positive_opposites(
+    dependent_clause: str,
+):
+    positive_name = "spouse_can_be_claimed_as_another_taxpayers_dependent"
+    result = _ky_fact_gate_analysis(
+        f"the spouse {dependent_clause}",
+        terminal_name=positive_name,
+        terminal_description=(
+            "The spouse can be claimed as another taxpayer's dependent."
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", positive_name)
+
+
+@pytest.mark.parametrize(
+    ("fact_clause", "positive_name", "positive_description"),
+    (
+        (
+            "the spouse is not without Kentucky gross income",
+            "spouse_has_kentucky_gross_income",
+            "The spouse has Kentucky gross income.",
+        ),
+        (
+            "it is not true that the spouse does not receive Kentucky gross income",
+            "spouse_receives_kentucky_gross_income",
+            "The spouse receives Kentucky gross income.",
+        ),
+    ),
+)
+def test_double_negative_income_sources_accept_positive_terminals(
+    fact_clause: str,
+    positive_name: str,
+    positive_description: str,
+):
+    result = _ky_fact_gate_analysis(
+        fact_clause,
+        terminal_name=positive_name,
+        terminal_description=positive_description,
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "The spouse is not without Kentucky gross income.",
+        ("It is not true that the spouse does not receive Kentucky gross income."),
+    ),
+)
+def test_double_negative_income_parity_is_explicitly_positive(text: str):
+    assert completeness_module._source_gate_explicit_polarities(text) == {
+        "income": False
+    }
+
+
+@pytest.mark.parametrize(
+    "double_negative_description",
+    (
+        "The spouse is not without Kentucky gross income.",
+        ("It is not true that the spouse does not receive Kentucky gross income."),
+    ),
+)
+def test_double_negative_descriptions_do_not_conflict_with_positive_names(
+    double_negative_description: str,
+):
+    result = _ky_income_gate_analysis(
+        "has Kentucky gross income",
+        terminal_name="spouse_has_kentucky_gross_income",
+        terminal_description=double_negative_description,
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        (
+            "It is not true that the spouse is blind. "
+            "The spouse does not receive income."
+        ),
+        (
+            "It is not true that the spouse is blind; "
+            "the spouse does not receive income."
+        ),
+        (
+            "It is not true that the spouse is blind whereas "
+            "the spouse does not receive income."
+        ),
+        (
+            "It is not true that the spouse is blind and "
+            "the spouse does not receive income."
+        ),
+        (
+            "It is not true that the spouse is blind, yet "
+            "the spouse does not receive income."
+        ),
+    ),
+)
+def test_sentential_negation_does_not_cross_clause_boundaries(text: str):
+    assert completeness_module._source_gate_predicate_polarities(text) == {
+        "income": True
+    }
+
+
+def test_independent_yet_clause_rejects_opposite_income_terminal():
+    result = _ky_fact_gate_analysis(
+        ("it is not true that the spouse is blind, yet the spouse has no income"),
+        terminal_name="spouse_has_income",
+        terminal_description="The spouse has income.",
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", "spouse_has_income")
+
+
+def test_independent_yet_separates_conjunctive_fact_gates():
+    gates = completeness_module._source_conjunctive_fact_gates(
+        "A credit applies if the spouse is blind, yet the spouse has no income."
+    )
+
+    assert gates == (
+        (frozenset({"spouse"}), frozenset({"blind"})),
+        (frozenset({"spouse"}), frozenset({"no_income"})),
+    )
+
+
+@pytest.mark.parametrize(
+    "income_clause",
+    (
+        "has not yet received income",
+        "does not yet receive income",
+        "has yet to receive income",
+        "has yet to actually receive income",
+        "has not yet legally actually formally finally received income",
+    ),
+)
+def test_temporal_yet_income_cannot_corroborate_positive_terminal(income_clause):
+    text = f"The spouse {income_clause}."
+
+    assert completeness_module._source_gate_polarity_clauses(text) == (
+        text.casefold().rstrip("."),
+    )
+    assert completeness_module._source_gate_predicate_polarities(text) == {
+        "income": None
+    }
+
+    result = _ky_income_gate_analysis(
+        income_clause,
+        terminal_name="spouse_has_income",
+        terminal_description="The spouse has income.",
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", "spouse_has_income")
+
+
+@pytest.mark.parametrize(
+    "dependent_clause",
+    (
+        "is not yet claimed as another taxpayer's dependent",
+        "has yet to be claimed as another taxpayer's dependent",
+        "is not yet eligible to be claimed as another taxpayer's dependent",
+        "has yet to lawfully be claimed as another taxpayer's dependent",
+        (
+            "is not yet legally actually formally finally claimed as another "
+            "taxpayer's dependent"
+        ),
+    ),
+)
+def test_temporal_yet_dependent_cannot_corroborate_positive_terminal(
+    dependent_clause,
+):
+    text = f"The spouse {dependent_clause}."
+
+    assert completeness_module._source_gate_polarity_clauses(text) == (
+        text.casefold().rstrip("."),
+    )
+    assert completeness_module._source_gate_predicate_polarities(text) == {
+        "dependent": None
+    }
+
+    terminal_name = "spouse_is_another_taxpayers_dependent"
+    result = _ky_fact_gate_analysis(
+        f"the spouse {dependent_clause}",
+        terminal_name=terminal_name,
+        terminal_description="The spouse is another taxpayer's dependent.",
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", terminal_name)
+
+
+@pytest.mark.parametrize(
+    "independent_subject",
+    (
+        "the surviving spouse",
+        "the elderly surviving resident spouse",
+        "the elderly long-term surviving resident spouse",
+        "she",
+        "they",
+    ),
+)
+def test_independent_yet_with_bounded_subject_rejects_outer_negation_bypass(
+    independent_subject,
+):
+    fact_clause = (
+        "it is not true that the applicant is blind, yet "
+        f"{independent_subject} has no income"
+    )
+
+    assert completeness_module._source_gate_predicate_polarities(fact_clause) == {
+        "income": True
+    }
+    assert (
+        completeness_module._source_conjunctive_fact_gate_count(
+            f"A credit applies if the applicant is blind, yet "
+            f"{independent_subject} has no income."
+        )
+        == 2
+    )
+
+    result = _ky_fact_gate_analysis(
+        fact_clause,
+        terminal_name="spouse_has_income",
+        terminal_description="The spouse has income.",
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", "spouse_has_income")
+
+
+def test_ambiguous_yet_subject_scan_exhaustion_fails_closed():
+    fact_clause = (
+        "it is not true that the applicant is blind, yet the first second third "
+        "fourth fifth sixth seventh eighth spouse has no income"
+    )
+
+    assert completeness_module._source_gate_predicate_polarities(fact_clause) == {
+        "income": None
+    }
+    assert (
+        completeness_module._source_conjunctive_fact_gate_count(
+            f"A credit applies if {fact_clause}."
+        )
+        == 2
+    )
+
+    result = _ky_fact_gate_analysis(
+        fact_clause,
+        terminal_name="spouse_has_income",
+        terminal_description="The spouse has income.",
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", "spouse_has_income")
+
+
+def test_conflicting_income_readings_are_unknown():
+    assert completeness_module._source_gate_predicate_polarities(
+        "The spouse has income and the spouse has no income."
+    ) == {"income": None}
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    (
+        ("The spouse obtains income.", {"income": None}),
+        ("The spouse supports a dependent.", {"dependent": None}),
+    ),
+)
+def test_unsupported_predicate_constructions_are_unknown(
+    text: str,
+    expected: dict[str, None],
+):
+    assert completeness_module._source_gate_predicate_polarities(text) == expected
+
+
+def test_out_of_window_income_negation_is_unknown_and_cannot_corroborate():
+    padding = " ".join(f"qualification{index}" for index in range(20))
+    fact_clause = f"the spouse has no {padding} income"
+    assert completeness_module._source_gate_predicate_polarities(fact_clause) == {
+        "income": None
+    }
+
+    result = _ky_fact_gate_analysis(
+        fact_clause,
+        terminal_name="spouse_has_no_income",
+        terminal_description="The spouse has no income.",
+    )
+
+    assert _has_issue(result, "source-explicit-conditions")
+
+
+@pytest.mark.parametrize(
+    ("wrong_name", "wrong_description"),
+    (
+        (
+            "spouse_has_no_proof_of_income",
+            "The spouse has no proof of income.",
+        ),
+        (
+            "spouse_has_no_documentation_of_income",
+            "The spouse has no documentation of income.",
+        ),
+        (
+            "spouse_has_no_income_report",
+            "The spouse has no income report.",
+        ),
+        (
+            "spouse_has_zero_income_tax",
+            "The spouse has zero income tax.",
+        ),
+        (
+            "spouse_does_not_report_income",
+            "The spouse does not report income.",
+        ),
+        (
+            "spouse_income_is_not_taxed",
+            "The spouse's income is not taxed.",
+        ),
+    ),
+)
+def test_income_mention_in_wrong_predicate_cannot_corroborate_gate(
+    wrong_name: str,
+    wrong_description: str,
+):
+    result = _ky_income_gate_analysis(
+        "has no Kentucky gross income",
+        terminal_name=wrong_name,
+        terminal_description=wrong_description,
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", wrong_name)
+
+
+@pytest.mark.parametrize(
+    ("wrong_name", "wrong_description"),
+    (
+        (
+            "spouse_has_no_dependent_report",
+            "The spouse has no dependent report.",
+        ),
+        (
+            "spouse_does_not_live_with_a_dependent",
+            "The spouse does not live with a dependent.",
+        ),
+        (
+            "spouse_is_not_responsible_for_a_dependent",
+            "The spouse is not responsible for a dependent.",
+        ),
+    ),
+)
+def test_dependent_mention_in_wrong_predicate_cannot_corroborate_gate(
+    wrong_name: str,
+    wrong_description: str,
+):
+    result = _ky_fact_gate_analysis(
+        "the spouse is not another taxpayer's dependent",
+        terminal_name=wrong_name,
+        terminal_description=wrong_description,
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", wrong_name)
+
+
+@pytest.mark.parametrize(
+    ("fact_clause", "negative_name", "negative_description"),
+    (
+        (
+            "the spouse has Kentucky gross income",
+            "spouse_has_no_kentucky_gross_income",
+            "The spouse has no Kentucky gross income.",
+        ),
+        (
+            "the spouse is another taxpayer's dependent",
+            "spouse_is_not_another_taxpayers_dependent",
+            "The spouse is not another taxpayer's dependent.",
+        ),
+    ),
+)
+@pytest.mark.parametrize("imported", (False, True), ids=("input", "import"))
+def test_positive_source_gates_reject_negative_terminals_and_imports(
+    fact_clause: str,
+    negative_name: str,
+    negative_description: str,
+    imported: bool,
+):
+    result = _ky_fact_gate_analysis(
+        fact_clause,
+        terminal_name=negative_name,
+        terminal_description=negative_description,
+        imported=imported,
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", negative_name)
+
+
+def test_gate_named_administrative_review_padding_is_rejected():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    applies = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit_applies"
+    )
+    padded_names = (
+        "taxpayer_return_review_complete",
+        "spouse_age_review_complete",
+        "spouse_income_review_complete",
+        "spouse_dependency_review_complete",
+    )
+    applies["versions"][0]["formula"] = " and ".join(padded_names)
+    payload["inputs"] = [
+        _ky_boolean_input(name, "The administrative review is complete.")
+        for name in padded_names
+    ]
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions")
+
+
+def test_source_stated_administrative_gates_accept_matching_terminals():
+    source = (
+        "A determination applies if the return review is complete and the spouse "
+        "age review is complete."
+    )
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": [
+            _ky_derived_rule(
+                "review_determination",
+                source="KRS 141.020",
+                dtype="Judgment",
+                formula=("return_review_complete and spouse_age_review_complete"),
+                excerpt=source.rstrip("."),
+            )
+        ],
+        "inputs": [
+            _ky_boolean_input(
+                "return_review_complete",
+                "The return review is complete.",
+            ),
+            _ky_boolean_input(
+                "spouse_age_review_complete",
+                "The spouse age review is complete.",
+            ),
+        ],
+    }
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_accepts_nested_decomposed_same_source_fact_gates():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    applies = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit_applies"
+    )
+    applies["versions"][0]["formula"] = """\
+if taxpayer_files_separate_return:
+  if spouse_has_attained_age_sixty_five and spouse_has_no_kentucky_gross_income and spouse_is_not_another_taxpayers_dependent:
+    true
+  else:
+    false
+else:
+  false
+"""
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_rejects_opaque_active_conditional_alternative():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    applies = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit_applies"
+    )
+    applies["versions"][0]["formula"] = """\
+if use_decomposed_path:
+  taxpayer_files_separate_return and spouse_has_attained_age_sixty_five and spouse_has_no_kentucky_gross_income and spouse_is_not_another_taxpayers_dependent
+else:
+  opaque_spouse_status
+"""
+    payload["inputs"].extend(
+        [
+            _ky_boolean_input("use_decomposed_path", "Selects an implementation path."),
+            _ky_boolean_input("opaque_spouse_status", "Provided with the filing."),
+        ]
+    )
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "opaque_spouse_status",
+    )
+
+
+def test_accepts_constant_false_conditional_alternative():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    applies = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit_applies"
+    )
+    applies["versions"][0]["formula"] = """\
+if use_decomposed_path:
+  taxpayer_files_separate_return and spouse_has_attained_age_sixty_five and spouse_has_no_kentucky_gross_income and spouse_is_not_another_taxpayers_dependent
+else:
+  false and opaque_spouse_status
+"""
+    payload["inputs"].extend(
+        [
+            _ky_boolean_input("use_decomposed_path", "Selects an implementation path."),
+            _ky_boolean_input("opaque_spouse_status", "Provided with the filing."),
+        ]
+    )
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_rejects_opaque_alias_temporal_partition():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    applies = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit_applies"
+    )
+    applies["versions"] = [
+        applies["versions"][0] | {"effective_to": "2026-12-31"},
+        {
+            "effective_from": "2027-01-01",
+            "formula": "opaque_spouse_status",
+        },
+    ]
+    payload["inputs"].append(
+        _ky_boolean_input("opaque_spouse_status", "Provided with the filing.")
+    )
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "opaque_spouse_status",
+    )
+
+
+def test_accepts_aggregate_boundary_for_source_atomic_external_status():
+    source = """\
+(1) A forty dollar ($40) credit applies if all eligibility conditions under
+Section 99 are certified by the department.
+"""
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {KY_CITATION_PATH}
+rules:
+  - name: externally_certified_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Section 99 certification clause
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: {KY_CITATION_PATH}
+              excerpt: "A forty dollar ($40) credit applies if all eligibility conditions under Section 99 are certified by the department"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 'if external_eligibility_conditions_hold: 40 else: 0'
+inputs:
+  - name: external_eligibility_conditions_hold
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: All eligibility conditions under Section 99 hold as certified by the department.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_rejects_renamed_neutral_aggregate_same_source_gate():
+    payload = _ky_spouse_credit_payload(decomposed=False)
+    replacements = {
+        "spouse_age_credit_conditions_hold": "status_alpha",
+        "spouse_blindness_credit_conditions_hold": "status_beta",
+    }
+    for rule in payload["rules"]:
+        for version in rule.get("versions", []):
+            formula = version.get("formula")
+            if isinstance(formula, str):
+                for old, new in replacements.items():
+                    formula = formula.replace(old, new)
+                version["formula"] = formula
+    for item in payload["inputs"]:
+        item["name"] = replacements[item["name"]]
+        item["description"] = "Provided with the filing."
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", "status_alpha")
+    assert _has_issue(result, "source-explicit-conditions", "status_beta")
+
+
+def test_rejects_partial_collapse_of_same_source_fact_gates():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    applies = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit_applies"
+    )
+    applies["versions"][0]["formula"] = (
+        "taxpayer_files_separate_return and remaining_status"
+    )
+    payload["inputs"] = [
+        item
+        for item in payload["inputs"]
+        if item["name"] == "taxpayer_files_separate_return"
+    ]
+    payload["inputs"].append(
+        _ky_boolean_input("remaining_status", "Provided with the filing.")
+    )
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "taxpayer_files_separate_return",
+        "remaining_status",
+    )
+
+
+def test_rejects_proofless_alias_to_opaque_same_source_gate():
+    payload = _ky_spouse_credit_payload(decomposed=False)
+    spouse_age_credit = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit"
+    )
+    spouse_age_credit["versions"][0]["formula"] = (
+        "if filing_status_alias: spouse_credit_amount else: 0"
+    )
+    payload["rules"].insert(
+        -2,
+        {
+            "name": "filing_status_alias",
+            "kind": "derived",
+            "entity": "TaxUnit",
+            "dtype": "Judgment",
+            "period": "Year",
+            "versions": [
+                {
+                    "effective_from": "2026-01-01",
+                    "formula": "spouse_age_credit_conditions_hold",
+                }
+            ],
+        },
+    )
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "filing_status_alias",
+        "spouse_age_credit_conditions_hold",
+    )
+
+
+def test_unrelated_later_source_sentence_does_not_contaminate_atomic_gate():
+    source = """\
+(1) A forty dollar ($40) credit applies if certification_status holds.
+A separate return must be filed and the spouse must be blind and have no income.
+"""
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": [
+            _ky_derived_rule(
+                "certified_credit",
+                source="KRS 141.020(1)",
+                formula="if external_conditions_hold: 40 else: 0",
+                excerpt=(
+                    "A forty dollar ($40) credit applies if certification_status holds"
+                ),
+            )
+        ],
+        "inputs": [
+            _ky_boolean_input(
+                "external_conditions_hold",
+                "All eligibility conditions are satisfied.",
+            )
+        ],
+    }
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_later_independent_condition_in_same_sentence_does_not_contaminate():
+    source = (
+        "A credit applies if certification status holds, and an applicant "
+        "qualifies if employed and owns a home."
+    )
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": [
+            _ky_derived_rule(
+                "certified_credit",
+                source="KRS 141.020",
+                formula="if external_certification_status: 40 else: 0",
+                excerpt="A credit applies if certification status holds",
+            )
+        ],
+        "inputs": [
+            _ky_boolean_input(
+                "external_certification_status",
+                "Certification status supplied by the department.",
+            )
+        ],
+    }
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_elided_subject_later_condition_does_not_contaminate_atomic_proposition():
+    source = (
+        "A credit applies if certification status holds, and is refundable if "
+        "the applicant is employed and owns a home."
+    )
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": [
+            _ky_derived_rule(
+                "certified_credit",
+                source="KRS 141.020",
+                formula="if external_certification_status: 40 else: 0",
+                excerpt="A credit applies if certification status holds",
+            )
+        ],
+        "inputs": [
+            _ky_boolean_input(
+                "external_certification_status",
+                "Certification status supplied by the department.",
+            )
+        ],
+    }
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_elided_has_later_condition_does_not_contaminate_atomic_proposition():
+    source = (
+        "A credit applies if certification status holds, and has a bonus if the "
+        "applicant is employed and owns a home."
+    )
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": [
+            _ky_derived_rule(
+                "certified_credit",
+                source="KRS 141.020",
+                formula="if external_certification_status: 40 else: 0",
+                excerpt="A credit applies if certification status holds",
+            )
+        ],
+        "inputs": [
+            _ky_boolean_input(
+                "external_certification_status",
+                "Certification status supplied by the department.",
+            )
+        ],
+    }
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_repeated_excerpt_is_disambiguated_by_rule_source_path():
+    source = """\
+(1) A credit applies if the claimant is employed and owns a home.
+(2) A credit applies if the claimant is insured and has income.
+"""
+    citation_path = "us-ky/statute/krs/141.999/document-1"
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": citation_path}},
+        "rules": [
+            {
+                **_ky_derived_rule(
+                    "employment_home_credit",
+                    source="KRS 141.999(1)",
+                    formula=(
+                        "if claimant_is_employed and claimant_owns_home: 40 else: 0"
+                    ),
+                    excerpt="A credit applies",
+                ),
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "formula",
+                                "source": {
+                                    "corpus_citation_path": citation_path,
+                                    "excerpt": "A credit applies",
+                                },
+                            }
+                        ]
+                    }
+                },
+            }
+        ],
+        "inputs": [
+            _ky_boolean_input("claimant_is_employed", "The claimant is employed."),
+            _ky_boolean_input("claimant_owns_home", "The claimant owns a home."),
+        ],
+    }
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=citation_path,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+    payload["rules"][0]["source"] = "KRS 141.999"
+    ambiguous = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=citation_path,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(ambiguous, "source-explicit-conditions")
+
+
+def test_generic_conjunctive_predicates_require_distinct_matching_facts():
+    source = (
+        "A credit applies if the claimant is employed and owns a home and has "
+        "health insurance."
+    )
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": [
+            _ky_derived_rule(
+                "generic_credit",
+                source="KRS 141.020",
+                formula="if generic_status: 40 else: 0",
+                excerpt=source.rstrip("."),
+            )
+        ],
+        "inputs": [_ky_boolean_input("generic_status", "Provided with the filing.")],
+    }
+
+    opaque = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+    assert _has_issue(opaque, "source-explicit-conditions", "generic_status")
+
+    payload["rules"][0]["versions"][0]["formula"] = (
+        "if claimant_is_employed and claimant_owns_home "
+        "and claimant_has_health_insurance: 40 else: 0"
+    )
+    payload["inputs"] = [
+        _ky_boolean_input(name, name.replace("_", " "))
+        for name in (
+            "claimant_is_employed",
+            "claimant_owns_home",
+            "claimant_has_health_insurance",
+        )
+    ]
+    decomposed = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+    assert not _has_issue(decomposed, "source-explicit-conditions")
+
+
+def test_repeated_same_category_predicates_require_entity_correspondence():
+    source = "A credit applies if the taxpayer has income and the spouse has no income."
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": [
+            _ky_derived_rule(
+                "two_income_credit",
+                source="KRS 141.020",
+                formula="if taxpayer_has_income and spouse_has_no_income: 40 else: 0",
+                excerpt=source.rstrip("."),
+            )
+        ],
+        "inputs": [
+            _ky_boolean_input("taxpayer_has_income", "The taxpayer has income."),
+            _ky_boolean_input("spouse_has_no_income", "The spouse has no income."),
+        ],
+    }
+
+    aligned = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+    assert not _has_issue(aligned, "source-explicit-conditions")
+
+    payload["rules"][0]["versions"][0]["formula"] = (
+        "if taxpayer_has_income and taxpayer_income_reviewed: 40 else: 0"
+    )
+    payload["inputs"][1] = _ky_boolean_input(
+        "taxpayer_income_reviewed",
+        "The taxpayer income record was reviewed.",
+    )
+    mismatched = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+    assert _has_issue(mismatched, "source-explicit-conditions")
+
+
+def test_unrelated_boolean_padding_does_not_satisfy_gate_cardinality():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    applies = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit_applies"
+    )
+    applies["versions"][0]["formula"] = (
+        "taxpayer_files_separate_return and administrative_review_complete "
+        "and document_scan_complete and supervisor_signoff_complete"
+    )
+    payload["inputs"] = [
+        item
+        for item in payload["inputs"]
+        if item["name"] == "taxpayer_files_separate_return"
+    ] + [
+        _ky_boolean_input(name, "Administrative workflow status.")
+        for name in (
+            "administrative_review_complete",
+            "document_scan_complete",
+            "supervisor_signoff_complete",
+        )
+    ]
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions")
+
+
+def test_gate_terminal_matching_is_bounded_for_dense_unsatisfied_graph():
+    gate_count = completeness_module._SOURCE_EXPLICIT_CONDITION_EXPANSION_LIMIT
+    gates = tuple(
+        (frozenset(), frozenset({"gross", "income"})) for _index in range(gate_count)
+    )
+    names = frozenset(f"income_fact_{index}" for index in range(gate_count - 1))
+    terminal_evidence = {
+        name: completeness_module._TerminalGateEvidence(
+            frozenset(),
+            frozenset({"gross", "income"}),
+            False,
+        )
+        for name in names
+    }
+
+    assert not completeness_module._terminal_names_corroborate_source_gates(
+        names,
+        gates,
+        terminal_evidence=terminal_evidence,
+    )
+
+
+def _same_source_gate_graph_payload(
+    formulas: dict[str, str],
+) -> tuple[dict[str, object], str, dict[str, object]]:
+    source = "A credit applies if the spouse is blind and the spouse has no income."
+    root = _ky_derived_rule(
+        "deep_gate_root",
+        source="KRS 141.020",
+        formula="gate_alias_0",
+        excerpt=source,
+        dtype="Judgment",
+    )
+    aliases = [
+        {
+            "name": name,
+            "kind": "derived",
+            "entity": "TaxUnit",
+            "dtype": "Judgment",
+            "period": "Year",
+            "versions": [
+                {
+                    "effective_from": "2026-01-01",
+                    "formula": formula,
+                }
+            ],
+        }
+        for name, formula in formulas.items()
+    ]
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": [root, *aliases],
+        "inputs": [
+            _ky_boolean_input("spouse_is_blind", "The spouse is blind."),
+            _ky_boolean_input(
+                "spouse_has_no_income",
+                "The spouse has no income.",
+            ),
+        ],
+    }
+    return payload, source, root
+
+
+def _same_source_gate_alias_chain_issues(
+    alias_count: int,
+    *,
+    cyclic: bool = False,
+):
+    formulas = {
+        f"gate_alias_{index}": (
+            "gate_alias_0"
+            if cyclic and index == alias_count - 1
+            else f"gate_alias_{index + 1}"
+            if index < alias_count - 1
+            else "spouse_is_blind and spouse_has_no_income"
+        )
+        for index in range(alias_count)
+    }
+    payload, source, root = _same_source_gate_graph_payload(formulas)
+    return completeness_module._opaque_same_source_condition_input_issues(
+        payload,
+        source_text=source,
+        branches=recognize_source_structure(source),
+        principal_rules={"deep_gate_root": root},
+        corpus_citation_path=KY_CITATION_PATH,
+    )
+
+
+def test_source_gate_dependency_expansion_accepts_deep_chain_within_budget():
+    assert not _same_source_gate_alias_chain_issues(
+        completeness_module._SOURCE_EXPLICIT_CONDITION_DEPENDENCY_NODE_LIMIT // 2
+    )
+
+
+def test_source_gate_dependency_expansion_fails_closed_on_oversized_chain():
+    assert _same_source_gate_alias_chain_issues(1200)
+
+
+def test_source_gate_dependency_expansion_preserves_cycle_fail_closed():
+    assert _same_source_gate_alias_chain_issues(2, cyclic=True)
+
+
+def test_source_gate_dependency_cycle_cannot_borrow_sibling_terminals():
+    payload, source, root = _same_source_gate_graph_payload(
+        {
+            "gate_alias_0": "gate_alias_1 and spouse_is_blind",
+            "gate_alias_1": "gate_alias_0 and spouse_has_no_income",
+        }
+    )
+
+    issues = completeness_module._opaque_same_source_condition_input_issues(
+        payload,
+        source_text=source,
+        branches=recognize_source_structure(source),
+        principal_rules={"deep_gate_root": root},
+        corpus_citation_path=KY_CITATION_PATH,
+    )
+
+    assert any("source-explicit-conditions" in issue for issue in issues)
+
+
+def test_source_gate_dependency_cycle_fails_closed_end_to_end():
+    payload, source, _root = _same_source_gate_graph_payload(
+        {
+            "gate_alias_0": "gate_alias_1 and spouse_is_blind",
+            "gate_alias_1": "gate_alias_0 and spouse_has_no_income",
+        }
+    )
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions")
+
+
+def test_source_gate_dependency_expansion_accepts_shared_acyclic_dag():
+    payload, source, root = _same_source_gate_graph_payload(
+        {
+            "gate_alias_0": "left_gate_alias and right_gate_alias",
+            "left_gate_alias": "shared_gate_alias and spouse_is_blind",
+            "right_gate_alias": "shared_gate_alias and spouse_has_no_income",
+            "shared_gate_alias": "spouse_is_blind",
+        }
+    )
+
+    issues = completeness_module._opaque_same_source_condition_input_issues(
+        payload,
+        source_text=source,
+        branches=recognize_source_structure(source),
+        principal_rules={"deep_gate_root": root},
+        corpus_citation_path=KY_CITATION_PATH,
+    )
+
+    assert not issues
+
+
+def test_source_gate_dependency_expansion_ignores_future_cycle_edge():
+    payload, source, root = _same_source_gate_graph_payload(
+        {
+            "gate_alias_0": "gate_alias_1",
+            "gate_alias_1": "spouse_is_blind and spouse_has_no_income",
+        }
+    )
+    root["versions"][0]["effective_to"] = "2026-12-31"
+    alias_0, alias_1 = payload["rules"][1:]
+    alias_0["versions"][0]["effective_to"] = "2026-12-31"
+    alias_1["versions"] = [
+        {
+            "effective_from": "2026-01-01",
+            "effective_to": "2026-12-31",
+            "formula": "spouse_is_blind and spouse_has_no_income",
+        },
+        {
+            "effective_from": "2027-01-01",
+            "formula": "gate_alias_0",
+        },
+    ]
+
+    issues = completeness_module._opaque_same_source_condition_input_issues(
+        payload,
+        source_text=source,
+        branches=recognize_source_structure(source),
+        principal_rules={"deep_gate_root": root},
+        corpus_citation_path=KY_CITATION_PATH,
+    )
+
+    assert not issues
+
+
+def test_source_gate_dependency_expansion_accepts_temporally_acyclic_slices():
+    payload, source, root = _same_source_gate_graph_payload(
+        {
+            "gate_alias_0": "gate_alias_1",
+            "gate_alias_1": "spouse_is_blind and spouse_has_no_income",
+        }
+    )
+    alias_0, alias_1 = payload["rules"][1:]
+    alias_0["versions"] = [
+        {
+            "effective_from": "2026-01-01",
+            "effective_to": "2026-12-31",
+            "formula": "gate_alias_1",
+        },
+        {
+            "effective_from": "2027-01-01",
+            "formula": "spouse_is_blind and spouse_has_no_income",
+        },
+    ]
+    alias_1["versions"] = [
+        {
+            "effective_from": "2026-01-01",
+            "effective_to": "2026-12-31",
+            "formula": "spouse_is_blind and spouse_has_no_income",
+        },
+        {
+            "effective_from": "2027-01-01",
+            "formula": "gate_alias_0",
+        },
+    ]
+
+    issues = completeness_module._opaque_same_source_condition_input_issues(
+        payload,
+        source_text=source,
+        branches=recognize_source_structure(source),
+        principal_rules={"deep_gate_root": root},
+        corpus_citation_path=KY_CITATION_PATH,
+    )
+
+    assert not issues
+
+
+def test_formula_control_selector_outcomes_accept_nesting_within_budget():
+    groups = completeness_module._formula_control_selector_name_groups(
+        "not " * (completeness_module._SOURCE_EXPLICIT_CONDITION_AST_DEPTH_LIMIT // 2)
+        + "spouse_is_blind",
+        include_result_leaves=True,
+    )
+
+    assert groups == (frozenset({"spouse_is_blind"}),)
+
+
+def test_formula_control_selector_outcomes_fail_closed_on_oversized_nesting():
+    groups = completeness_module._formula_control_selector_name_groups(
+        "not " * 1000 + "spouse_is_blind",
+        include_result_leaves=True,
+    )
+
+    assert groups == (frozenset(),)
+
+
+def test_same_source_gate_proof_binds_matching_temporal_formula_version():
+    payload = _ky_spouse_credit_payload(decomposed=False)
+    age_rule = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit"
+    )
+    payload["rules"] = [
+        rule
+        for rule in payload["rules"]
+        if rule["name"] not in {"spouse_blindness_credit"}
+    ]
+    payload["inputs"] = [payload["inputs"][0]] + [
+        _ky_boolean_input(name, "One source-stated fact.")
+        for name in (
+            "taxpayer_files_separate_return",
+            "spouse_has_attained_age_sixty_five",
+            "spouse_has_no_kentucky_gross_income",
+            "spouse_is_not_another_taxpayers_dependent",
+        )
+    ]
+    decomposed_formula = (
+        "if taxpayer_files_separate_return "
+        "and spouse_has_attained_age_sixty_five "
+        "and spouse_has_no_kentucky_gross_income "
+        "and spouse_is_not_another_taxpayers_dependent: "
+        "spouse_credit_amount else: 0"
+    )
+    age_rule["versions"] = [
+        {
+            "effective_from": "2025-01-01",
+            "effective_to": "2025-12-31",
+            "formula": (
+                "if spouse_age_credit_conditions_hold: spouse_credit_amount else: 0"
+            ),
+        },
+        {"effective_from": "2026-01-01", "formula": decomposed_formula},
+    ]
+    age_rule["metadata"] = {
+        "proof": {
+            "atoms": [
+                {
+                    "path": "versions[1].formula",
+                    "kind": "formula",
+                    "source": {
+                        "corpus_citation_path": KY_CITATION_PATH,
+                        "excerpt": (
+                            "An additional forty dollars ($40) credit for the "
+                            "taxpayer's spouse if a separate return is made by the "
+                            "taxpayer"
+                        ),
+                    },
+                }
+            ]
+        }
+    }
+
+    aligned = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(aligned, "source-explicit-conditions")
+
+    age_rule["versions"][1]["formula"] = age_rule["versions"][0]["formula"]
+    matching_opaque = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        matching_opaque,
+        "source-explicit-conditions",
+        "versions[1]",
+        "spouse_age_credit_conditions_hold",
+    )
+
+
+def test_accepts_distinct_imports_for_same_source_fact_gates():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    age_rule = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit"
+    )
+    payload["rules"] = [
+        rule
+        for rule in payload["rules"]
+        if rule["name"] not in {"spouse_age_credit_applies"}
+    ]
+    imported_facts = (
+        "separate_return_fact",
+        "spouse_age_fact",
+        "spouse_income_fact",
+        "spouse_dependency_fact",
+    )
+    payload["imports"] = [f"us-ky:statutes/facts#{name}" for name in imported_facts]
+    payload["inputs"] = []
+    age_rule["versions"][0]["formula"] = (
+        f"if {' and '.join(imported_facts)}: spouse_credit_amount else: 0"
+    )
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+@pytest.mark.parametrize(
+    ("neutral_name", "positive_name"),
+    (
+        ("spouse_income_fact", "spouse_receives_income_fact"),
+        ("spouse_income_fact", "spouse_earns_income_fact"),
+        ("spouse_dependency_fact", "spouse_claimed_dependent_fact"),
+    ),
+)
+def test_explicit_positive_import_names_are_not_polarity_neutral(
+    neutral_name: str,
+    positive_name: str,
+):
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    age_rule = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit"
+    )
+    payload["rules"] = [
+        rule for rule in payload["rules"] if rule["name"] != "spouse_age_credit_applies"
+    ]
+    imported_facts = [
+        "separate_return_fact",
+        "spouse_age_fact",
+        "spouse_income_fact",
+        "spouse_dependency_fact",
+    ]
+    imported_facts[imported_facts.index(neutral_name)] = positive_name
+    payload["imports"] = [f"us-ky:statutes/facts#{name}" for name in imported_facts]
+    payload["inputs"] = []
+    age_rule["versions"][0]["formula"] = (
+        f"if {' and '.join(imported_facts)}: spouse_credit_amount else: 0"
+    )
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", positive_name)
+
+
+def test_same_source_gate_diagnostics_are_grouped_capped_and_cached(monkeypatch):
+    source_excerpt = (
+        "An additional forty dollars ($40) credit for the taxpayer's spouse "
+        "if a separate return is made by the taxpayer"
+    )
+    rules = [
+        _ky_derived_rule(
+            f"credit_{index:02d}",
+            source="KRS 141.020(3)(a)5.",
+            formula="if status_flag: 40 else: 0",
+            excerpt=source_excerpt,
+        )
+        for index in range(10)
+    ]
+    payload = {
+        "format": "rulespec/v1",
+        "module": {"source_verification": {"corpus_citation_path": KY_CITATION_PATH}},
+        "rules": rules,
+        "inputs": [_ky_boolean_input("status_flag", "Provided with the filing.")],
+    }
+    selector_calls = 0
+    gate_calls = 0
+    original = completeness_module._formula_control_selector_name_groups
+    original_gate_scan = completeness_module._source_conjunctive_fact_gates
+
+    def counted(formula, **kwargs):
+        nonlocal selector_calls
+        selector_calls += 1
+        return original(formula, **kwargs)
+
+    def counted_gate_scan(source_clause):
+        nonlocal gate_calls
+        gate_calls += 1
+        return original_gate_scan(source_clause)
+
+    monkeypatch.setattr(
+        completeness_module,
+        "_formula_control_selector_name_groups",
+        counted,
+    )
+    monkeypatch.setattr(
+        completeness_module,
+        "_source_conjunctive_fact_gates",
+        counted_gate_scan,
+    )
+    principal = {rule["name"]: rule for rule in rules}
+    issues = completeness_module._opaque_same_source_condition_input_issues(
+        payload,
+        source_text=KY_SPOUSE_CREDIT_SOURCE,
+        branches=recognize_source_structure(KY_SPOUSE_CREDIT_SOURCE),
+        principal_rules=principal,
+        corpus_citation_path=KY_CITATION_PATH,
+    )
+
+    assert len(issues) == 1
+    assert "credit_00" in issues[0]
+    assert "credit_07" in issues[0]
+    assert "credit_08" not in issues[0]
+    assert "2 additional formula versions omitted" in issues[0]
+    assert selector_calls == 1
+    assert gate_calls == 1
+
+
 def _formula_test(
     name: str,
     taxable_income: int,
@@ -1237,6 +3521,14 @@ rules:
     period: Year
     unit: USD
     source: us-al/statute/40-18-5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: The tax is two percent of taxable income not in excess of $500.
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -1250,6 +3542,575 @@ inputs:
 """
     return _analyze(
         content,
+        source,
+        corpus_citation_path="us-al/statute/40-18-5",
+        test_cases=test_cases,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+
+def _al_owner_only_direct_input_clamp_analysis(
+    test_cases,
+    *,
+    include_future_consumer=False,
+    owner_open_ended=False,
+):
+    source = "Taxable income is the greater of completed taxable income or zero."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-al/statute/40-18-5
+rules:
+  - name: taxable_income_boundary
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: us-al/statute/40-18-5
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, completed_taxable_income)
+inputs:
+  - name: completed_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+"""
+    if include_future_consumer or owner_open_ended:
+        payload = yaml.safe_load(content)
+        if owner_open_ended:
+            payload["rules"][0]["versions"][0].pop("effective_to")
+    if include_future_consumer:
+        payload["rules"].append(
+            {
+                "name": "future_taxable_income_report",
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+                "source": "us-al/statute/40-18-5",
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "formula",
+                                "source": {
+                                    "corpus_citation_path": ("us-al/statute/40-18-5"),
+                                    "excerpt": (
+                                        "Taxable income is the greater of "
+                                        "completed taxable income or zero."
+                                    ),
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [
+                    {
+                        "effective_from": "2027-01-01",
+                        "effective_to": "2027-12-31",
+                        "formula": "taxable_income_boundary * 1",
+                    }
+                ],
+            }
+        )
+    if include_future_consumer or owner_open_ended:
+        content = yaml.safe_dump(payload, sort_keys=False)
+    return _analyze(
+        content,
+        source,
+        corpus_citation_path="us-al/statute/40-18-5",
+        test_cases=test_cases,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+
+def _al_gated_direct_input_clamp_analysis(
+    test_cases,
+    *,
+    include_shadow_helper=False,
+    shadow_claims_source=False,
+    include_copied_shadow=False,
+    copied_shadow_copies_proof=False,
+    include_unresolved_cycle=False,
+    schedule_proof_path="versions[0].formula",
+    schedule_has_proof=True,
+    schedule_claims_source=True,
+):
+    source = (
+        "The tax applies to a resident and is two percent of taxable income "
+        "not in excess of $500."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-al/statute/40-18-5
+rules:
+  - name: first_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0.02
+  - name: taxable_income_boundary
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: us-al/statute/40-18-5
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, completed_taxable_income)
+  - name: resident_tax_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: us-al/statute/40-18-5
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: taxpayer_is_resident
+  - name: schedule_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: us-al/statute/40-18-5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: The tax applies to a resident and is two percent of taxable income not in excess of $500.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if resident_tax_applies:
+            first_rate * min(taxable_income_boundary, 500)
+          else: 0
+inputs:
+  - name: completed_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+  - name: taxpayer_is_resident
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+"""
+    payload = yaml.safe_load(content)
+    schedule = next(
+        rule for rule in payload["rules"] if rule["name"] == "schedule_before_credits"
+    )
+    schedule["metadata"]["proof"]["atoms"][0]["path"] = schedule_proof_path
+    if not schedule_has_proof:
+        schedule.pop("metadata")
+    if not schedule_claims_source:
+        schedule.pop("source")
+    schedule_index = payload["rules"].index(schedule)
+    if include_shadow_helper:
+        shadow_rule = {
+            "name": "shadow_clamp_diagnostic",
+            "kind": "derived",
+            "entity": "TaxUnit",
+            "dtype": "Money",
+            "period": "Year",
+            "unit": "USD",
+            "versions": [
+                {
+                    "effective_from": "2026-01-01",
+                    "effective_to": "2026-12-31",
+                    "formula": "taxable_income_boundary",
+                }
+            ],
+        }
+        if shadow_claims_source:
+            shadow_rule["source"] = "us-al/statute/40-18-5"
+        payload["rules"].insert(schedule_index, shadow_rule)
+    if include_copied_shadow:
+        copied_shadow = {
+            "name": "shadow_schedule",
+            "kind": "derived",
+            "entity": "TaxUnit",
+            "dtype": "Money",
+            "period": "Year",
+            "unit": "USD",
+            "source": "us-al/statute/40-18-5",
+            "versions": [
+                {
+                    "effective_from": "2026-01-01",
+                    "effective_to": "2026-12-31",
+                    "formula": "first_rate * min(taxable_income_boundary, 500)",
+                }
+            ],
+        }
+        if copied_shadow_copies_proof:
+            copied_shadow["metadata"] = {
+                "proof": {
+                    "atoms": [
+                        {
+                            "path": schedule_proof_path,
+                            "kind": "formula",
+                            "source": {
+                                "corpus_citation_path": "us-al/statute/40-18-5",
+                                "excerpt": source,
+                            },
+                        }
+                    ]
+                }
+            }
+        payload["rules"].insert(
+            schedule_index,
+            copied_shadow,
+        )
+    if include_unresolved_cycle:
+        for offset, (name, formula) in enumerate(
+            (
+                ("clamp_cycle_a", "clamp_cycle_b"),
+                ("clamp_cycle_b", "clamp_cycle_a"),
+            )
+        ):
+            payload["rules"].insert(
+                schedule_index + offset,
+                {
+                    "name": name,
+                    "kind": "derived",
+                    "entity": "TaxUnit",
+                    "dtype": "Money",
+                    "period": "Year",
+                    "unit": "USD",
+                    "versions": [
+                        {
+                            "effective_from": "2026-01-01",
+                            "effective_to": "2026-12-31",
+                            "formula": formula,
+                        }
+                    ],
+                },
+            )
+        schedule["versions"][0]["formula"] = (
+            "if resident_tax_applies:\n"
+            "  taxable_income_boundary + clamp_cycle_a\n"
+            "else: 0"
+        )
+    content = yaml.safe_dump(payload, sort_keys=False)
+    return _analyze(
+        content,
+        source,
+        corpus_citation_path="us-al/statute/40-18-5",
+        test_cases=test_cases,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+
+def _al_temporal_control_direct_input_clamp_analysis(test_cases):
+    source = (
+        "The tax applies to a resident and is two percent of taxable income "
+        "not in excess of $500."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-al/statute/40-18-5
+rules:
+  - name: first_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.02
+  - name: taxable_income_boundary
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: us-al/statute/40-18-5
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, completed_taxable_income)
+  - name: resident_tax_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: taxpayer_is_resident
+      - effective_from: '2027-01-01'
+        formula: taxpayer_is_full_year_resident
+  - name: schedule_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: us-al/statute/40-18-5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: The tax applies to a resident and is two percent of taxable income not in excess of $500.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if resident_tax_applies:
+            first_rate * min(taxable_income_boundary, 500)
+          else: 0
+inputs:
+  - name: completed_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+  - name: taxpayer_is_resident
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+  - name: taxpayer_is_full_year_resident
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+"""
+    return _analyze(
+        content,
+        source,
+        corpus_citation_path="us-al/statute/40-18-5",
+        test_cases=test_cases,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+
+def _al_temporal_parameter_control_direct_input_clamp_analysis(
+    test_cases,
+    *,
+    transitive_control=False,
+    parameter_alias=False,
+    later_enabled=False,
+    stable_numeric_rate_alias=False,
+    transitive_dtype="Judgment",
+):
+    source = "The tax is two percent of taxable income not in excess of $500."
+    payload = {
+        "format": "rulespec/v1",
+        "module": {
+            "source_verification": {"corpus_citation_path": "us-al/statute/40-18-5"}
+        },
+        "rules": [
+            {
+                "name": "first_rate",
+                "kind": "parameter",
+                "dtype": "Rate",
+                "period": "Year",
+                "versions": [{"effective_from": "2026-01-01", "formula": 0.02}],
+            },
+            {
+                "name": "bracket_ceiling",
+                "kind": "parameter",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+                "versions": [{"effective_from": "2026-01-01", "formula": 500}],
+            },
+            {
+                "name": "schedule_enabled",
+                "kind": "parameter",
+                "dtype": "Boolean",
+                "period": "Year",
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "effective_to": "2026-12-31",
+                        "formula": True,
+                    },
+                    {
+                        "effective_from": "2027-01-01",
+                        "formula": later_enabled,
+                    },
+                ],
+            },
+            {
+                "name": "taxable_income_boundary",
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+                "source": "us-al/statute/40-18-5",
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "formula": "max(0, completed_taxable_income)",
+                    }
+                ],
+            },
+            {
+                "name": "schedule_before_credits",
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+                "source": "us-al/statute/40-18-5",
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "formula",
+                                "source": {
+                                    "corpus_citation_path": ("us-al/statute/40-18-5"),
+                                    "excerpt": source,
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "formula": (
+                            "if resident_tax_applies:\n"
+                            "  first_rate * min(taxable_income_boundary, "
+                            "bracket_ceiling)\n"
+                            "else: 0"
+                            if transitive_control
+                            else "if schedule_enabled_alias:\n"
+                            "  first_rate * min(taxable_income_boundary, "
+                            "bracket_ceiling)\n"
+                            "else: 0"
+                            if parameter_alias
+                            else "if schedule_enabled:\n"
+                            "  first_rate * min(taxable_income_boundary, "
+                            "bracket_ceiling)\n"
+                            "else: 0"
+                        ),
+                    }
+                ],
+            },
+        ],
+        "inputs": [
+            {
+                "name": "completed_taxable_income",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+            }
+        ],
+    }
+    if parameter_alias:
+        payload["rules"].insert(
+            -1,
+            {
+                "name": "schedule_enabled_alias",
+                "kind": "parameter",
+                "dtype": "Boolean",
+                "period": "Year",
+                "versions": [{"formula": "schedule_enabled"}],
+            },
+        )
+    if stable_numeric_rate_alias:
+        first_rate = next(
+            rule for rule in payload["rules"] if rule["name"] == "first_rate"
+        )
+        first_rate["versions"] = [
+            {
+                "effective_from": "2026-01-01",
+                "effective_to": "2026-12-31",
+                "formula": 0.02,
+            },
+            {"effective_from": "2027-01-01", "formula": 0.02},
+        ]
+        schedule_enabled = next(
+            rule for rule in payload["rules"] if rule["name"] == "schedule_enabled"
+        )
+        schedule_enabled["versions"] = [
+            {"effective_from": "2026-01-01", "formula": True}
+        ]
+        schedule_index = next(
+            index
+            for index, rule in enumerate(payload["rules"])
+            if rule["name"] == "schedule_before_credits"
+        )
+        payload["rules"].insert(
+            schedule_index,
+            {
+                "name": "rate_alias",
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": "Rate",
+                "period": "Year",
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "formula": "first_rate",
+                    }
+                ],
+            },
+        )
+        schedule = next(
+            rule
+            for rule in payload["rules"]
+            if rule["name"] == "schedule_before_credits"
+        )
+        schedule["versions"][0]["formula"] = schedule["versions"][0]["formula"].replace(
+            "first_rate", "rate_alias"
+        )
+    if transitive_control:
+        payload["rules"].insert(
+            -1,
+            {
+                "name": "resident_tax_applies",
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": transitive_dtype,
+                "period": "Year",
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "formula": "schedule_enabled",
+                    }
+                ],
+            },
+        )
+    return _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
         source,
         corpus_citation_path="us-al/statute/40-18-5",
         test_cases=test_cases,
@@ -1294,6 +4155,833 @@ def test_direct_local_input_clamp_accepts_negative_shared_dependency_evidence():
     )
 
     assert not _has_issue(result, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_allows_owner_proof_beside_downstream_proof():
+    source = (
+        "Taxable income is the greater of completed taxable income or zero, "
+        "and the tax is two percent of taxable income not in excess of $500."
+    )
+    proof = {
+        "proof": {
+            "atoms": [
+                {
+                    "path": "versions[0].formula",
+                    "kind": "formula",
+                    "source": {
+                        "corpus_citation_path": "us-al/statute/40-18-5",
+                        "excerpt": source,
+                    },
+                }
+            ]
+        }
+    }
+    payload = {
+        "format": "rulespec/v1",
+        "module": {
+            "source_verification": {"corpus_citation_path": "us-al/statute/40-18-5"}
+        },
+        "rules": [
+            {
+                "name": "taxable_income_boundary",
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+                "source": "us-al/statute/40-18-5",
+                "metadata": proof,
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "effective_to": "2026-12-31",
+                        "formula": "max(0, completed_taxable_income)",
+                    }
+                ],
+            },
+            {
+                "name": "schedule_before_credits",
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+                "source": "us-al/statute/40-18-5",
+                "metadata": proof,
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "effective_to": "2026-12-31",
+                        "formula": "0.02 * min(taxable_income_boundary, 500)",
+                    }
+                ],
+            },
+        ],
+        "inputs": [
+            {
+                "name": "completed_taxable_income",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+            }
+        ],
+    }
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path="us-al/statute/40-18-5",
+        test_cases=[
+            {
+                "name": "negative_income_reaches_tax_schedule",
+                "period": "2026",
+                "input": {"completed_taxable_income": -1},
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "schedule_before_credits": 0,
+                },
+            }
+        ],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_accepts_owner_only_principal_evidence():
+    result = _al_owner_only_direct_input_clamp_analysis(
+        [
+            {
+                "name": "negative_income_is_clamped_at_mapped_boundary",
+                "period": "2026",
+                "input": {"completed_taxable_income": -1},
+                "output": {"taxable_income_boundary": 0},
+            }
+        ]
+    )
+
+    assert not _has_issue(result, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_ignores_disjoint_future_consumer():
+    result = _al_owner_only_direct_input_clamp_analysis(
+        [
+            {
+                "name": "negative_income_before_future_consumer",
+                "period": "2026",
+                "input": {"completed_taxable_income": -1},
+                "output": {"taxable_income_boundary": 0},
+            }
+        ],
+        include_future_consumer=True,
+    )
+
+    assert not _has_issue(result, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_requires_each_temporal_claimant_context():
+    insufficient = _al_owner_only_direct_input_clamp_analysis(
+        [
+            {
+                "name": "negative_income_before_future_consumer",
+                "period": "2026",
+                "input": {"completed_taxable_income": -1},
+                "output": {"taxable_income_boundary": 0},
+            },
+            {
+                "name": "positive_income_reaches_future_consumer",
+                "period": "2027",
+                "input": {"completed_taxable_income": 1},
+                "output": {
+                    "taxable_income_boundary": 1,
+                    "future_taxable_income_report": 1,
+                },
+            },
+        ],
+        include_future_consumer=True,
+        owner_open_ended=True,
+    )
+
+    assert _has_issue(insufficient, "direct nonnegative clamp", "below zero")
+
+    complete = _al_owner_only_direct_input_clamp_analysis(
+        [
+            {
+                "name": "negative_income_before_future_consumer",
+                "period": "2026",
+                "input": {"completed_taxable_income": -1},
+                "output": {"taxable_income_boundary": 0},
+            },
+            {
+                "name": "negative_income_reaches_future_consumer",
+                "period": "2027",
+                "input": {"completed_taxable_income": -1},
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "future_taxable_income_report": 0,
+                },
+            },
+        ],
+        include_future_consumer=True,
+        owner_open_ended=True,
+    )
+
+    assert not _has_issue(complete, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_tracks_temporal_claimant_control_dependencies():
+    prior_negative_and_later_inactive = [
+        {
+            "name": "negative_income_reaches_2026_resident_schedule",
+            "period": "2026",
+            "input": {
+                "completed_taxable_income": -1,
+                "taxpayer_is_resident": True,
+                "taxpayer_is_full_year_resident": False,
+            },
+            "output": {
+                "taxable_income_boundary": 0,
+                "resident_tax_applies": "holds",
+                "schedule_before_credits": 0,
+            },
+        },
+        {
+            "name": "positive_income_does_not_reach_2027_schedule",
+            "period": "2027",
+            "input": {
+                "completed_taxable_income": 1,
+                "taxpayer_is_resident": False,
+                "taxpayer_is_full_year_resident": False,
+            },
+            "output": {
+                "taxable_income_boundary": 1,
+                "resident_tax_applies": "not_holds",
+                "schedule_before_credits": 0,
+            },
+        },
+    ]
+
+    insufficient = _al_temporal_control_direct_input_clamp_analysis(
+        prior_negative_and_later_inactive
+    )
+
+    assert _has_issue(insufficient, "direct nonnegative clamp", "below zero")
+
+    complete = _al_temporal_control_direct_input_clamp_analysis(
+        [
+            *prior_negative_and_later_inactive,
+            {
+                "name": "negative_income_reaches_2027_resident_schedule",
+                "period": "2027",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": False,
+                    "taxpayer_is_full_year_resident": True,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "holds",
+                    "schedule_before_credits": 0,
+                },
+            },
+        ]
+    )
+
+    assert not _has_issue(complete, "direct nonnegative clamp", "below zero")
+
+
+@pytest.mark.parametrize(
+    ("transitive_control", "parameter_alias", "transitive_dtype"),
+    [
+        (False, False, "Judgment"),
+        (False, True, "Judgment"),
+        (True, False, "Judgment"),
+        (True, False, "bool"),
+    ],
+    ids=[
+        "direct-parameter",
+        "parameter-alias",
+        "stable-derived-selector",
+        "transitive-lowercase-bool",
+    ],
+)
+def test_direct_local_input_clamp_tracks_temporal_parameter_controls(
+    transitive_control,
+    parameter_alias,
+    transitive_dtype,
+):
+    def outputs(*, income, enabled):
+        result = {
+            "taxable_income_boundary": max(0, income),
+            "schedule_before_credits": (
+                0.02 * min(max(0, income), 500) if enabled else 0
+            ),
+        }
+        if transitive_control:
+            result["resident_tax_applies"] = enabled
+            if transitive_dtype != "bool":
+                result["resident_tax_applies"] = "holds" if enabled else "not_holds"
+        return result
+
+    prior_negative_boundary_and_later_inactive = [
+        {
+            "name": "negative_income_reaches_2026_schedule",
+            "period": "2026",
+            "input": {"completed_taxable_income": -1},
+            "output": outputs(income=-1, enabled=True),
+        },
+        {
+            "name": "ceiling_income_reaches_2026_schedule",
+            "period": "2026",
+            "input": {"completed_taxable_income": 500},
+            "output": outputs(income=500, enabled=True),
+        },
+        {
+            "name": "positive_income_is_masked_in_2027",
+            "period": "2027",
+            "input": {"completed_taxable_income": 1},
+            "output": outputs(income=1, enabled=False),
+        },
+    ]
+
+    insufficient = _al_temporal_parameter_control_direct_input_clamp_analysis(
+        prior_negative_boundary_and_later_inactive,
+        transitive_control=transitive_control,
+        parameter_alias=parameter_alias,
+        transitive_dtype=transitive_dtype,
+    )
+
+    assert _has_issue(insufficient, "direct nonnegative clamp", "below zero")
+
+    complete = _al_temporal_parameter_control_direct_input_clamp_analysis(
+        [
+            *prior_negative_boundary_and_later_inactive[:2],
+            {
+                "name": "negative_income_reaches_2027_schedule",
+                "period": "2027",
+                "input": {"completed_taxable_income": -1},
+                "output": outputs(income=-1, enabled=True),
+            },
+        ],
+        transitive_control=transitive_control,
+        parameter_alias=parameter_alias,
+        later_enabled=True,
+        transitive_dtype=transitive_dtype,
+    )
+
+    assert not _has_issue(complete, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_ignores_stable_temporal_numeric_alias_versions():
+    result = _al_temporal_parameter_control_direct_input_clamp_analysis(
+        [
+            {
+                "name": "negative_income_reaches_2026_schedule",
+                "period": "2026",
+                "input": {"completed_taxable_income": -1},
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "rate_alias": 0.02,
+                    "schedule_before_credits": 0,
+                },
+            },
+            {
+                "name": "ceiling_income_reaches_2026_schedule",
+                "period": "2026",
+                "input": {"completed_taxable_income": 500},
+                "output": {
+                    "taxable_income_boundary": 500,
+                    "rate_alias": 0.02,
+                    "schedule_before_credits": 10,
+                },
+            },
+            {
+                "name": "positive_income_reaches_2027_schedule",
+                "period": "2027",
+                "input": {"completed_taxable_income": 1},
+                "output": {
+                    "taxable_income_boundary": 1,
+                    "rate_alias": 0.02,
+                    "schedule_before_credits": 0.02,
+                },
+            },
+        ],
+        later_enabled=True,
+        stable_numeric_rate_alias=True,
+    )
+
+    assert not _has_issue(result, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_uses_case_selected_alias_classification():
+    source = "Taxable income is the greater of completed taxable income or zero."
+    formula_atom = {
+        "kind": "formula",
+        "source": {
+            "corpus_citation_path": "us-al/statute/40-18-5",
+            "excerpt": source,
+        },
+    }
+    payload = {
+        "format": "rulespec/v1",
+        "module": {
+            "source_verification": {"corpus_citation_path": "us-al/statute/40-18-5"}
+        },
+        "rules": [
+            {
+                "name": "taxable_income_boundary",
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+                "source": "us-al/statute/40-18-5",
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "formula": "max(0, completed_taxable_income)",
+                    }
+                ],
+            },
+            {
+                "name": "mixed_taxable_income_report",
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+                "source": "us-al/statute/40-18-5",
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {"path": "versions[0].formula", **formula_atom},
+                            {"path": "versions[1].formula", **formula_atom},
+                        ]
+                    }
+                },
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "effective_to": "2026-12-31",
+                        "formula": "taxable_income_boundary",
+                    },
+                    {
+                        "effective_from": "2027-01-01",
+                        "formula": "taxable_income_boundary * 1",
+                    },
+                ],
+            },
+        ],
+        "inputs": [
+            {
+                "name": "completed_taxable_income",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+            }
+        ],
+    }
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        source,
+        corpus_citation_path="us-al/statute/40-18-5",
+        test_cases=[
+            {
+                "name": "alias_period_uses_owner_fallback",
+                "period": "2026",
+                "input": {"completed_taxable_income": -1},
+                "output": {"taxable_income_boundary": 0},
+            },
+            {
+                "name": "computational_period_reaches_report",
+                "period": "2027",
+                "input": {"completed_taxable_income": -1},
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "mixed_taxable_income_report": 0,
+                },
+            },
+        ],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_rejects_mismatched_owner_only_assertion():
+    result = _al_owner_only_direct_input_clamp_analysis(
+        [
+            {
+                "name": "negative_income_has_wrong_boundary_assertion",
+                "period": "2026",
+                "input": {"completed_taxable_income": -1},
+                "output": {"taxable_income_boundary": 999},
+            }
+        ]
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_rejects_false_selector_masked_principal():
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "negative_income_is_masked_by_nonapplicability",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": False,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "not_holds",
+                    "schedule_before_credits": 0,
+                },
+            }
+        ]
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "selected formula path")
+
+
+@pytest.mark.parametrize(
+    "proof_path",
+    ("versions.formula", "versions [ 0 ] . formula"),
+)
+def test_direct_local_input_clamp_normalizes_false_selector_proof_path(proof_path):
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "normalized_proof_path_does_not_mask_false_selector",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": False,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "not_holds",
+                    "schedule_before_credits": 0,
+                },
+            }
+        ],
+        schedule_proof_path=proof_path,
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "selected formula path")
+
+
+def test_direct_local_input_clamp_accepts_true_selector_reached_principal():
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "negative_income_reaches_applicable_schedule",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": True,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "holds",
+                    "schedule_before_credits": 0,
+                },
+            }
+        ]
+    )
+
+    assert not _has_issue(result, "direct nonnegative clamp", "below zero")
+
+
+def test_direct_local_input_clamp_rejects_shadow_helper_laundering():
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "shadow_helper_reaches_inactive_clamp",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": False,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "not_holds",
+                    "shadow_clamp_diagnostic": 0,
+                    "schedule_before_credits": 0,
+                },
+            }
+        ],
+        include_shadow_helper=True,
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "authoritative principal")
+
+
+def test_direct_local_input_clamp_rejects_same_source_shadow_laundering():
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "same_source_shadow_reaches_inactive_clamp",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": False,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "not_holds",
+                    "shadow_clamp_diagnostic": 0,
+                    "schedule_before_credits": 0,
+                },
+            }
+        ],
+        include_shadow_helper=True,
+        shadow_claims_source=True,
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "authoritative principal")
+
+
+def test_direct_local_input_clamp_rejects_copied_source_computation_laundering():
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "copied_shadow_reaches_inactive_clamp",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": False,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "not_holds",
+                    "shadow_schedule": 0,
+                    "schedule_before_credits": 0,
+                },
+            }
+        ],
+        include_copied_shadow=True,
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "authoritative principal")
+
+
+def test_direct_local_input_clamp_rejects_exact_proof_copied_laundering():
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "proof_copied_shadow_reaches_inactive_clamp",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": False,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "not_holds",
+                    "shadow_schedule": 0,
+                    "schedule_before_credits": 0,
+                },
+            }
+        ],
+        include_copied_shadow=True,
+        copied_shadow_copies_proof=True,
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "unambiguous")
+
+
+def test_direct_local_input_clamp_rejects_exact_proof_moved_to_shadow():
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "proof_moved_shadow_reaches_inactive_clamp",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": False,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "not_holds",
+                    "shadow_schedule": 0,
+                    "schedule_before_credits": 0,
+                },
+            }
+        ],
+        include_copied_shadow=True,
+        copied_shadow_copies_proof=True,
+        schedule_has_proof=False,
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "unambiguous")
+
+
+def test_direct_local_input_clamp_rejects_source_and_proof_moved_to_shadow():
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "source_and_proof_moved_shadow_reaches_inactive_clamp",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": False,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "not_holds",
+                    "shadow_schedule": 0,
+                    "schedule_before_credits": 0,
+                },
+            },
+            {
+                "name": "applicable_schedule_reaches_source_boundary",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": 500,
+                    "taxpayer_is_resident": True,
+                },
+                "output": {
+                    "taxable_income_boundary": 500,
+                    "resident_tax_applies": "holds",
+                    "shadow_schedule": 10,
+                    "schedule_before_credits": 10,
+                },
+            },
+        ],
+        include_copied_shadow=True,
+        copied_shadow_copies_proof=True,
+        schedule_has_proof=False,
+        schedule_claims_source=False,
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "unambiguous")
+    assert not _has_issue(result, "do not demonstrate formula branch")
+    assert not _has_issue(result, "do not exercise every source-stated boundary")
+
+
+def test_direct_local_input_clamp_groups_and_caps_diagnostics():
+    clamp_count = completeness_module._NEGATIVE_LOCAL_INPUT_CLAMP_DIAGNOSTIC_LIMIT + 2
+    payload = {
+        "format": "rulespec/v1",
+        "module": {
+            "source_verification": {"corpus_citation_path": "us-al/statute/40-18-5"}
+        },
+        "rules": [],
+        "inputs": [],
+    }
+    case_inputs = {}
+    for index in range(clamp_count):
+        input_name = f"raw_amount_{index:02d}"
+        owner = f"clamped_amount_{index:02d}"
+        payload["inputs"].append(
+            {
+                "name": input_name,
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+            }
+        )
+        payload["rules"].append(
+            {
+                "name": owner,
+                "kind": "derived",
+                "entity": "TaxUnit",
+                "dtype": "Money",
+                "period": "Year",
+                "unit": "USD",
+                "source": "us-al/statute/40-18-5",
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "effective_to": "2026-12-31",
+                        "formula": f"max(0, {input_name})",
+                    }
+                ],
+            }
+        )
+        case_inputs[input_name] = -1
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        "Each amount is the greater of the completed amount or zero.",
+        corpus_citation_path="us-al/statute/40-18-5",
+        test_cases=[
+            {
+                "name": "all_negative_without_outputs",
+                "period": "2026",
+                "input": case_inputs,
+                "output": {},
+            }
+        ],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    clamp_issues = [
+        issue for issue in result.issues if "direct nonnegative clamp" in issue.lower()
+    ]
+    assert len(clamp_issues) == 1
+    assert "clamped_amount_00" in clamp_issues[0]
+    assert "clamped_amount_07" in clamp_issues[0]
+    assert "clamped_amount_08" not in clamp_issues[0]
+    assert "2 additional clamps omitted" in clamp_issues[0]
+
+
+def test_direct_local_input_clamp_rejects_unresolved_cyclic_downstream():
+    result = _al_gated_direct_input_clamp_analysis(
+        [
+            {
+                "name": "cycle_masks_unresolved_schedule",
+                "period": "2026",
+                "input": {
+                    "completed_taxable_income": -1,
+                    "taxpayer_is_resident": True,
+                },
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "resident_tax_applies": "holds",
+                    "clamp_cycle_a": 0,
+                    "clamp_cycle_b": 0,
+                    "schedule_before_credits": 0,
+                },
+            }
+        ],
+        include_unresolved_cycle=True,
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "selected formula path")
+
+
+def test_direct_local_input_clamp_rejects_mismatched_downstream_assertion():
+    result = _al_direct_input_clamp_analysis(
+        [
+            {
+                "name": "negative_income_has_wrong_schedule_assertion",
+                "period": "2026",
+                "input": {"completed_taxable_income": -1},
+                "output": {
+                    "taxable_income_boundary": 0,
+                    "schedule_before_credits": 999,
+                },
+            }
+        ]
+    )
+
+    assert _has_issue(result, "direct nonnegative clamp", "matching assertion")
 
 
 def test_direct_local_input_clamp_requires_clamped_dependency_assertion():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1670"
+version = "0.2.1671"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- require proof-bound, version-aligned decomposition of same-source conjunctive condition gates, with scoped tri-state polarity and fail-closed bounded dependency expansion
- require negative clamp evidence to reach the selected, exactly proved source computation in each temporal execution context; reject borrowed, copied, moved, shadow, inactive, and ambiguous witnesses
- add deterministic depth, node, alternative, context, and diagnostic bounds, including interval-aware cycle handling
- bump `axiom-encode` to `0.2.1671`

## Review cycle

Completed repeated independent review-fix cycles for the Kentucky aggregate-gate and Mississippi clamp-reach owner gaps. The final integration and final PR tree received independent clean verdicts with no actionable findings. The final commit has exactly one parent at current `main` (`8c8c499a`), preserves PR #1475 telemetry blobs, and byte-matches the reviewed validator/test implementation.

No new acronym token is introduced.

## Checks

- `uv run --extra dev --python 3.13.3 pytest` — **12,869 passed, 123 skipped**
- `tests/test_source_completeness.py` — **5,642 passed**
- provenance/version guard — **passed**
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests` — **passed**
- `python -m compileall -q src/axiom_encode scripts` — **passed**
- `uv lock --check` — **passed**
- `git diff --check` — **passed**

A plain `uv run pytest` initially selected local Python 3.14 and failed before collection while building `pyroaring==1.0.3`; the complete repository suite above passed under the established Python 3.13.3 dev environment.
