### PR TITLE
Fix flattened inline source ownership

### DIFF
--- a/changelog.d/flattened-inline-source-ownership.fixed.md
+++ b/changelog.d/flattened-inline-source-ownership.fixed.md
@@ -1,0 +1,1 @@
+Disambiguate proof ownership for authoritative dotted lists flattened onto physical lines without promoting citations, decimals, or prose cross-references to source branches.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1671"
+version = "0.2.1672"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1671"
+__version__ = "0.2.1672"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -268,6 +268,48 @@ _NUMBER_MARKER = re.compile(
     r"(?m)^[ \t]*(?P<marker>(?P<label>\d+[a-z]?)\.)[ \t]+",
     flags=re.IGNORECASE,
 )
+_INLINE_DOTTED_NUMBER_MARKER = re.compile(
+    r"(?<![A-Za-z0-9.])(?P<marker>(?P<label>[1-9]\d{0,2})\.)[ \t]+"
+)
+_INLINE_DOTTED_LIST_MINIMUM_LENGTH = 3
+_INLINE_DOTTED_LIST_MATCH_LIMIT = 256
+_INLINE_DOTTED_LIST_CHAPEAU_LIMIT = 512
+_INLINE_DOTTED_LIST_STRUCTURAL_CHAPEAU = re.compile(
+    r"^\s*(?:(?:(?:all|each)\s+of\s+the|the)\s+)?following\s+(?:tax\s+)?"
+    r"(?:allowances?|benefits?|conditions?|credits?|deductions?|eligibility|"
+    r"exceptions?|exemptions?|qualifications?|requirements?)\b"
+    r"(?:\s*,\s*(?:when|where|if)\s+applicable\s*,|"
+    r"\s+(?:when|where|if)\s+applicable)?\s+"
+    r"(?:appl(?:y|ies)|(?:shall|must|may)\s+(?:apply|hold|be\s+"
+    r"(?:allowed|available|claimed|required|satisfied|met))|"
+    r"(?:are|is)\s+(?:allowed|available|required|satisfied|met)|"
+    r"(?:shall|must)(?:\s*,\s*(?:when|where|if)\s+applicable\s*,)?\s+"
+    r"be\s+deducted(?:\s+from\s+the\s+result\s+obtained\s+under\s+"
+    r"subsection\s+\(\d+[a-z]?\)\s+of\s+this\s+section\s+to\s+arrive\s+at\s+"
+    r"the\s+annual\s+tax)?)"
+    r"(?:\s+(?:(?:only\s+)?when|if)\s+(?:"
+    r"no\s+(?:[a-z][a-z'-]*\s+){0,5}"
+    r"(?:income|earnings?|wages?|benefits?|credits?|deductions?|allowances?|"
+    r"exemptions?)\s+(?:(?:is|are|was|were)|(?:has|have|had)\s+been)\s+"
+    r"(?:reported|received|earned|available|claimed|allowed|paid|provided)|"
+    r"(?:[a-z][a-z'-]*\s+){0,5}"
+    r"(?:income|earnings?|wages?|benefits?|credits?|deductions?|allowances?|"
+    r"exemptions?)\s+(?:is|are|was|were)\s+not\s+"
+    r"(?:reported|received|earned|available|claimed|allowed|paid|provided)|"
+    r"(?:the\s+)?(?:applicant|claimant|dependent|household|individual|person|"
+    r"recipient|spouse|taxpayer|taxpayer(?:'s|’s)\s+spouse)\s+"
+    r"(?:(?:is|are|was|were)\s+not\s+(?:"
+    r"(?:(?:an?|the)\s+)?(?:(?:another\s+)?taxpayer(?:'s|’s)\s+)?"
+    r"(?:dependent|eligible|qualified|blind|disabled|married|resident)|"
+    r"the\s+dependent\s+of\s+another\s+taxpayer)|"
+    r"(?:has|have|had)\s+no\s+(?:[a-z][a-z'-]*\s+){0,5}"
+    r"(?:income|earnings?|wages?|benefits?|credits?|deductions?|allowances?|"
+    r"exemptions?)|"
+    r"(?:is|are|was|were)\s+"
+    r"(?:dependent|eligible|qualified|blind|disabled|married|resident))"
+    r"))?\s*:\s*$",
+    flags=re.IGNORECASE,
+)
 _LETTER_MARKER = re.compile(
     r"(?m)^[ \t]*(?P<marker>(?P<label>[a-z]{1,2})\))[ \t]+",
     flags=re.IGNORECASE,
@@ -12667,6 +12709,166 @@ def _source_proposition_bounds(text: str, start: int, end: int) -> tuple[int, in
     )
 
 
+def _flattened_inline_dotted_marker_has_item_boundary(
+    source_text: str,
+    *,
+    start: int,
+    container_start: int,
+) -> bool:
+    """Require list punctuation or a physical-line boundary before a marker."""
+
+    line_start = source_text.rfind("\n", container_start, start) + 1
+    if not source_text[line_start:start].strip():
+        return True
+    prefix = source_text[max(container_start, start - 64) : start]
+    return (
+        re.search(
+            r"(?:[:;.!?]\s*(?:(?:and|or)\s+)?)$",
+            prefix,
+            flags=re.IGNORECASE,
+        )
+        is not None
+    )
+
+
+def _flattened_inline_dotted_list_has_structural_chapeau(
+    source_text: str,
+    *,
+    start: int,
+    parent: SourceStructureBranch,
+) -> bool:
+    """Require the entire bounded parent prefix to be an operative chapeau."""
+
+    if (
+        start <= parent.start
+        or start - parent.start > _INLINE_DOTTED_LIST_CHAPEAU_LIMIT
+    ):
+        return False
+    prefix = source_text[parent.start : start]
+    chapeau_candidates = [prefix]
+
+    label = parent.label.strip()
+    if label:
+        label_match = re.match(
+            rf"^\s*{re.escape(label)}\s*",
+            prefix,
+            flags=re.IGNORECASE,
+        )
+        if label_match is not None:
+            chapeau_candidates.append(prefix[label_match.end() :])
+
+    if parent.path:
+        path_pattern = r"\s*".join(
+            rf"\(\s*{re.escape(part)}\s*\)" for part in parent.path
+        )
+        path_match = re.match(
+            rf"^\s*{path_pattern}\s*",
+            prefix,
+            flags=re.IGNORECASE,
+        )
+        if path_match is not None:
+            chapeau_candidates.append(prefix[path_match.end() :])
+
+    return any(
+        _INLINE_DOTTED_LIST_STRUCTURAL_CHAPEAU.fullmatch(candidate) is not None
+        for candidate in chapeau_candidates
+    )
+
+
+def _flattened_inline_dotted_list_ownership(
+    source_text: str,
+    *,
+    parent: SourceStructureBranch,
+) -> tuple[tuple[SourceStructureBranch, ...], bool]:
+    """Recover proof-only children from a proven flattened dotted list.
+
+    Corpus extraction can flatten ``1.`` through ``N.`` children onto one
+    physical line even when their parenthesized parent remains recognizable.
+    Keep these virtual branches local to proof ownership: they disambiguate an
+    explicit leaf citation without expanding the source-completeness surface.
+    The boolean result marks multiple plausible lists or an over-budget scan.
+    """
+
+    if not parent.path:
+        return (), False
+    matches = tuple(
+        itertools.islice(
+            (
+                match
+                for match in _INLINE_DOTTED_NUMBER_MARKER.finditer(
+                    source_text,
+                    parent.start,
+                    parent.end,
+                )
+                if _flattened_inline_dotted_marker_has_item_boundary(
+                    source_text,
+                    start=match.start(),
+                    container_start=parent.start,
+                )
+            ),
+            _INLINE_DOTTED_LIST_MATCH_LIMIT + 1,
+        )
+    )
+    if len(matches) > _INLINE_DOTTED_LIST_MATCH_LIMIT:
+        return (), True
+
+    candidate_sequence_count = 0
+    qualified_sequence: tuple[re.Match[str], ...] | None = None
+    match_index = 0
+    while match_index < len(matches):
+        if int(matches[match_index].group("label")) != 1:
+            match_index += 1
+            continue
+        has_structural_chapeau = _flattened_inline_dotted_list_has_structural_chapeau(
+            source_text,
+            start=matches[match_index].start(),
+            parent=parent,
+        )
+        sequence = [matches[match_index]]
+        expected = 2
+        next_index = match_index + 1
+        while next_index < len(matches):
+            label = int(matches[next_index].group("label"))
+            if label != expected:
+                break
+            sequence.append(matches[next_index])
+            expected += 1
+            next_index += 1
+        if len(sequence) < _INLINE_DOTTED_LIST_MINIMUM_LENGTH:
+            match_index += 1
+            continue
+        candidate_sequence_count += 1
+        if has_structural_chapeau:
+            qualified_sequence = tuple(sequence)
+        if candidate_sequence_count > 1 and qualified_sequence is not None:
+            return (), True
+        match_index = next_index
+    if qualified_sequence is None:
+        return (), False
+
+    branches: list[SourceStructureBranch] = []
+    sequence = qualified_sequence
+    next_index = matches.index(sequence[-1]) + 1
+    sequence_end = (
+        matches[next_index].start() if next_index < len(matches) else parent.end
+    )
+    for index, match in enumerate(sequence):
+        start = match.start()
+        end = sequence[index + 1].start() if index + 1 < len(sequence) else sequence_end
+        label = match.group("label").lower()
+        branches.append(
+            SourceStructureBranch(
+                (*parent.path, label),
+                "number",
+                match.group("marker"),
+                source_text[start:end].strip(),
+                start,
+                end,
+            )
+        )
+    return tuple(branches), False
+
+
 def _source_condition_clauses_owned_by_excerpt(
     excerpt: str,
     *,
@@ -12687,15 +12889,60 @@ def _source_condition_clauses_owned_by_excerpt(
     matches = tuple(pattern.finditer(source_text))
     if not matches:
         return (), False
+    virtual_branches: dict[tuple[tuple[str, ...], str, int], SourceStructureBranch] = {}
+    ambiguous_inline_ownership = False
+    inline_ownership_by_parent: dict[
+        tuple[tuple[str, ...], str, int],
+        tuple[tuple[SourceStructureBranch, ...], bool],
+    ] = {}
+    for match in matches:
+        containing_parents = sorted(
+            (
+                branch
+                for branch in branches
+                if branch.path
+                and branch.start <= match.start()
+                and match.end() <= branch.end
+            ),
+            key=lambda branch: (-len(branch.path), branch.end - branch.start),
+        )
+        for parent in containing_parents:
+            parent_key = (parent.path, parent.kind, parent.start)
+            ownership = inline_ownership_by_parent.get(parent_key)
+            if ownership is None:
+                ownership = _flattened_inline_dotted_list_ownership(
+                    source_text,
+                    parent=parent,
+                )
+                inline_ownership_by_parent[parent_key] = ownership
+            owned_branches, ambiguous = ownership
+            if ambiguous:
+                ambiguous_inline_ownership = True
+                break
+            if not any(
+                branch.start <= match.start() and match.end() <= branch.end
+                for branch in owned_branches
+            ):
+                continue
+            virtual_branches.update(
+                {
+                    (branch.path, branch.kind, branch.start): branch
+                    for branch in owned_branches
+                }
+            )
+            break
+    ownership_branches = (*branches, *virtual_branches.values())
     cited_paths = _rule_cited_source_paths(
         rule,
-        branches=branches,
+        branches=ownership_branches,
         corpus_citation_path=corpus_citation_path,
     )
 
     def containing_branch(start: int, end: int) -> SourceStructureBranch | None:
         candidates = [
-            branch for branch in branches if branch.start <= start and end <= branch.end
+            branch
+            for branch in ownership_branches
+            if branch.start <= start and end <= branch.end
         ]
         return max(
             candidates,
@@ -12743,7 +12990,10 @@ def _source_condition_clauses_owned_by_excerpt(
         clauses[key]
         for key in sorted(clauses, key=lambda item: (item[1], item[2], item[0]))
     )
-    return ordered, citation_mismatch or len(ordered) != 1
+    return (
+        ordered,
+        citation_mismatch or ambiguous_inline_ownership or len(ordered) != 1,
+    )
 
 
 def _effective_formula_version_intervals(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1671"
+ENCODER_VERSION = "0.2.1672"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1671"
+ENCODER_VERSION = "0.2.1672"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1671"
+ENCODER_VERSION = "0.2.1672"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_live_run_telemetry.py
+++ b/tests/test_live_run_telemetry.py
@@ -95,7 +95,7 @@ class TestLiveRunTelemetry:
                 citation="us/statute/26/32",
                 backend="codex",
                 model="gpt-5.5",
-                encoder_version="0.2.1671",
+                encoder_version="0.2.1672",
             ) as live:
                 live.set_attempt(2, "gpt-5.5-max")
                 live.finish("completed", run_id="abc12345")

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1671"
+ENCODER_VERSION = "0.2.1672"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1671"
+ENCODER_VERSION = "0.2.1672"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1671"
+ENCODER_VERSION = "0.2.1672"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1671"
+ENCODER_VERSION = "0.2.1672"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6216,7 +6216,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1671"')
+        .startswith('__version__ = "0.2.1672"')
     )
 
 
@@ -6448,13 +6448,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1671"
+    assert encoder_package["version"] == "0.2.1672"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1671"
+    assert project["project"]["version"] == "0.2.1672"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1671"')
+        .startswith('__version__ = "0.2.1672"')
     )
 
 
@@ -6716,13 +6716,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1671"
+    assert encoder_package["version"] == "0.2.1672"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1671"
+    assert project["project"]["version"] == "0.2.1672"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1671"')
+        .startswith('__version__ = "0.2.1672"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1671"
+ENCODER_VERSION = "0.2.1672"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -116,6 +116,22 @@ no Kentucky gross income and is not the dependent of another taxpayer;
 separate return is made by the taxpayer and if the taxpayer's spouse is blind,
 and has no Kentucky gross income and is not the dependent of another taxpayer.
 """
+KY_FLATTENED_SPOUSE_CREDIT_SOURCE = (
+    "(1) First subsection.\n(2) Second subsection.\n"
+    "(3) (A) The following tax credits, when applicable, shall be deducted from "
+    "the result obtained under subsection (2) of this section to arrive at the "
+    "annual tax: 1. First credit; 2. Second credit; 3. Third credit; "
+    "4. A taxpayer age credit; 5. An additional forty dollars ($40) credit for "
+    "the taxpayer's spouse if a separate return is made by the taxpayer and if "
+    "the taxpayer's spouse has attained the age of sixty-five before the close "
+    "of the taxable year, and has no Kentucky gross income and is not the "
+    "dependent of another taxpayer;\n6. A taxpayer blindness credit; "
+    "7. An additional forty dollars ($40) credit for the taxpayer's spouse if a "
+    "separate return is made by the taxpayer and if the taxpayer's spouse is "
+    "blind, and has no Kentucky gross income and is not the dependent of another "
+    "taxpayer; and 8. A National Guard credit. (b) Other credits.\n"
+    "(4) Fourth subsection.\n(5) Fifth subsection.\n(6) Sixth subsection."
+)
 KY_CITATION_PATH = "us-ky/statute/krs/141.020/document-1"
 
 
@@ -421,6 +437,580 @@ def test_accepts_decomposed_facts_for_same_source_spouse_credit_gates():
     )
 
     assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_flattened_inline_dotted_items_disambiguate_spouse_credit_proof():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_FLATTENED_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+    branches = recognize_source_structure(KY_FLATTENED_SPOUSE_CREDIT_SOURCE)
+    age_rule = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit"
+    )
+    age_excerpt = age_rule["metadata"]["proof"]["atoms"][0]["source"]["excerpt"]
+    age_clauses, age_ambiguous = (
+        completeness_module._source_condition_clauses_owned_by_excerpt(
+            age_excerpt,
+            rule=age_rule,
+            source_text=KY_FLATTENED_SPOUSE_CREDIT_SOURCE,
+            branches=branches,
+            corpus_citation_path=KY_CITATION_PATH,
+        )
+    )
+    blindness_rule = age_rule | {"source": "KRS 141.020(3)(a)7."}
+    blindness_clauses, blindness_ambiguous = (
+        completeness_module._source_condition_clauses_owned_by_excerpt(
+            age_excerpt,
+            rule=blindness_rule,
+            source_text=KY_FLATTENED_SPOUSE_CREDIT_SOURCE,
+            branches=branches,
+            corpus_citation_path=KY_CITATION_PATH,
+        )
+    )
+
+    assert not age_ambiguous
+    assert [clause.branch_path for clause in age_clauses] == [("3", "a", "5")]
+    assert not blindness_ambiguous
+    assert [clause.branch_path for clause in blindness_clauses] == [("3", "a", "7")]
+
+
+def test_flattened_inline_dotted_items_keep_wrong_leaf_gate_fail_closed():
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    age_rule = next(
+        rule for rule in payload["rules"] if rule["name"] == "spouse_age_credit"
+    )
+    age_rule["source"] = "KRS 141.020(3)(a)7."
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_FLATTENED_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "spouse_age_credit",
+        "spouse_has_attained_age_sixty_five",
+    )
+
+
+def test_unproven_inline_dotted_items_keep_repeated_proof_ambiguous():
+    source = " ".join(
+        line.strip() for line in KY_SPOUSE_CREDIT_SOURCE.splitlines() if line.strip()
+    )
+    result = _analyze(
+        yaml.safe_dump(_ky_spouse_credit_payload(decomposed=True), sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", "spouse_age_credit")
+
+
+@pytest.mark.parametrize(
+    "mutate_payload",
+    (
+        lambda payload: next(
+            rule
+            for rule in payload["rules"]
+            if rule["name"] == "spouse_age_credit_applies"
+        )["versions"][0].update({"effective_to": "2025-12-31"}),
+        lambda payload: next(
+            rule
+            for rule in payload["rules"]
+            if rule["name"] == "spouse_age_credit_applies"
+        )["versions"][0].update(
+            {
+                "formula": (
+                    "taxpayer_files_separate_return "
+                    "and spouse_has_attained_age_sixty_five "
+                    "and spouse_has_no_kentucky_gross_income"
+                )
+            }
+        ),
+    ),
+)
+def test_flattened_inline_dotted_items_do_not_bypass_helper_integrity(
+    mutate_payload,
+):
+    payload = _ky_spouse_credit_payload(decomposed=True)
+    mutate_payload(payload)
+
+    result = _analyze(
+        yaml.safe_dump(payload, sort_keys=False),
+        KY_FLATTENED_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", "spouse_age_credit")
+
+
+def test_flattened_inline_dotted_items_still_reject_opaque_gate():
+    result = _analyze(
+        yaml.safe_dump(_ky_spouse_credit_payload(decomposed=False), sort_keys=False),
+        KY_FLATTENED_SPOUSE_CREDIT_SOURCE,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(
+        result,
+        "source-explicit-conditions",
+        "spouse_age_credit_conditions_hold",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        (
+            "(3) (a) Values include KRS 141.019 and KRS 141.023. Rates are "
+            "3.5% and 5.8%. The amount is $3,000. History: Amended 2025 Ky. "
+            "Acts ch. 1, sec. 1. See subparagraphs 2. and 3. and paragraph 4."
+        ),
+        "(3) (a) Credits follow: 1. First credit; 2. Second credit.",
+        "(3) (a) Credits follow: 1. First credit; 3. Third credit; 4. Fourth.",
+        "(3) (a) See subparagraphs: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following summary is illustrative: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following historical rates are listed: 1. First; 2. Second; 3. Third.",
+        "(3) (a) History: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following rates are: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following references are: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following examples are: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following summaries are: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following credit examples are illustrative: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following credit illustration is provided: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following percentages shall apply: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following effective dates are provided: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following citations are provided: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following sentences are included for convenience: 1. First; 2. Second; 3. Third.",
+        "(3) (a) The following discussion shall govern interpretation: 1. First; 2. Second; 3. Third.",
+    ),
+)
+def test_unproven_inline_dotted_markers_do_not_create_proof_owners(source: str):
+    parent = completeness_module.SourceStructureBranch(
+        ("3", "a"),
+        "letter",
+        "(a)",
+        source,
+        0,
+        len(source),
+    )
+
+    assert completeness_module._flattened_inline_dotted_list_ownership(
+        source,
+        parent=parent,
+    ) == ((), False)
+
+
+@pytest.mark.parametrize(
+    "chapeau",
+    (
+        "The following credits apply",
+        "The following credits apply when no Kentucky gross income is reported",
+        "The following credits apply only when no Kentucky gross income is reported",
+        "The following credits apply if spouse is not another taxpayer's dependent",
+        "The following credits apply when the claimant is not a dependent",
+        "The following credits apply when spouse is not the dependent of another taxpayer",
+        "The following credits apply when claimant has no Kentucky gross income",
+        "The following credits apply if no Kentucky gross income has been reported",
+        "The following credits if applicable shall apply",
+        "The following credits, if applicable, shall apply",
+        "The following credits must be deducted",
+        "Each of the following credits applies",
+        "All of the following credits apply",
+        "The following credits when applicable shall be deducted",
+        "The following credits, where applicable, shall be deducted",
+        "The following credits shall, when applicable, be deducted",
+        "The following credits apply if Kentucky gross income is not reported",
+        "The following credits apply if the claimant is eligible",
+    ),
+)
+def test_operational_apply_chapeau_creates_inline_dotted_owners(chapeau: str):
+    source = f"(3) (a) {chapeau}: 1. First credit; 2. Second credit; 3. Third credit."
+    parent = completeness_module.SourceStructureBranch(
+        ("3", "a"),
+        "letter",
+        "(a)",
+        source,
+        0,
+        len(source),
+    )
+
+    owned_branches, ownership_ambiguous = (
+        completeness_module._flattened_inline_dotted_list_ownership(
+            source,
+            parent=parent,
+        )
+    )
+
+    assert [branch.path for branch in owned_branches] == [
+        ("3", "a", "1"),
+        ("3", "a", "2"),
+        ("3", "a", "3"),
+    ]
+    assert not ownership_ambiguous
+
+
+@pytest.mark.parametrize(
+    ("marker", "normalized_path"),
+    (("A", ("a", "1", "a")), ("I", ("a", "1", "i"))),
+)
+def test_uppercase_parent_path_creates_inline_dotted_owners(
+    marker: str,
+    normalized_path: tuple[str, ...],
+):
+    source = (
+        f"(a) (1) ({marker}) The following credits apply: "
+        "1. First credit; 2. Second credit; 3. Third credit."
+    )
+    parent = completeness_module.SourceStructureBranch(
+        normalized_path,
+        "letter",
+        f"({marker.lower()})",
+        source,
+        0,
+        len(source),
+    )
+
+    owned_branches, ownership_ambiguous = (
+        completeness_module._flattened_inline_dotted_list_ownership(
+            source,
+            parent=parent,
+        )
+    )
+
+    assert [branch.path for branch in owned_branches] == [
+        (*normalized_path, "1"),
+        (*normalized_path, "2"),
+        (*normalized_path, "3"),
+    ]
+    assert not ownership_ambiguous
+
+
+def test_sibling_inline_lists_use_deepest_relevant_parent():
+    source = (
+        "(3) (a) The following deductions shall apply: 1. An age credit if the claimant "
+        "is sixty-five; 2. A blindness credit; 3. A dependent credit. "
+        "(b) The following deductions shall apply: 1. A business credit; "
+        "2. An investment credit; 3. A research credit."
+    )
+    paragraph_start = 0
+    paragraph_end = len(source)
+    paragraph_b_start = source.index("(b)")
+    branches = (
+        completeness_module.SourceStructureBranch(
+            (), "document", "", source, paragraph_start, paragraph_end
+        ),
+        completeness_module.SourceStructureBranch(
+            ("3",), "paragraph", "(3)", source, paragraph_start, paragraph_end
+        ),
+        completeness_module.SourceStructureBranch(
+            ("3", "a"),
+            "letter",
+            "(a)",
+            source[:paragraph_b_start],
+            paragraph_start,
+            paragraph_b_start,
+        ),
+        completeness_module.SourceStructureBranch(
+            ("3", "b"),
+            "letter",
+            "(b)",
+            source[paragraph_b_start:],
+            paragraph_b_start,
+            paragraph_end,
+        ),
+    )
+    excerpt = "An age credit if the claimant is sixty-five"
+    rule = _ky_derived_rule(
+        "claimant_age_credit",
+        source="KRS 141.020(3)(a)1.",
+        dtype="Judgment",
+        formula="claimant_is_sixty_five",
+        excerpt=excerpt,
+    )
+
+    clauses, clause_ambiguous = (
+        completeness_module._source_condition_clauses_owned_by_excerpt(
+            excerpt,
+            rule=rule,
+            source_text=source,
+            branches=branches,
+            corpus_citation_path=KY_CITATION_PATH,
+        )
+    )
+
+    assert [clause.branch_path for clause in clauses] == [("3", "a", "1")]
+    assert not clause_ambiguous
+
+
+def test_deeper_unrelated_inline_list_does_not_suppress_ancestor_ambiguity():
+    source = (
+        "(3) (a) The following credits shall apply: 1. Outer first; "
+        "2. Outer second; 3. Outer third; 4. Outer fourth; 5. Outer fifth; "
+        "6. The following conditions must hold: 1. Nested first; "
+        "2. Nested second; 3. Nested third; 7. TARGET condition; 8. Outer eighth."
+    )
+    item_six_start = source.index("6. The following")
+    outer_parent = completeness_module.SourceStructureBranch(
+        ("3", "a"), "letter", "(a)", source, 0, len(source)
+    )
+    overbroad_item_six = completeness_module.SourceStructureBranch(
+        ("3", "a", "6"),
+        "number",
+        "6.",
+        source[item_six_start:],
+        item_six_start,
+        len(source),
+    )
+    excerpt = "TARGET condition"
+    rule = _ky_derived_rule(
+        "target_condition",
+        source="KRS 141.020(3)(a)7.",
+        dtype="Judgment",
+        formula="target_condition_applies",
+        excerpt=excerpt,
+    )
+
+    nested_branches, nested_ambiguous = (
+        completeness_module._flattened_inline_dotted_list_ownership(
+            source,
+            parent=overbroad_item_six,
+        )
+    )
+    clauses, clause_ambiguous = (
+        completeness_module._source_condition_clauses_owned_by_excerpt(
+            excerpt,
+            rule=rule,
+            source_text=source,
+            branches=(outer_parent, overbroad_item_six),
+            corpus_citation_path=KY_CITATION_PATH,
+        )
+    )
+
+    target_start = source.index(excerpt)
+    assert nested_branches
+    assert not nested_ambiguous
+    assert not any(
+        branch.start <= target_start < branch.end for branch in nested_branches
+    )
+    assert [clause.branch_path for clause in clauses] == [("3", "a", "6")]
+    assert clause_ambiguous
+
+
+@pytest.mark.parametrize(
+    "chapeau",
+    (
+        "The following credits are nonoperative commentary",
+        "The following credits shall be discussed",
+        "The following credits are included for explanatory purposes",
+        "The following credit commencement days shall apply",
+        "The following credit ratios shall apply",
+        "The following credit authorities shall apply",
+        "The following credits shall not apply",
+        "The following credits shall apply hypothetically",
+        "The following credits are allowed only for explanatory purposes",
+        "The following credits are available as nonbinding guidance",
+        "The following credits may apply in a fictional scenario",
+        "The following credits shall be deducted according to a mock calculation",
+        "For commentary purposes, the following credits shall be allowed",
+        "For explanatory purposes, the following credits shall be allowed",
+        "For educational purposes, the following credits shall be allowed",
+        "For hypothetical purposes, the following credits shall apply",
+        "For testing, the following credits shall apply",
+        "As a demonstration, the following credits shall apply",
+        "In this sample, the following credits shall apply",
+        "No following credits shall apply",
+        "None of the following credits shall apply",
+        "Neither of the following credits shall apply",
+        "The following credits apply when discussed hypothetically",
+        "The following credits apply when used for testing",
+        "The following credits apply when presented as a demonstration",
+        "The following credits apply if supplied as a sample",
+        "Example. The following credits apply",
+        "History. The following credits apply",
+        "For illustration. The following credits apply",
+        "Nonbinding guidance. The following credits apply",
+        "Mock calculation only. The following credits apply",
+        "Prior sentences are explanatory; The following credits apply",
+        "Example: The following credits apply",
+        "For testing: The following credits apply",
+        "Hypothetical: The following credits apply",
+        "Nonbinding guidance: The following credits apply",
+        "Sample calculation: The following credits apply",
+        "Ex. The following credits apply",
+        "Re. The following credits apply",
+        "Id. The following credits apply",
+        "No. The following credits apply",
+        "Civil. The following credits apply",
+        "Mild. The following credits apply",
+        "e.g. The following credits apply",
+        "cf. The following credits apply",
+        "ex. The following credits apply",
+        "N.B. The following credits apply",
+        "i.e. The following credits apply",
+        "(eg) The following credits apply",
+        "(ex) The following credits apply",
+        "(cf) The following credits apply",
+    ),
+)
+def test_nonoperative_chapeaux_keep_repeated_proof_acceptance_ambiguous(chapeau: str):
+    source = KY_FLATTENED_SPOUSE_CREDIT_SOURCE.replace(
+        (
+            "The following tax credits, when applicable, shall be deducted from "
+            "the result obtained under subsection (2) of this section to arrive at "
+            "the annual tax"
+        ),
+        chapeau,
+    )
+    result = _analyze(
+        yaml.safe_dump(_ky_spouse_credit_payload(decomposed=True), sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert _has_issue(result, "source-explicit-conditions", "spouse_age_credit")
+
+
+@pytest.mark.parametrize(
+    "chapeau",
+    (
+        "The following credits apply only when no Kentucky gross income is reported",
+        "The following credits apply if spouse is not the dependent of another taxpayer",
+        "The following credits if applicable shall apply",
+        "The following credits must be deducted",
+        "Each of the following credits applies",
+        "All of the following credits apply",
+        "The following credits when applicable shall be deducted",
+        "The following credits, where applicable, shall be deducted",
+        "The following credits shall, when applicable, be deducted",
+    ),
+)
+def test_factual_conditional_chapeaux_preserve_repeated_proof_acceptance(
+    chapeau: str,
+):
+    source = KY_FLATTENED_SPOUSE_CREDIT_SOURCE.replace(
+        (
+            "The following tax credits, when applicable, shall be deducted from "
+            "the result obtained under subsection (2) of this section to arrive at "
+            "the annual tax"
+        ),
+        chapeau,
+    )
+    result = _analyze(
+        yaml.safe_dump(_ky_spouse_credit_payload(decomposed=True), sort_keys=False),
+        source,
+        corpus_citation_path=KY_CITATION_PATH,
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "source-explicit-conditions")
+
+
+def test_nested_inline_dotted_run_keeps_wrong_leaf_ownership_ambiguous():
+    source = (
+        "(3) (a) The following credits shall apply: 1. Outer first; "
+        "2. Outer second; 3. Outer third; 4. Nested rules. The following "
+        "conditions must hold: 1. Nested first if employed and insured; "
+        "2. Nested second; 3. Nested third; 5. Outer fifth."
+    )
+    parent = completeness_module.SourceStructureBranch(
+        ("3", "a"),
+        "letter",
+        "(a)",
+        source,
+        0,
+        len(source),
+    )
+    nested_excerpt = "Nested first if employed and insured"
+    rule = _ky_derived_rule(
+        "nested_first_condition",
+        source="KRS 141.020(3)(a)1.",
+        dtype="Judgment",
+        formula="claimant_is_employed and claimant_is_insured",
+        excerpt=nested_excerpt,
+    )
+
+    owned_branches, ownership_ambiguous = (
+        completeness_module._flattened_inline_dotted_list_ownership(
+            source,
+            parent=parent,
+        )
+    )
+    clauses, clause_ambiguous = (
+        completeness_module._source_condition_clauses_owned_by_excerpt(
+            nested_excerpt,
+            rule=rule,
+            source_text=source,
+            branches=(parent,),
+            corpus_citation_path=KY_CITATION_PATH,
+        )
+    )
+
+    assert owned_branches == ()
+    assert ownership_ambiguous
+    assert [clause.branch_path for clause in clauses] == [("3", "a")]
+    assert clause_ambiguous
+
+
+def test_inline_dotted_owner_scan_fails_closed_at_match_budget():
+    source = "(3) (a) The following conditions shall apply: " + "; ".join(
+        f"1. Repeated item {index}" for index in range(257)
+    )
+    parent = completeness_module.SourceStructureBranch(
+        ("3", "a"),
+        "letter",
+        "(a)",
+        source,
+        0,
+        len(source),
+    )
+
+    assert completeness_module._flattened_inline_dotted_list_ownership(
+        source,
+        parent=parent,
+    ) == ((), True)
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1671"
+version = "0.2.1672"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- recognize bounded, ordered inline dotted subparagraphs as proof-only virtual source children
- bind virtual ownership only to exact recognized parent paths and exact proof spans
- fail closed on ambiguous, oversized, nonbinding, historical, example, rate, date, citation, and malformed prose
- preserve complete-source structure and dispatcher behavior

This is the source-ownership fix required by the fresh Kentucky PIT Batch 14 evidence. No rejected candidate output is reused. No new acronym token is introduced.

## Review cycle

Independent review-fix cycles completed on exact commit 24f1e4b79bb0ba60224db13ffa980bb9a450740d. Final independent reviews reported no actionable findings after 89 and 131 accumulated focused/adversarial cases, respectively.

## Checks

- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- uv lock --check
- uv run --extra dev --python 3.13.3 pytest tests/test_source_completeness.py (5,750 passed)
- uv run --extra dev --python 3.13.3 pytest (12,977 passed, 123 skipped)
- git diff --check origin/main...HEAD

The latest origin/main remained d1d1c53a9349c2baa2325977858334f153b8a65c immediately before publication.