### PR TITLE
Fix proof scope ownership for nested subsections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1672"
+version = "0.2.1673"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1672"
+__version__ = "0.2.1673"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -38599,8 +38599,7 @@ def _declared_rule_subsection_source_segment(
             )
         )
         direct_indent = min(
-            len(match.group("indent").expandtabs(2))
-            for match in structural_markers
+            len(match.group("indent").expandtabs(2)) for match in structural_markers
         )
         markers = [
             match
@@ -38634,8 +38633,7 @@ def _declared_rule_subsection_source_segment(
                     for structural in structural_markers
                     if structural.start() < match.start()
                     and structural.group("marker").isdigit()
-                    and len(structural.group("indent").expandtabs(2))
-                    == direct_indent
+                    and len(structural.group("indent").expandtabs(2)) == direct_indent
                 ]
             )
             or any(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -212,11 +212,16 @@ from .harness.policyengine_runtime import (
     PolicyEngineRuntimeError,
 )
 from .harness.proof_validator import (
+    _UNRESOLVED_NUMERIC_ALPHA_PARENT,
     MONEY_UNITS,
     MoneyAtomRatchet,
     ProofValidationResult,
+    _rule_source_broad_structural_chains,
+    _rule_source_deeper_roman_scope,
+    _rule_source_numeric_parent_alpha_scope,
     _rule_source_subsection_scope,
     _source_contains_proof_evidence,
+    _source_numeric_parent_alpha_range_blocks,
     emit_money_atom_ratchet,
     evaluate_money_atoms,
     find_noncanonical_corpus_citation_path_issues,
@@ -38518,13 +38523,57 @@ def _declared_rule_subsection_source_text(
     if not isinstance(rule_source, str):
         return None
     scope = _rule_source_subsection_scope(rule_source)
-    if not scope:
+    deeper_roman_parents = {
+        next(coordinate for coordinate in chain if not coordinate.isdigit())
+        for chain in _rule_source_deeper_roman_scope(rule_source)
+    }
+    scope = {
+        parent: children
+        for parent, children in scope.items()
+        if parent not in deeper_roman_parents or children is None
+    }
+    numeric_parent_alpha_scope = _rule_source_numeric_parent_alpha_scope(rule_source)
+    unresolved_alpha_markers = numeric_parent_alpha_scope.get(
+        _UNRESOLVED_NUMERIC_ALPHA_PARENT,
+        frozenset(),
+    )
+    authoritative_alpha_parents = {
+        next(coordinate for coordinate in chain if not coordinate.isdigit())
+        for chain in _rule_source_broad_structural_chains(rule_source)
+    }
+    scope = {
+        parent: children
+        for parent, children in scope.items()
+        if parent not in unresolved_alpha_markers
+        or parent in authoritative_alpha_parents
+    }
+    resolved_numeric_parent_alpha_scope = {
+        parent: children
+        for parent, children in numeric_parent_alpha_scope.items()
+        if parent != _UNRESOLVED_NUMERIC_ALPHA_PARENT
+    }
+    if not scope and not resolved_numeric_parent_alpha_scope:
         return None
-    selected_segments = [
-        selected
-        for segment in split_proof_evidence_text(source_text)
-        if (selected := _declared_rule_subsection_source_segment(segment, scope))
-    ]
+    evidence_segments = split_proof_evidence_text(source_text)
+    numeric_selected_segments = (
+        _declared_rule_numeric_parent_alpha_source_segments(
+            source_text,
+            resolved_numeric_parent_alpha_scope,
+        )
+        if resolved_numeric_parent_alpha_scope
+        else {}
+    )
+    selected_segments = []
+    for segment_index, segment in enumerate(evidence_segments):
+        selected_parts = []
+        if scope and (
+            selected := _declared_rule_subsection_source_segment(segment, scope)
+        ):
+            selected_parts.append(selected)
+        if selected := numeric_selected_segments.get(segment_index):
+            selected_parts.append(selected)
+        if selected_parts:
+            selected_segments.append("\n\n".join(selected_parts))
     return PROOF_EVIDENCE_SEGMENT_SEPARATOR.join(selected_segments) or None
 
 
@@ -38534,7 +38583,67 @@ def _declared_rule_subsection_source_segment(
 ) -> str | None:
     """Select subsection blocks without joining distinct evidence records."""
 
-    markers = list(re.finditer(r"(?m)^[ \t]*\((?P<marker>[a-z])\)[ \t]+", source))
+    markers = list(
+        re.finditer(
+            r"(?m)^(?P<indent>[ \t]*)\((?P<marker>[a-z])\)[ \t]+",
+            source,
+        )
+    )
+    if markers:
+        structural_markers = list(
+            re.finditer(
+                r"(?m)^(?P<indent>[ \t]*)"
+                r"\((?P<marker>\d+|[ivxlcdmIVXLCDM]{2,}|[IVXLCDM]|[a-z])\)"
+                r"[ \t]+",
+                source,
+            )
+        )
+        direct_indent = min(
+            len(match.group("indent").expandtabs(2))
+            for match in structural_markers
+        )
+        markers = [
+            match
+            for match in markers
+            if len(match.group("indent").expandtabs(2)) == direct_indent
+        ]
+        if len(markers) > 1:
+            ordered_markers = []
+            expected = markers[0].group("marker")
+            previous_marker = None
+            for match in markers:
+                if match.group("marker") != expected:
+                    if previous_marker is None or not any(
+                        previous_marker.start() < structural.start() < match.start()
+                        and len(structural.group("indent").expandtabs(2))
+                        > direct_indent
+                        for structural in structural_markers
+                    ):
+                        break
+                    expected = match.group("marker")
+                ordered_markers.append(match)
+                expected = chr(ord(expected) + 1)
+                previous_marker = match
+            markers = ordered_markers
+        markers = [
+            match
+            for match in markers
+            if not (
+                prior_numerics := [
+                    structural
+                    for structural in structural_markers
+                    if structural.start() < match.start()
+                    and structural.group("marker").isdigit()
+                    and len(structural.group("indent").expandtabs(2))
+                    == direct_indent
+                ]
+            )
+            or any(
+                prior_numerics[-1].start() < structural.start() < match.start()
+                and len(structural.group("indent").expandtabs(2)) > direct_indent
+                for structural in structural_markers
+            )
+        ]
     blocks: list[str] = []
     for index, marker in enumerate(markers):
         top = marker.group("marker")
@@ -38564,6 +38673,26 @@ def _declared_rule_subsection_source_segment(
         elif not child_markers:
             blocks.append(block)
     return "\n\n".join(blocks) or None
+
+
+def _declared_rule_numeric_parent_alpha_source_segments(
+    source: str,
+    scope: dict[str, frozenset[str]],
+) -> dict[int, str]:
+    """Select parent-owned alpha children without joining evidence records."""
+    blocks = _source_numeric_parent_alpha_range_blocks(source, scope)
+    selected: dict[int, list[str]] = {}
+    offset = 0
+    for segment_index, segment in enumerate(split_proof_evidence_text(source)):
+        segment_end = offset + len(segment)
+        for _, _, start, end in blocks:
+            if offset <= start < segment_end and end <= segment_end:
+                selected.setdefault(segment_index, []).append(source[start:end])
+        offset = segment_end + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
+    return {
+        segment_index: "\n\n".join(children)
+        for segment_index, children in selected.items()
+    }
 
 
 def _install_generated_yaml_payload(rules_file: Path, payload: dict) -> bool:

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -946,9 +946,7 @@ _NUMERIC_PARENT_ALPHA_RANGE_RE = re.compile(
     r"\((?P<parent>\d+)\)\s*\((?P<start>[a-z])\)\s*"
     r"(?P<separator>[^\w\s])\s*\((?P<end>[a-z])\)"
 )
-_STRUCTURAL_COORDINATE_TOKEN = (
-    r"(?:\d+|[a-z]|[IVXLCDM]|[ivxlcdmIVXLCDM]{2,})"
-)
+_STRUCTURAL_COORDINATE_TOKEN = r"(?:\d+|[a-z]|[IVXLCDM]|[ivxlcdmIVXLCDM]{2,})"
 _NUMERIC_PARENT_ALPHA_SINGLETON_RE = re.compile(
     r"\((?P<parent>\d+)\)\s*\((?P<child>[a-z])\)"
     rf"(?!\s*\({_STRUCTURAL_COORDINATE_TOKEN}\))"
@@ -1093,7 +1091,9 @@ def _roman_chain_alpha_parent(chain: tuple[str, ...]) -> str:
     return next(coordinate for coordinate in chain if not coordinate.isdigit())
 
 
-def _rule_source_broad_structural_chains(rule_source: str) -> frozenset[tuple[str, ...]]:
+def _rule_source_broad_structural_chains(
+    rule_source: str,
+) -> frozenset[tuple[str, ...]]:
     """Retain broad numeric/alpha ancestry at arbitrary structural depth."""
     chains: set[tuple[str, ...]] = set()
     coordinate_pattern = re.compile(
@@ -1127,10 +1127,7 @@ def _rule_source_broad_structural_chains(rule_source: str) -> frozenset[tuple[st
     connected_range_chains: set[tuple[str, ...]] = set()
     for start, end, coordinates in groups:
         gap = "" if previous_end is None else rule_source[previous_end:start].strip()
-        if (
-            len(gap) == 1
-            and (_is_subsection_range_separator(gap) or gap == "/")
-        ):
+        if len(gap) == 1 and (_is_subsection_range_separator(gap) or gap == "/"):
             if connected_range_active:
                 chains.difference_update(connected_range_chains)
                 connected_range_chains.clear()
@@ -1148,10 +1145,7 @@ def _rule_source_broad_structural_chains(rule_source: str) -> frozenset[tuple[st
                     if len(previous_chain[-1]) <= 10 and len(suffix) <= 10:
                         range_start = int(previous_chain[-1])
                         range_end = int(suffix)
-                        if (
-                            range_start <= range_end
-                            and range_end - range_start <= 100
-                        ):
+                        if range_start <= range_end and range_end - range_start <= 100:
                             range_values = [
                                 str(value)
                                 for value in range(range_start, range_end + 1)
@@ -1170,9 +1164,7 @@ def _rule_source_broad_structural_chains(rule_source: str) -> frozenset[tuple[st
                 chains.discard(previous_chain)
             if range_values:
                 prefix = previous_chain[:-1]
-                connected_range_chains = {
-                    (*prefix, value) for value in range_values
-                }
+                connected_range_chains = {(*prefix, value) for value in range_values}
                 chains.update(connected_range_chains)
                 previous_chain = (*prefix, range_values[-1])
             else:
@@ -1298,8 +1290,8 @@ def _masked_numeric_parent_alpha_segments(
     current_parent: str | None = None
     carry_blocked = False
     for raw_segment in str(rule_source).split(","):
-        masked, segment_scope, rightmost_parent = (
-            _masked_numeric_parent_alpha_segment(raw_segment)
+        masked, segment_scope, rightmost_parent = _masked_numeric_parent_alpha_segment(
+            raw_segment
         )
         if segment_scope:
             current_parent = rightmost_parent
@@ -1345,9 +1337,7 @@ def _rule_source_numeric_parent_alpha_scope(
             if (parent, marker) in valid_pairs:
                 scope.setdefault(parent, set()).add(marker)
             else:
-                scope.setdefault(_UNRESOLVED_NUMERIC_ALPHA_PARENT, set()).add(
-                    marker
-                )
+                scope.setdefault(_UNRESOLVED_NUMERIC_ALPHA_PARENT, set()).add(marker)
     return {parent: frozenset(markers) for parent, markers in scope.items()}
 
 
@@ -1371,9 +1361,7 @@ def _proof_excerpt_subsection_scope_issues(
     excerpt_marker = re.match(r"^\s*\((?P<marker>[a-z])\)(?:\s|$)", evidence_text)
     marker = excerpt_marker.group("marker") if excerpt_marker is not None else None
     parent_scoped_markers = {
-        child
-        for children in numeric_parent_alpha_scope.values()
-        for child in children
+        child for children in numeric_parent_alpha_scope.values() for child in children
     }
     unresolved_parent_scoped_markers = numeric_parent_alpha_scope.get(
         _UNRESOLVED_NUMERIC_ALPHA_PARENT,
@@ -1396,15 +1384,12 @@ def _proof_excerpt_subsection_scope_issues(
             scope=resolved_numeric_parent_alpha_scope,
         ):
             return []
-        authoritative_broad_chains = _rule_source_broad_structural_chains(
-            rule_source
-        )
+        authoritative_broad_chains = _rule_source_broad_structural_chains(rule_source)
         if (
-            (marker,) in authoritative_broad_chains
-            and _source_evidence_is_direct_alpha_header(
-                source_text=source_text,
-                evidence_text=evidence_text,
-            )
+            marker,
+        ) in authoritative_broad_chains and _source_evidence_is_direct_alpha_header(
+            source_text=source_text,
+            evidence_text=evidence_text,
         ):
             return []
         return [
@@ -1514,9 +1499,9 @@ def _proof_excerpt_subsection_scope_issues(
             f"subsection scope `{rule_source}` (excerpt begins at `({marker})`)."
         ]
     if declared and marker is not None and marker not in declared:
-        has_explicit_deeper_alpha_coordinate = re.search(
-            r"\([a-z]\)\s*\(\d+\)\s*\([a-z]\)", rule_source
-        ) is not None
+        has_explicit_deeper_alpha_coordinate = (
+            re.search(r"\([a-z]\)\s*\(\d+\)\s*\([a-z]\)", rule_source) is not None
+        )
         if not has_explicit_deeper_alpha_coordinate and (
             _is_nested_alpha_marker_in_declared_numeric_scope(
                 source_text=source_text,
@@ -1658,8 +1643,10 @@ def _source_roman_evidence_chain(
         0,
         evidence_match.start(),
     )
-    record_start = 0 if record_start < 0 else (
-        record_start + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
+    record_start = (
+        0
+        if record_start < 0
+        else (record_start + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR))
     )
 
     structural_headers = list(
@@ -1720,8 +1707,10 @@ def _source_evidence_is_direct_alpha_header(
         0,
         evidence_match.start(),
     )
-    record_start = 0 if record_start < 0 else (
-        record_start + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
+    record_start = (
+        0
+        if record_start < 0
+        else (record_start + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR))
     )
     record_end = source_text.find(
         PROOF_EVIDENCE_SEGMENT_SEPARATOR,
@@ -1877,8 +1866,10 @@ def _source_numeric_parent_alpha_range_blocks(
             0,
             parent_start,
         )
-        record_start = 0 if record_start < 0 else (
-            record_start + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
+        record_start = (
+            0
+            if record_start < 0
+            else (record_start + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR))
         )
         record_end = source_text.find(
             PROOF_EVIDENCE_SEGMENT_SEPARATOR,
@@ -1888,8 +1879,7 @@ def _source_numeric_parent_alpha_range_blocks(
         record_structural_indents = [
             len(match.group("indent").expandtabs(2))
             for start, event_kind, match in events
-            if event_kind in {"numeric", "alpha"}
-            and record_start <= start < record_end
+            if event_kind in {"numeric", "alpha"} and record_start <= start < record_end
         ]
         if parent_indent != min(record_structural_indents, default=parent_indent):
             continue
@@ -1903,9 +1893,7 @@ def _source_numeric_parent_alpha_range_blocks(
         previous_peer_numeric_position = max(
             (
                 position
-                for position, (_, event_kind, match) in enumerate(
-                    prior_record_events
-                )
+                for position, (_, event_kind, match) in enumerate(prior_record_events)
                 if event_kind == "numeric"
                 and len(match.group("indent").expandtabs(2)) == parent_indent
             ),

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -26,6 +26,7 @@ from typing import Any, Mapping
 import yaml
 
 from ..corpus_resolver import (
+    PROOF_EVIDENCE_SEGMENT_SEPARATOR,
     InvalidCorpusCitationError,
     require_canonical_corpus_citation_path,
     split_proof_evidence_text,
@@ -937,6 +938,419 @@ def _is_hyphen_marker(character: str) -> bool:
     )
 
 
+_ALPHA_SUBSECTION_RANGE_RE = re.compile(
+    r"\((?P<start>[a-z])\)\s*(?P<separator>[^\w\s])\s*"
+    r"\((?P<end>[a-z])\)"
+)
+_NUMERIC_PARENT_ALPHA_RANGE_RE = re.compile(
+    r"\((?P<parent>\d+)\)\s*\((?P<start>[a-z])\)\s*"
+    r"(?P<separator>[^\w\s])\s*\((?P<end>[a-z])\)"
+)
+_STRUCTURAL_COORDINATE_TOKEN = (
+    r"(?:\d+|[a-z]|[IVXLCDM]|[ivxlcdmIVXLCDM]{2,})"
+)
+_NUMERIC_PARENT_ALPHA_SINGLETON_RE = re.compile(
+    r"\((?P<parent>\d+)\)\s*\((?P<child>[a-z])\)"
+    rf"(?!\s*\({_STRUCTURAL_COORDINATE_TOKEN}\))"
+)
+_DEEPER_ROMAN_COORDINATE_RE = re.compile(
+    r"(?P<outer_chain>(?:\(\d+\)\s*)*)"
+    r"\((?P<parent>[a-z])\)(?P<numeric_chain>(?:\s*\(\d+\))*)\s*"
+    r"\((?P<start>[ivxlcdmIVXLCDM]+)\)"
+    r"(?:\s*(?P<separator>[^\w\s])\s*"
+    r"\((?P<end>[ivxlcdmIVXLCDM]+)\))?"
+)
+_SUBSECTION_RANGE_SEPARATORS = frozenset(
+    {
+        "-",  # HYPHEN-MINUS
+        "\u2010",  # HYPHEN
+        "\u2011",  # NON-BREAKING HYPHEN
+        "\u2012",  # FIGURE DASH
+        "\u2013",  # EN DASH
+        "\u2014",  # EM DASH
+        "\u2015",  # HORIZONTAL BAR
+        "\u2212",  # MINUS SIGN
+        "\uff0d",  # FULLWIDTH HYPHEN-MINUS
+    }
+)
+_UNRESOLVED_NUMERIC_ALPHA_PARENT = "<unresolved>"
+
+
+def _is_subsection_range_separator(character: str) -> bool:
+    """Recognize legal hyphen/dash glyphs without admitting other punctuation."""
+    return character in _SUBSECTION_RANGE_SEPARATORS
+
+
+def _canonical_roman_value(token: str) -> int | None:
+    """Return a bounded canonical Roman value, independent of source case."""
+    values = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
+    upper = token.upper()
+    total = 0
+    previous = 0
+    for character in reversed(upper):
+        value = values[character]
+        if value < previous:
+            total -= value
+        else:
+            total += value
+            previous = value
+    if not 0 < total <= 3999:
+        return None
+
+    remainder = total
+    rendered = []
+    for value, numeral in (
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ):
+        count, remainder = divmod(remainder, value)
+        rendered.append(numeral * count)
+    return total if "".join(rendered) == upper else None
+
+
+def _canonical_roman_marker(value: int) -> str:
+    """Render a validated Roman coordinate in its normalized lowercase form."""
+    remainder = value
+    rendered = []
+    for number, numeral in (
+        (1000, "m"),
+        (900, "cm"),
+        (500, "d"),
+        (400, "cd"),
+        (100, "c"),
+        (90, "xc"),
+        (50, "l"),
+        (40, "xl"),
+        (10, "x"),
+        (9, "ix"),
+        (5, "v"),
+        (4, "iv"),
+        (1, "i"),
+    ):
+        count, remainder = divmod(remainder, number)
+        rendered.append(numeral * count)
+    return "".join(rendered)
+
+
+def _deeper_roman_match_markers(match: re.Match[str]) -> frozenset[str]:
+    """Expand one canonical singleton/range, failing closed on malformed ranges."""
+    start = _canonical_roman_value(match.group("start"))
+    if start is None:
+        return frozenset()
+    end_token = match.group("end")
+    if end_token is None:
+        return frozenset({_canonical_roman_marker(start)})
+    separator = match.group("separator")
+    end = _canonical_roman_value(end_token)
+    if (
+        separator is None
+        or not _is_subsection_range_separator(separator)
+        or end is None
+        or start > end
+        or end - start > 100
+    ):
+        return frozenset()
+    return frozenset(_canonical_roman_marker(value) for value in range(start, end + 1))
+
+
+def _rule_source_deeper_roman_scope(
+    rule_source: str,
+) -> dict[tuple[str, ...], frozenset[str] | None]:
+    """Parse exact Roman children with their complete alpha/numeric ownership."""
+    scope: dict[tuple[str, ...], set[str] | None] = {}
+    for match in _DEEPER_ROMAN_COORDINATE_RE.finditer(rule_source):
+        chain = (
+            *re.findall(r"\((\d+)\)", match.group("outer_chain")),
+            match.group("parent"),
+            *re.findall(r"\((\d+)\)", match.group("numeric_chain")),
+        )
+        markers = _deeper_roman_match_markers(match)
+        if not markers:
+            scope[chain] = None
+        elif scope.get(chain, set()) is not None:
+            current = scope.setdefault(chain, set())
+            assert isinstance(current, set)
+            current.update(markers)
+    return {
+        chain: None if markers is None else frozenset(markers)
+        for chain, markers in scope.items()
+    }
+
+
+def _roman_chain_alpha_parent(chain: tuple[str, ...]) -> str:
+    """Return the single alphabetic owner retained in a Roman coordinate chain."""
+    return next(coordinate for coordinate in chain if not coordinate.isdigit())
+
+
+def _rule_source_broad_structural_chains(rule_source: str) -> frozenset[tuple[str, ...]]:
+    """Retain broad numeric/alpha ancestry at arbitrary structural depth."""
+    chains: set[tuple[str, ...]] = set()
+    coordinate_pattern = re.compile(
+        r"\((?P<coordinate>\d+|[a-z]|[ivxlcdmIVXLCDM]{2,}|[IVXLCDM])\)"
+    )
+    groups: list[tuple[int, int, tuple[str, ...]]] = []
+    current: list[re.Match[str]] = []
+    for match in coordinate_pattern.finditer(rule_source):
+        if current and rule_source[current[-1].end() : match.start()].strip():
+            groups.append(
+                (
+                    current[0].start(),
+                    current[-1].end(),
+                    tuple(item.group("coordinate") for item in current),
+                )
+            )
+            current = []
+        current.append(match)
+    if current:
+        groups.append(
+            (
+                current[0].start(),
+                current[-1].end(),
+                tuple(item.group("coordinate") for item in current),
+            )
+        )
+
+    previous_end: int | None = None
+    previous_chain: tuple[str, ...] | None = None
+    connected_range_active = False
+    connected_range_chains: set[tuple[str, ...]] = set()
+    for start, end, coordinates in groups:
+        gap = "" if previous_end is None else rule_source[previous_end:start].strip()
+        if (
+            len(gap) == 1
+            and (_is_subsection_range_separator(gap) or gap == "/")
+        ):
+            if connected_range_active:
+                chains.difference_update(connected_range_chains)
+                connected_range_chains.clear()
+                previous_chain = None
+                previous_end = end
+                continue
+            suffix = coordinates[0] if len(coordinates) == 1 else None
+            range_values: list[str] = []
+            if (
+                previous_chain is not None
+                and _is_subsection_range_separator(gap)
+                and suffix is not None
+            ):
+                if previous_chain[-1].isdigit() and suffix.isdigit():
+                    if len(previous_chain[-1]) <= 10 and len(suffix) <= 10:
+                        range_start = int(previous_chain[-1])
+                        range_end = int(suffix)
+                        if (
+                            range_start <= range_end
+                            and range_end - range_start <= 100
+                        ):
+                            range_values = [
+                                str(value)
+                                for value in range(range_start, range_end + 1)
+                            ]
+                elif (
+                    re.fullmatch(r"[a-z]", previous_chain[-1]) is not None
+                    and re.fullmatch(r"[a-z]", suffix) is not None
+                ):
+                    range_start = ord(previous_chain[-1])
+                    range_end = ord(suffix)
+                    if range_start <= range_end and range_end - range_start <= 25:
+                        range_values = [
+                            chr(value) for value in range(range_start, range_end + 1)
+                        ]
+            if previous_chain is not None:
+                chains.discard(previous_chain)
+            if range_values:
+                prefix = previous_chain[:-1]
+                connected_range_chains = {
+                    (*prefix, value) for value in range_values
+                }
+                chains.update(connected_range_chains)
+                previous_chain = (*prefix, range_values[-1])
+            else:
+                previous_chain = None
+            connected_range_active = True
+            previous_end = end
+            continue
+
+        connected_range_active = False
+        connected_range_chains.clear()
+
+        if gap == "," and len(coordinates) == 1:
+            if (
+                previous_chain is not None
+                and previous_chain[-1].isdigit() == coordinates[0].isdigit()
+            ):
+                shorthand = (*previous_chain[:-1], coordinates[0])
+                chains.add(shorthand)
+                previous_chain = shorthand
+            else:
+                previous_chain = None
+            previous_end = end
+            continue
+
+        alpha_coordinates = [
+            coordinate for coordinate in coordinates if not coordinate.isdigit()
+        ]
+        chain = (
+            coordinates
+            if len(alpha_coordinates) == 1
+            and re.fullmatch(r"[a-z]", alpha_coordinates[0]) is not None
+            else None
+        )
+        if chain is not None:
+            chains.add(chain)
+        previous_chain = chain
+        previous_end = end
+    return frozenset(chains)
+
+
+def _expanded_alpha_subsection_range_markers(value: str) -> frozenset[str]:
+    """Expand bounded ascending single-letter subsection ranges."""
+    expanded: set[str] = set()
+    for match in _ALPHA_SUBSECTION_RANGE_RE.finditer(value):
+        if not _is_subsection_range_separator(match.group("separator")):
+            continue
+        start = ord(match.group("start"))
+        end = ord(match.group("end"))
+        if start <= end and end - start <= 25:
+            expanded.update(chr(codepoint) for codepoint in range(start, end + 1))
+    return frozenset(expanded)
+
+
+def _numeric_parent_alpha_range_match_markers(
+    segment: str,
+    match: re.Match[str],
+) -> frozenset[str]:
+    """Return a direct alphabetic child range or fail closed for nested/Roman use."""
+    prefix = segment[: match.start()]
+    if re.search(rf"\({_STRUCTURAL_COORDINATE_TOKEN}\)\s*$", prefix):
+        return frozenset()
+    return _expanded_alpha_subsection_range_markers(match.group(0))
+
+
+def _masked_numeric_parent_alpha_segment(
+    segment: str,
+) -> tuple[str, dict[str, set[str]], str | None]:
+    """Mask handled direct numeric-parent alpha coordinates in one segment."""
+    masked = segment
+    scope: dict[str, set[str]] = {}
+    rightmost_parent: tuple[int, str] | None = None
+    for match in reversed(list(_NUMERIC_PARENT_ALPHA_RANGE_RE.finditer(masked))):
+        markers = _numeric_parent_alpha_range_match_markers(masked, match)
+        if not markers:
+            continue
+        scope.setdefault(match.group("parent"), set()).update(markers)
+        if rightmost_parent is None or match.end() > rightmost_parent[0]:
+            rightmost_parent = (match.end(), match.group("parent"))
+        masked = (
+            masked[: match.start()]
+            + " " * (match.end() - match.start())
+            + masked[match.end() :]
+        )
+    for match in reversed(list(_NUMERIC_PARENT_ALPHA_SINGLETON_RE.finditer(masked))):
+        prefix = masked[: match.start()]
+        if re.search(rf"\({_STRUCTURAL_COORDINATE_TOKEN}\)\s*$", prefix):
+            continue
+        scope.setdefault(match.group("parent"), set()).add(match.group("child"))
+        if rightmost_parent is None or match.end() > rightmost_parent[0]:
+            rightmost_parent = (match.end(), match.group("parent"))
+        masked = (
+            masked[: match.start()]
+            + " " * (match.end() - match.start())
+            + masked[match.end() :]
+        )
+    if rightmost_parent is not None and re.search(
+        rf"\({_STRUCTURAL_COORDINATE_TOKEN}\)",
+        masked[rightmost_parent[0] :],
+    ):
+        rightmost_parent = None
+    return masked, scope, None if rightmost_parent is None else rightmost_parent[1]
+
+
+def _masked_deeper_roman_segment(segment: str) -> tuple[str, frozenset[str]]:
+    """Mask unsupported deeper Roman coordinates while preserving other scope."""
+    masked = segment
+    parents: set[str] = set()
+    for match in reversed(list(_DEEPER_ROMAN_COORDINATE_RE.finditer(segment))):
+        parents.add(match.group("parent"))
+        masked = (
+            masked[: match.start()]
+            + " " * (match.end() - match.start())
+            + masked[match.end() :]
+        )
+    return masked, frozenset(parents)
+
+
+def _masked_numeric_parent_alpha_segments(
+    rule_source: str,
+) -> list[tuple[str, dict[str, set[str]]]]:
+    """Mask direct coordinates and carry exact alpha comma shorthand ownership."""
+    results: list[tuple[str, dict[str, set[str]]]] = []
+    current_parent: str | None = None
+    carry_blocked = False
+    for raw_segment in str(rule_source).split(","):
+        masked, segment_scope, rightmost_parent = (
+            _masked_numeric_parent_alpha_segment(raw_segment)
+        )
+        if segment_scope:
+            current_parent = rightmost_parent
+            carry_blocked = rightmost_parent is None
+        elif shorthand := re.fullmatch(
+            r"\s*\((?P<child>[a-z])\)\s*",
+            raw_segment,
+        ):
+            if current_parent is not None:
+                segment_scope = {current_parent: {shorthand.group("child")}}
+                masked = " " * len(raw_segment)
+            elif carry_blocked:
+                segment_scope = {
+                    _UNRESOLVED_NUMERIC_ALPHA_PARENT: {shorthand.group("child")}
+                }
+                masked = " " * len(raw_segment)
+        else:
+            current_parent = None
+            carry_blocked = False
+        results.append((masked, segment_scope))
+    return results
+
+
+def _rule_source_numeric_parent_alpha_scope(
+    rule_source: str,
+) -> dict[str, frozenset[str]]:
+    """Parse direct numeric-parent alphabetic coordinates without flattening."""
+    raw_scope: dict[str, set[str]] = {}
+    for _, segment_scope in _masked_numeric_parent_alpha_segments(rule_source):
+        for parent, markers in segment_scope.items():
+            raw_scope.setdefault(parent, set()).update(markers)
+    valid_pairs = {
+        chain
+        for chain in _rule_source_broad_structural_chains(rule_source)
+        if len(chain) == 2 and chain[0].isdigit() and not chain[1].isdigit()
+    }
+    scope: dict[str, set[str]] = {}
+    for parent, markers in raw_scope.items():
+        if parent == _UNRESOLVED_NUMERIC_ALPHA_PARENT:
+            scope.setdefault(parent, set()).update(markers)
+            continue
+        for marker in markers:
+            if (parent, marker) in valid_pairs:
+                scope.setdefault(parent, set()).add(marker)
+            else:
+                scope.setdefault(_UNRESOLVED_NUMERIC_ALPHA_PARENT, set()).add(
+                    marker
+                )
+    return {parent: frozenset(markers) for parent, markers in scope.items()}
+
+
 def _proof_excerpt_subsection_scope_issues(
     *,
     source_text: str,
@@ -949,18 +1363,167 @@ def _proof_excerpt_subsection_scope_issues(
     if not isinstance(rule_source, str):
         return []
     scope = _rule_source_subsection_scope(rule_source)
+    numeric_parent_alpha_scope = _rule_source_numeric_parent_alpha_scope(rule_source)
     declared = {
         match.group("marker")
         for match in re.finditer(r"\((?P<marker>[a-z])\)", rule_source)
     }
     excerpt_marker = re.match(r"^\s*\((?P<marker>[a-z])\)(?:\s|$)", evidence_text)
     marker = excerpt_marker.group("marker") if excerpt_marker is not None else None
-    if declared and marker is not None and marker not in declared:
-        if _is_nested_alpha_marker_in_declared_numeric_scope(
+    parent_scoped_markers = {
+        child
+        for children in numeric_parent_alpha_scope.values()
+        for child in children
+    }
+    unresolved_parent_scoped_markers = numeric_parent_alpha_scope.get(
+        _UNRESOLVED_NUMERIC_ALPHA_PARENT,
+        frozenset(),
+    )
+    if marker is not None and marker in unresolved_parent_scoped_markers:
+        resolved_numeric_parent_alpha_scope = {
+            parent: children
+            for parent, children in numeric_parent_alpha_scope.items()
+            if parent != _UNRESOLVED_NUMERIC_ALPHA_PARENT
+        }
+        if marker in {
+            child
+            for children in resolved_numeric_parent_alpha_scope.values()
+            for child in children
+        } and _is_alpha_marker_in_declared_numeric_parent_scope(
             source_text=source_text,
             evidence_text=evidence_text,
             marker=marker,
-            scope=scope,
+            scope=resolved_numeric_parent_alpha_scope,
+        ):
+            return []
+        authoritative_broad_chains = _rule_source_broad_structural_chains(
+            rule_source
+        )
+        if (
+            (marker,) in authoritative_broad_chains
+            and _source_evidence_is_direct_alpha_header(
+                source_text=source_text,
+                evidence_text=evidence_text,
+            )
+        ):
+            return []
+        return [
+            "Proof source evidence not found: "
+            f"{label} `source.{field}` appears outside the rule's declared "
+            f"subsection scope `{rule_source}` (excerpt begins at `({marker})`)."
+        ]
+    if marker is not None and marker in parent_scoped_markers and marker not in scope:
+        if _is_alpha_marker_in_declared_numeric_parent_scope(
+            source_text=source_text,
+            evidence_text=evidence_text,
+            marker=marker,
+            scope=numeric_parent_alpha_scope,
+        ):
+            return []
+        return [
+            "Proof source evidence not found: "
+            f"{label} `source.{field}` appears outside the rule's declared "
+            f"subsection scope `{rule_source}` (excerpt begins at `({marker})`)."
+        ]
+    deeper_roman_scope = _rule_source_deeper_roman_scope(rule_source)
+    deeper_roman_parents = frozenset(
+        _roman_chain_alpha_parent(chain) for chain in deeper_roman_scope
+    )
+    independently_broad = (
+        marker is not None and marker in scope and scope[marker] is None
+    )
+    roman_evidence_marker = re.match(
+        r"^\s*\((?P<marker>[ivxlcdmIVXLCDM]+)\)(?:\s|$)",
+        evidence_text,
+    )
+    source_chain = _source_roman_evidence_chain(
+        source_text=source_text,
+        evidence_text=evidence_text,
+    )
+    verified_broad_alpha = independently_broad and (
+        _source_text_is_exact_evidence_scalar(source_text, evidence_text)
+        or _source_evidence_is_direct_alpha_header(
+            source_text=source_text,
+            evidence_text=evidence_text,
+        )
+    )
+    roman_marker_is_authorized = False
+    if (
+        deeper_roman_parents
+        and roman_evidence_marker is not None
+        and not verified_broad_alpha
+    ):
+        roman_marker = roman_evidence_marker.group("marker")
+        normalized_roman_marker = _canonical_roman_value(roman_marker)
+        broad_roman_chains = set(_rule_source_broad_structural_chains(rule_source))
+        broad_roman_parents = {
+            _roman_chain_alpha_parent(chain) for chain in broad_roman_chains
+        }
+        matching_broad_chains = (
+            []
+            if source_chain is None
+            else [
+                chain
+                for chain in broad_roman_chains
+                if source_chain[: len(chain)] == chain
+            ]
+        )
+        broad_roman_parent = (
+            source_chain is not None
+            and len(matching_broad_chains) == 1
+            and normalized_roman_marker is not None
+            and _source_roman_coordinate_occurrence_count(
+                source_text=source_text,
+                chain=source_chain,
+                marker=_canonical_roman_marker(normalized_roman_marker),
+            )
+            == 1
+        ) or (
+            source_chain is None
+            and _source_text_is_exact_evidence_scalar(source_text, evidence_text)
+            and len(broad_roman_chains) == 1
+            and len(deeper_roman_parents) == 1
+            and deeper_roman_parents <= broad_roman_parents
+        )
+        roman_marker_is_owned = (
+            normalized_roman_marker is not None
+            and _is_roman_marker_in_declared_scope(
+                source_text=source_text,
+                evidence_text=evidence_text,
+                marker=_canonical_roman_marker(normalized_roman_marker),
+                scope=deeper_roman_scope,
+            )
+        )
+        if not broad_roman_parent and not roman_marker_is_owned:
+            return [
+                "Proof source evidence not found: "
+                f"{label} `source.{field}` appears outside the rule's declared "
+                f"subsection scope `{rule_source}` "
+                f"(excerpt begins at `({roman_marker})`)."
+            ]
+        roman_marker_is_authorized = True
+    if (
+        marker is not None
+        and marker in deeper_roman_parents
+        and not independently_broad
+        and not roman_marker_is_authorized
+    ):
+        return [
+            "Proof source evidence not found: "
+            f"{label} `source.{field}` appears outside the rule's declared "
+            f"subsection scope `{rule_source}` (excerpt begins at `({marker})`)."
+        ]
+    if declared and marker is not None and marker not in declared:
+        has_explicit_deeper_alpha_coordinate = re.search(
+            r"\([a-z]\)\s*\(\d+\)\s*\([a-z]\)", rule_source
+        ) is not None
+        if not has_explicit_deeper_alpha_coordinate and (
+            _is_nested_alpha_marker_in_declared_numeric_scope(
+                source_text=source_text,
+                evidence_text=evidence_text,
+                marker=marker,
+                scope=scope,
+            )
         ):
             return []
         return [
@@ -988,6 +1551,452 @@ def _proof_excerpt_subsection_scope_issues(
         f"{label} `source.{field}` appears outside the rule's declared "
         f"subsection scope `{rule_source}` (excerpt begins at `({numeric})`)."
     ]
+
+
+def _is_roman_marker_in_declared_scope(
+    *,
+    source_text: str,
+    evidence_text: str,
+    marker: str,
+    scope: Mapping[tuple[str, ...], frozenset[str] | None],
+) -> bool:
+    """Require a Roman excerpt to belong to its cited alpha/numeric chain."""
+    declared_chains = {
+        chain
+        for chain, children in scope.items()
+        if children is not None and marker in children
+    }
+    if not declared_chains:
+        return False
+
+    if _source_text_is_exact_evidence_scalar(source_text, evidence_text):
+        # Some corpus units are already the exact cited scalar, with no parent
+        # headings available to resolve. Marker membership is the tightest
+        # ownership proof possible for that established representation.
+        return len(declared_chains) == 1
+
+    source_chain = _source_roman_evidence_chain(
+        source_text=source_text,
+        evidence_text=evidence_text,
+    )
+    return source_chain in declared_chains and (
+        _source_roman_coordinate_occurrence_count(
+            source_text=source_text,
+            chain=source_chain,
+            marker=marker,
+        )
+        == 1
+    )
+
+
+def _source_roman_coordinate_occurrence_count(
+    *,
+    source_text: str,
+    chain: tuple[str, ...],
+    marker: str,
+) -> int:
+    """Count a complete Roman coordinate without carrying ancestry across records."""
+    count = 0
+    header_pattern = re.compile(
+        r"(?m)^(?P<indent>[ \t]*)"
+        r"\((?P<marker>\d+|[ivxlcdmIVXLCDM]{2,}|[IVXLCDM]|[a-z])\)"
+        r"[ \t]+"
+    )
+    for record in source_text.split(PROOF_EVIDENCE_SEGMENT_SEPARATOR):
+        stack: list[tuple[int, str]] = []
+        for header in header_pattern.finditer(record):
+            indent = len(header.group("indent").expandtabs(2))
+            while stack and indent <= stack[-1][0]:
+                stack.pop()
+            raw_marker = header.group("marker")
+            roman_value = (
+                _canonical_roman_value(raw_marker)
+                if re.fullmatch(r"[ivxlcdmIVXLCDM]+", raw_marker) is not None
+                else None
+            )
+            if (
+                tuple(value for _, value in stack) == chain
+                and roman_value is not None
+                and _canonical_roman_marker(roman_value) == marker
+            ):
+                count += 1
+            stack.append((indent, raw_marker))
+    return count
+
+
+def _source_text_is_exact_evidence_scalar(
+    source_text: str,
+    evidence_text: str,
+) -> bool:
+    """Recognize an established corpus unit containing only the proof scalar."""
+    return source_text.strip() == evidence_text.strip()
+
+
+def _source_roman_evidence_chain(
+    *,
+    source_text: str,
+    evidence_text: str,
+) -> tuple[str, ...] | None:
+    """Resolve one Roman excerpt's structural owner within one evidence record."""
+    words = re.split(r"\s+", evidence_text.strip())
+    evidence_pattern = r"\s+".join(re.escape(word) for word in words)
+    evidence_matches = [
+        match
+        for match in re.finditer(evidence_pattern, source_text)
+        if _source_evidence_span_is_bounded(
+            evidence_text=evidence_text,
+            source_text=source_text,
+            start=match.start(),
+            end=match.end(),
+        )
+    ]
+    if len(evidence_matches) != 1:
+        return None
+    evidence_match = evidence_matches[0]
+    record_start = source_text.rfind(
+        PROOF_EVIDENCE_SEGMENT_SEPARATOR,
+        0,
+        evidence_match.start(),
+    )
+    record_start = 0 if record_start < 0 else (
+        record_start + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
+    )
+
+    structural_headers = list(
+        re.compile(
+            r"(?m)^(?P<indent>[ \t]*)"
+            r"\((?P<marker>\d+|[ivxlcdmIVXLCDM]{2,}|[IVXLCDM]|[a-z])\)"
+            r"[ \t]+",
+        ).finditer(source_text, record_start, evidence_match.end())
+    )
+    stack: list[tuple[int, str]] = []
+    for header in structural_headers:
+        if header.start() > evidence_match.start():
+            break
+        indent = len(header.group("indent").expandtabs(2))
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        marker_start = header.start("marker") - 1
+        if marker_start == evidence_match.start():
+            ancestry = tuple(value for _, value in stack)
+            alpha_indexes = [
+                index
+                for index, coordinate in enumerate(ancestry)
+                if not coordinate.isdigit()
+            ]
+            if len(alpha_indexes) != 1:
+                return None
+            alpha = ancestry[alpha_indexes[0]]
+            if len(alpha) != 1 or not alpha.islower():
+                return None
+            return ancestry
+        stack.append((indent, header.group("marker")))
+    return None
+
+
+def _source_evidence_is_direct_alpha_header(
+    *,
+    source_text: str,
+    evidence_text: str,
+) -> bool:
+    """Prove a Roman-looking singleton is a direct alpha header, not nested."""
+    words = re.split(r"\s+", evidence_text.strip())
+    evidence_pattern = r"\s+".join(re.escape(word) for word in words)
+    evidence_matches = [
+        match
+        for match in re.finditer(evidence_pattern, source_text)
+        if _source_evidence_span_is_bounded(
+            evidence_text=evidence_text,
+            source_text=source_text,
+            start=match.start(),
+            end=match.end(),
+        )
+    ]
+    if len(evidence_matches) != 1:
+        return False
+    evidence_match = evidence_matches[0]
+    record_start = source_text.rfind(
+        PROOF_EVIDENCE_SEGMENT_SEPARATOR,
+        0,
+        evidence_match.start(),
+    )
+    record_start = 0 if record_start < 0 else (
+        record_start + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
+    )
+    record_end = source_text.find(
+        PROOF_EVIDENCE_SEGMENT_SEPARATOR,
+        evidence_match.end(),
+    )
+    record_end = len(source_text) if record_end < 0 else record_end
+    headers = list(
+        re.compile(
+            r"(?m)^(?P<indent>[ \t]*)"
+            r"\((?P<marker>\d+|[ivxlcdmIVXLCDM]{2,}|[IVXLCDM]|[a-z])\)"
+            r"[ \t]+"
+        ).finditer(source_text, record_start, record_end)
+    )
+    evidence_header = next(
+        (
+            header
+            for header in headers
+            if header.start("marker") - 1 == evidence_match.start()
+            and re.fullmatch(r"[a-z]", header.group("marker")) is not None
+        ),
+        None,
+    )
+    if evidence_header is None:
+        return False
+    evidence_indent = len(evidence_header.group("indent").expandtabs(2))
+    direct_indent = min(
+        (len(header.group("indent").expandtabs(2)) for header in headers),
+        default=evidence_indent,
+    )
+    if evidence_indent != direct_indent:
+        return False
+    same_depth_same_marker = [
+        header
+        for header in headers
+        if header.group("marker") == evidence_header.group("marker")
+        and len(header.group("indent").expandtabs(2)) == evidence_indent
+    ]
+    if len(same_depth_same_marker) != 1:
+        return False
+    direct_alpha_headers = [
+        header
+        for header in headers
+        if re.fullmatch(r"[a-z]", header.group("marker")) is not None
+        and len(header.group("indent").expandtabs(2)) == evidence_indent
+    ]
+    if len(direct_alpha_headers) > 1:
+        expected = direct_alpha_headers[0].group("marker")
+        ordered_headers = []
+        previous_header = None
+        for header in direct_alpha_headers:
+            if header.group("marker") != expected:
+                if previous_header is None or not any(
+                    previous_header.start() < nested.start() < header.start()
+                    and len(nested.group("indent").expandtabs(2)) > evidence_indent
+                    for nested in headers
+                ):
+                    break
+                expected = header.group("marker")
+            ordered_headers.append(header)
+            expected = chr(ord(expected) + 1)
+            previous_header = header
+        if evidence_header not in ordered_headers:
+            return False
+    prior_same_depth_numerics = [
+        header
+        for header in headers
+        if header.start() < evidence_header.start()
+        and header.group("marker").isdigit()
+        and len(header.group("indent").expandtabs(2)) == evidence_indent
+    ]
+    if not prior_same_depth_numerics:
+        return True
+    prior_numeric = prior_same_depth_numerics[-1]
+    return any(
+        prior_numeric.start() < header.start() < evidence_header.start()
+        and len(header.group("indent").expandtabs(2)) > evidence_indent
+        for header in headers
+    )
+
+
+def _is_alpha_marker_in_declared_numeric_parent_scope(
+    *,
+    source_text: str,
+    evidence_text: str,
+    marker: str,
+    scope: Mapping[str, frozenset[str]],
+) -> bool:
+    """Match a ranged alpha child to its declared numeric parent in the source."""
+    words = re.split(r"\s+", evidence_text.strip())
+    evidence_pattern = r"\s+".join(re.escape(word) for word in words)
+    scoped_blocks = [
+        (start, end)
+        for _, child, start, end in _source_numeric_parent_alpha_range_blocks(
+            source_text,
+            scope,
+        )
+        if child == marker
+    ]
+    for evidence_match in re.finditer(evidence_pattern, source_text):
+        if not _source_evidence_span_is_bounded(
+            evidence_text=evidence_text,
+            source_text=source_text,
+            start=evidence_match.start(),
+            end=evidence_match.end(),
+        ):
+            continue
+        if any(start <= evidence_match.start() < end for start, end in scoped_blocks):
+            return True
+    return False
+
+
+def _source_numeric_parent_alpha_range_blocks(
+    source_text: str,
+    scope: Mapping[str, frozenset[str]],
+) -> list[tuple[str, str, int, int]]:
+    """Return ordered alpha-child blocks owned by cited numeric parents."""
+    events = [
+        *(
+            (match.start(), "numeric", match)
+            for match in re.finditer(
+                r"(?m)^(?P<indent>[ \t]*)\((?P<marker>\d+)\)[ \t]+",
+                source_text,
+            )
+        ),
+        *(
+            (match.start(), "alpha", match)
+            for match in re.finditer(
+                r"(?m)^(?P<indent>[ \t]*)\((?P<marker>[a-z])\)[ \t]+",
+                source_text,
+            )
+        ),
+        *(
+            (match.start(), "boundary", match)
+            for match in re.finditer(
+                re.escape(PROOF_EVIDENCE_SEGMENT_SEPARATOR),
+                source_text,
+            )
+        ),
+    ]
+    events.sort(key=lambda event: event[0])
+    candidate_blocks: dict[str, list[list[tuple[str, str, int, int]]]] = {}
+    parent_occurrence_counts: dict[str, int] = {}
+    for event_index, (parent_start, kind, parent_match) in enumerate(events):
+        if kind != "numeric":
+            continue
+        parent = parent_match.group("marker")
+        allowed_children = scope.get(parent)
+        if not allowed_children:
+            continue
+        parent_indent = len(parent_match.group("indent").expandtabs(2))
+        record_start = source_text.rfind(
+            PROOF_EVIDENCE_SEGMENT_SEPARATOR,
+            0,
+            parent_start,
+        )
+        record_start = 0 if record_start < 0 else (
+            record_start + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
+        )
+        record_end = source_text.find(
+            PROOF_EVIDENCE_SEGMENT_SEPARATOR,
+            parent_start,
+        )
+        record_end = len(source_text) if record_end < 0 else record_end
+        record_structural_indents = [
+            len(match.group("indent").expandtabs(2))
+            for start, event_kind, match in events
+            if event_kind in {"numeric", "alpha"}
+            and record_start <= start < record_end
+        ]
+        if parent_indent != min(record_structural_indents, default=parent_indent):
+            continue
+        parent_occurrence_counts[parent] = parent_occurrence_counts.get(parent, 0) + 1
+        prior_record_events = [
+            (start, event_kind, match)
+            for start, event_kind, match in events[:event_index]
+            if record_start <= start < parent_start
+            and event_kind in {"numeric", "alpha"}
+        ]
+        previous_peer_numeric_position = max(
+            (
+                position
+                for position, (_, event_kind, match) in enumerate(
+                    prior_record_events
+                )
+                if event_kind == "numeric"
+                and len(match.group("indent").expandtabs(2)) == parent_indent
+            ),
+            default=-1,
+        )
+        prior_alpha_after_peer = any(
+            event_kind == "alpha"
+            for _, event_kind, _ in prior_record_events[
+                previous_peer_numeric_position + 1 :
+            ]
+        )
+        if prior_alpha_after_peer:
+            continue
+        sequence: list[tuple[str, int]] = []
+        expected = "a"
+        inside_nested_numeric = False
+        ambiguous_nested_alpha = False
+        direct_alpha_indent: int | None = None
+        boundary = len(source_text)
+        for start, child_kind, child_match in events[event_index + 1 :]:
+            if child_kind == "boundary":
+                boundary = start
+                break
+            if child_kind == "numeric":
+                numeric_indent = len(child_match.group("indent").expandtabs(2))
+                if not sequence or numeric_indent <= parent_indent:
+                    boundary = start
+                    break
+                inside_nested_numeric = True
+                continue
+            child = child_match.group("marker")
+            child_indent = len(child_match.group("indent").expandtabs(2))
+            if (
+                not sequence
+                and child in allowed_children
+                and child_indent > parent_indent
+            ):
+                direct_alpha_indent = child_indent
+                sequence.append((child, start))
+                expected = chr(ord(child) + 1)
+                inside_nested_numeric = False
+                continue
+            if (
+                child in allowed_children
+                and any(existing == child for existing, _ in sequence)
+                and child_indent == direct_alpha_indent
+            ):
+                ambiguous_nested_alpha = True
+                break
+            if (
+                inside_nested_numeric
+                and child in "ivxlcdm"
+                and direct_alpha_indent is not None
+                and direct_alpha_indent > parent_indent
+                and child_indent > direct_alpha_indent
+            ):
+                continue
+            if child == expected:
+                if direct_alpha_indent is None:
+                    if child_indent < parent_indent:
+                        ambiguous_nested_alpha = True
+                        break
+                    direct_alpha_indent = child_indent
+                elif child_indent != direct_alpha_indent:
+                    ambiguous_nested_alpha = True
+                    break
+            if child != expected:
+                boundary = start
+                break
+            sequence.append((child, start))
+            expected = chr(ord(expected) + 1)
+            inside_nested_numeric = False
+        if ambiguous_nested_alpha:
+            continue
+        candidate: list[tuple[str, str, int, int]] = []
+        for child_index, (child, start) in enumerate(sequence):
+            if child not in allowed_children:
+                continue
+            end = (
+                sequence[child_index + 1][1]
+                if child_index + 1 < len(sequence)
+                else boundary
+            )
+            candidate.append((parent, child, start, end))
+        if candidate:
+            candidate_blocks.setdefault(parent, []).append(candidate)
+    blocks: list[tuple[str, str, int, int]] = []
+    for parent, candidates in candidate_blocks.items():
+        if len(candidates) == 1 and parent_occurrence_counts.get(parent) == 1:
+            blocks.extend(candidates[0])
+    return blocks
 
 
 def _is_nested_alpha_marker_in_declared_numeric_scope(
@@ -1285,10 +2294,19 @@ def _source_marker_has_nested_list_context(
 def _rule_source_subsection_scope(
     rule_source: str,
 ) -> dict[str, frozenset[str] | None]:
-    """Parse top-level subsection markers and explicit numeric child ranges."""
+    """Parse top-level markers and explicit numeric child ranges."""
     scope: dict[str, set[str] | None] = {}
     current_top: str | None = None
-    for segment in str(rule_source).split(","):
+    for segment, parent_alpha_scope in _masked_numeric_parent_alpha_segments(
+        rule_source
+    ):
+        segment, deeper_roman_parents = _masked_deeper_roman_segment(segment)
+        if deeper_roman_parents and re.search(r"\([a-z]\)", segment) is None:
+            current_top = None
+            continue
+        if parent_alpha_scope and re.search(r"\([a-z]\)", segment) is None:
+            current_top = None
+            continue
         top_match = re.search(r"\((?P<top>[a-z])\)", segment)
         if top_match is not None:
             current_top = top_match.group("top")
@@ -1312,10 +2330,13 @@ def _rule_source_subsection_scope(
             match.group("value") for match in re.finditer(r"\((?P<value>\d+)\)", suffix)
         }
         for match in re.finditer(r"\((?P<start>\d+)\)\s*-\s*\((?P<end>\d+)\)", suffix):
-            start = int(match.group("start"))
-            end = int(match.group("end"))
-            if start <= end and end - start <= 100:
-                numeric.update(str(value) for value in range(start, end + 1))
+            start_token = match.group("start")
+            end_token = match.group("end")
+            if len(start_token) <= 10 and len(end_token) <= 10:
+                start = int(start_token)
+                end = int(end_token)
+                if start <= end and end - start <= 100:
+                    numeric.update(str(value) for value in range(start, end + 1))
         if not numeric:
             scope[top] = None
         elif scope.get(top, set()) is not None:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1672"
+ENCODER_VERSION = "0.2.1673"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11877,12 +11877,8 @@ def test_declared_subsection_source_keeps_mixed_numeric_parent_ownership():
 
 
 def test_declared_subsection_source_rejects_ambiguous_expected_nested_roman():
-    outer_prefix = "\n".join(
-        f"({child}) Outer child {child}." for child in "abcdefgh"
-    )
-    outer_suffix = "\n".join(
-        f"({child}) Outer child {child}." for child in "ijklm"
-    )
+    outer_prefix = "\n".join(f"({child}) Outer child {child}." for child in "abcdefgh")
+    outer_suffix = "\n".join(f"({child}) Outer child {child}." for child in "ijklm")
     source_text = f"""(4) Outer paragraph.
 {outer_prefix}
   (1) Nested numeric child.
@@ -12069,10 +12065,7 @@ def test_declared_subsection_source_rejects_shorthand_after_unhandled_coordinate
 
     scoped = _declared_rule_subsection_source_text(
         source_text,
-        rule_source=(
-            "Miss. Code section 27-7-5(2)(c); "
-            "42 CFR 1(a)(1)(i)-(v), (d)"
-        ),
+        rule_source=("Miss. Code section 27-7-5(2)(c); 42 CFR 1(a)(1)(i)-(v), (d)"),
     )
 
     assert scoped is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11777,6 +11777,521 @@ def test_declared_subsection_source_keeps_corpus_evidence_segments_separate():
     )
 
 
+def test_declared_subsection_source_expands_alphabetic_range():
+    source_text = """(4) The declared paragraph.
+(a) First declared block.
+(b) Second declared block.
+  (1) Nested declared detail one.
+  (2) Nested declared detail two.
+  (5) Nested declared detail five.
+(c) Interior declared block.
+
+(5) Another unrelated paragraph.
+(a) Later wrong first block.
+(b) Later wrong second block.
+(c) Later wrong interior block.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+    )
+
+    assert scoped is not None
+    assert "(a) First declared block." in scoped
+    assert "(b) Second declared block." in scoped
+    assert "(c) Interior declared block." in scoped
+    assert "(1) Nested declared detail one." in scoped
+    assert "(2) Nested declared detail two." in scoped
+    assert "(5) Nested declared detail five." in scoped
+    assert "Later wrong first block." not in scoped
+    assert "Later wrong second block." not in scoped
+    assert "Later wrong interior block." not in scoped
+
+
+def test_declared_subsection_source_rejects_flat_duplicate_parent_ambiguity():
+    source_text = """(3) Outer paragraph.
+(b) Outer child with nested paragraph.
+  (4) Nested paragraph.
+    (a) Nested first child.
+    (b) Nested second child.
+    (c) Nested third child.
+(4) Real paragraph.
+(a) Real first child.
+(b) Real second child.
+(c) Real third child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_keeps_outer_range_across_nested_roman_list():
+    source_text = """(4) Outer paragraph.
+  (a) First outer child with nested items.
+    (1) Nested numeric item.
+      (i) Nested Roman item.
+  (b) Second outer child.
+  (c) Third outer child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+    )
+
+    assert scoped is not None
+    assert "(a) First outer child with nested items." in scoped
+    assert "(i) Nested Roman item." in scoped
+    assert "(b) Second outer child." in scoped
+    assert "(c) Third outer child." in scoped
+
+
+def test_declared_subsection_source_keeps_mixed_numeric_parent_ownership():
+    source_text = """(2) Explicit paragraph.
+(a) Explicit first child.
+(b) Explicit second child.
+(c) Correct explicit third child.
+(9) Undeclared paragraph.
+(a) Wrong first child.
+(b) Wrong second child.
+(c) Wrong third child.
+(4) Ranged paragraph.
+(a) Ranged first child.
+(b) Ranged second child.
+(c) Ranged third child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(2)(c), (4)(a)-(c)",
+    )
+
+    assert scoped is not None
+    assert "Correct explicit third child." in scoped
+    assert "Wrong third child." not in scoped
+
+
+def test_declared_subsection_source_rejects_ambiguous_expected_nested_roman():
+    outer_prefix = "\n".join(
+        f"({child}) Outer child {child}." for child in "abcdefgh"
+    )
+    outer_suffix = "\n".join(
+        f"({child}) Outer child {child}." for child in "ijklm"
+    )
+    source_text = f"""(4) Outer paragraph.
+{outer_prefix}
+  (1) Nested numeric child.
+    (i) Wrong nested Roman child.
+{outer_suffix}
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a)-(m)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_rejects_deeper_expected_alpha_child():
+    source_text = """(4) Outer paragraph.
+(a) Direct first child.
+  (b) Wrong deeper second child.
+(b) Correct direct second child.
+(c) Correct direct third child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_rejects_sole_nested_numeric_parent():
+    source_text = """(3) Outer paragraph.
+(b) Outer child with nested paragraph.
+  (4) Nested paragraph.
+    (a) Nested first child.
+    (b) Nested second child.
+    (c) Nested third child.
+(5) Next outer paragraph.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_rejects_nested_parent_without_numeric_peers():
+    source_text = """(b) Shallower structural block.
+  (4) Nested numeric paragraph.
+(a) Wrong shallower first child.
+(b) Wrong shallower second child.
+(c) Wrong shallower third child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+    )
+
+    assert scoped is None
+
+
+@pytest.mark.parametrize("outer_parent", ["2", "3"])
+def test_declared_subsection_source_rejects_flat_nested_numeric_parent(
+    outer_parent: str,
+):
+    source_text = f"""({outer_parent}) Outer paragraph.
+(a) Outer first child.
+(b) Outer second child with nested paragraph.
+(4) Nested paragraph.
+(a) Nested first child.
+(b) Nested second child.
+(c) Nested third child.
+(5) Next outer paragraph.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_rejects_flat_nested_owned_numeric_parent():
+    source_text = """(2) Cited outer paragraph.
+(a) Outer first child.
+(b) Outer second child with nested paragraph.
+(4) Nested paragraph.
+(a) Nested first child.
+(b) Nested second child.
+(c) Wrong nested third child.
+(5) Next outer paragraph.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(2)(b), (4)(a)-(c)",
+    )
+
+    assert scoped is not None
+    assert "Outer second child with nested paragraph." in scoped
+    assert "Wrong nested third child." not in scoped
+
+
+def test_declared_subsection_source_owns_annotated_direct_singleton():
+    source_text = """(4) Cited paragraph.
+(a) Correct paragraph four child.
+(3) Uncited paragraph.
+(a) Wrong paragraph three child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a) (effective July 1)",
+    )
+
+    assert scoped is not None
+    assert "Correct paragraph four child." in scoped
+    assert "Wrong paragraph three child." not in scoped
+
+
+def test_declared_subsection_source_keeps_alpha_comma_shorthand_parent():
+    source_text = """(2) Explicit paragraph.
+(a) Explicit first child.
+(b) Explicit second child.
+(c) Correct explicit third child.
+(d) Correct explicit fourth child.
+(9) Undeclared paragraph.
+(a) Wrong first child.
+(b) Wrong second child.
+(c) Wrong third child.
+(d) Wrong fourth child.
+(4) Ranged paragraph.
+(a) Ranged first child.
+(b) Ranged second child.
+(c) Ranged third child.
+(d) Ranged fourth child.
+(e) Ranged fifth child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(2)(c), (d), (4)(a)-(e)",
+    )
+
+    assert scoped is not None
+    assert "Correct explicit third child." in scoped
+    assert "Correct explicit fourth child." in scoped
+    assert "Wrong third child." not in scoped
+    assert "Wrong fourth child." not in scoped
+
+
+def test_declared_subsection_source_uses_rightmost_parent_for_alpha_shorthand():
+    source_text = """(2) Paragraph two.
+(a) Paragraph two first child.
+(b) Wrong paragraph two second child.
+(c) Paragraph two third child.
+(4) Paragraph four.
+(a) Correct paragraph four first child.
+(b) Correct paragraph four second child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(2)(c); (4)(a), (b)",
+    )
+
+    assert scoped is not None
+    assert "Paragraph two third child." in scoped
+    assert "Wrong paragraph two second child." not in scoped
+
+
+def test_declared_subsection_source_rejects_shorthand_after_unhandled_coordinate():
+    source_text = """(2) Paragraph two.
+(a) First child.
+(b) Second child.
+(c) Correct third child.
+(d) Wrong stale-parent fourth child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source=(
+            "Miss. Code section 27-7-5(2)(c); "
+            "42 CFR 1(a)(1)(i)-(v), (d)"
+        ),
+    )
+
+    assert scoped is not None
+    assert "Correct third child." in scoped
+    assert "Wrong stale-parent fourth child." not in scoped
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "Miss. Code section 27-7-5(4)(a)(ii)",
+        "Miss. Code section 27-7-5(4)(a)(ii)-(iv)",
+        "Miss. Code section 27-7-5(4)(a)(IV)",
+        "Miss. Code section 27-7-5(4)(a)(Ii)",
+        "42 CFR 435.552(e)(2)(i)-(ii)",
+        "Miss. Code section 27-7-5(4)(a)(1)(ii)",
+    ],
+)
+def test_declared_subsection_source_rejects_broad_deeper_roman_parent(
+    rule_source: str,
+):
+    source_text = """(4) Cited paragraph.
+(a) Broad parent block.
+(ii) Narrow Roman child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source=rule_source,
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_rejects_roman_parent_narrowed_elsewhere():
+    source_text = """(a) Broad parent block.
+(1) Narrow numeric child.
+(ii) Narrow Roman child.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="section 1(a)(ii), section 2(a)(1)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_excludes_nested_roman_matching_broad_alpha():
+    source_text = """(a) Narrow Roman parent a.
+  (i) Wrong nested Roman child under parent a.
+(i) Correct independently broad alpha parent i.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="section 1(a)(ii), section 2(i)",
+    )
+
+    assert scoped is not None
+    assert "Wrong nested Roman child" not in scoped
+    assert "Correct independently broad alpha parent" in scoped
+
+
+def test_declared_subsection_source_excludes_numeric_nested_roman_as_broad_alpha():
+    source_text = """(4) Numeric parent four.
+  (i) Wrong nested Roman child under numeric parent four.
+(i) Correct independently broad alpha parent i.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="section 1(a)(ii), section 2(i)",
+    )
+
+    assert scoped is not None
+    assert "Wrong nested Roman child" not in scoped
+    assert "Correct independently broad alpha parent" in scoped
+
+
+def test_declared_subsection_source_excludes_flat_numeric_roman_as_broad_alpha():
+    source_text = """(4) Numeric parent four with a nested Roman item:
+(i) Wrong flat nested Roman child under numeric parent four.
+(5) Next numeric parent.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="section 1(a)(ii), section 2(i)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_rejects_duplicate_flat_roman_alpha_role():
+    source_text = """(a) Narrow Roman parent a.
+(i) Wrong flat Roman child under parent a.
+(i) Correct independently broad alpha parent i.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="section 1(a)(ii), section 2(i)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_rejects_direct_alpha_compound_suffix():
+    source_text = """(3) Numeric parent three.
+(a) Alpha child a.
+(b) Invalid direct alpha compound suffix.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="section (4)(a)(ii)/(3)(b)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_allows_valid_pair_beside_invalid_suffix():
+    source_text = """(5) Valid numeric parent five.
+  (b) Correct valid paragraph five child b.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="section (4)(a)(ii)/(3)(b); section (5)(b)",
+    )
+
+    assert scoped is not None
+    assert "Correct valid paragraph five child b." in scoped
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        """(5) Numeric parent five.
+  (b) First duplicate child b.
+  (b) Second duplicate child b.
+""",
+        """(5) First numeric parent five.
+  (b) First duplicate child b.
+(5) Second numeric parent five.
+  (b) Second duplicate child b.
+""",
+    ],
+)
+def test_declared_subsection_source_rejects_duplicate_numeric_alpha_coordinate(
+    source_text: str,
+):
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="section (5)(b)",
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_allows_owned_h_before_nested_roman_i():
+    source_text = """(5) Numeric parent five.
+  (h) Valid direct child h.
+    (1) Nested numeric child one.
+      (i) Nested Roman child i.
+"""
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="section (5)(h)",
+    )
+
+    assert scoped is not None
+    assert "Valid direct child h." in scoped
+    assert "Nested Roman child i." in scoped
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "section 1(a)(iv)-(ii)",
+        "section 1(a)(ii)/(iv)",
+        "section 1(a)(iiii)",
+        "section 1(a)(i)-(cc)",
+    ],
+)
+def test_declared_subsection_source_fails_closed_for_invalid_roman_scope(
+    rule_source: str,
+):
+    scoped = _declared_rule_subsection_source_text(
+        "(a) Invalid Roman scope cannot select this broad parent.",
+        rule_source=rule_source,
+    )
+
+    assert scoped is None
+
+
+def test_declared_subsection_source_rejects_parent_ambiguous_across_records():
+    source_text = (
+        "(4) Current paragraph.\n"
+        "(a) Current first child.\n"
+        "(b) Current second child.\n"
+        "(c) Unique current third child.\n"
+        + PROOF_EVIDENCE_SEGMENT_SEPARATOR
+        + "(4) Historical paragraph.\n"
+        "(a) Historical first child.\n"
+        "(b) Historical second child.\n"
+        "(c) Historical third child.\n"
+    )
+
+    scoped = _declared_rule_subsection_source_text(
+        source_text,
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+    )
+
+    assert scoped is None
+
+
 def test_protected_source_excerpt_rejects_repeated_coordinates():
     excerpt = "The amount is 25 Euro."
 

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1672"
+ENCODER_VERSION = "0.2.1673"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1672"
+ENCODER_VERSION = "0.2.1673"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1672"
+ENCODER_VERSION = "0.2.1673"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1672"
+ENCODER_VERSION = "0.2.1673"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1672"
+ENCODER_VERSION = "0.2.1673"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1672"
+ENCODER_VERSION = "0.2.1673"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -35,6 +35,7 @@ from axiom_encode.harness.policyengine_runtime import (
     PolicyEngineRuntimeError,
 )
 from axiom_encode.harness.proof_validator import (
+    _rule_source_numeric_parent_alpha_scope,
     _source_top_level_marker_for_numeric_parent,
     find_rulespec_proof_issues,
     validate_rulespec_proofs,
@@ -17202,6 +17203,1959 @@ rules:
     assert result.passed is False
     assert any(
         "outside the rule's declared subsection scope" in issue and "(b)" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "separator",
+    [
+        "-",
+        "\u2010",
+        "\u2011",
+        "\u2012",
+        "\u2013",
+        "\u2014",
+        "\u2015",
+        "\u2212",
+        "\uff0d",
+        " \u2013 ",
+    ],
+)
+def test_rule_source_scope_expands_bounded_alphabetic_ranges(separator: str):
+    assert _rule_source_numeric_parent_alpha_scope(
+        f"Miss. Code section 27-7-5(4)(a){separator}(e)"
+    ) == {"4": frozenset("abcde")}
+
+
+def test_rule_source_scope_treats_direct_roman_letters_as_alphabetic_range():
+    assert _rule_source_numeric_parent_alpha_scope(
+        "Miss. Code section 27-7-5(4)(c)-(d)"
+    ) == {"4": frozenset("cd")}
+
+
+def test_rule_source_scope_carries_numeric_parent_across_alpha_comma_shorthand():
+    assert _rule_source_numeric_parent_alpha_scope(
+        "Miss. Code section 27-7-5(2)(c), (d), (4)(a)-(e)"
+    ) == {"2": frozenset("cd"), "4": frozenset("abcde")}
+
+
+def test_rule_source_scope_uses_textually_rightmost_parent_for_shorthand():
+    assert _rule_source_numeric_parent_alpha_scope(
+        "Miss. Code section 27-7-5(2)(c); (4)(a), (b)"
+    ) == {"2": frozenset("c"), "4": frozenset("ab")}
+
+
+def test_rule_source_scope_invalidates_shorthand_after_unhandled_coordinate():
+    scope = _rule_source_numeric_parent_alpha_scope(
+        "Miss. Code section 27-7-5(2)(c); 42 CFR 1(a)(1)(i)-(v), (d)"
+    )
+
+    assert scope["2"] == frozenset("c")
+    assert "d" not in scope["2"]
+
+
+def test_rule_source_scope_keeps_singleton_before_parenthetical_annotation():
+    assert _rule_source_numeric_parent_alpha_scope(
+        "Miss. Code section 27-7-5(4)(a) (effective July 1)"
+    ) == {"4": frozenset("a")}
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "Miss. Code section 27-7-5(4)(a)(1)",
+        "Miss. Code section 27-7-5(4)(a)(1)-(3)",
+        "Miss. Code section 27-7-5(4)(a)(1), (2)",
+    ],
+)
+def test_rule_source_scope_does_not_flatten_deeper_numeric_coordinates(
+    rule_source: str,
+):
+    assert _rule_source_numeric_parent_alpha_scope(rule_source) == {}
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "Miss. Code section 27-7-5(4)(a)(ii)",
+        "Miss. Code section 27-7-5(4)(a)(ii)-(iv)",
+        "Miss. Code section 27-7-5(4)(a)(IV)",
+        "Miss. Code section 27-7-5(4)(a)(Ii)",
+        "42 CFR 435.552(e)(2)(i)-(ii)",
+        "Miss. Code section 27-7-5(4)(a)(1)(ii)",
+    ],
+)
+def test_rule_source_scope_does_not_flatten_deeper_roman_coordinates(
+    rule_source: str,
+):
+    assert _rule_source_numeric_parent_alpha_scope(rule_source) == {}
+
+
+@pytest.mark.parametrize("separator", ["-", "\u2011", " \u2013 "])
+@pytest.mark.parametrize("marker", ["b", "c", "d"])
+def test_rulespec_proof_validator_allows_interior_alphabetic_range_excerpt(
+    separator: str,
+    marker: str,
+):
+    excerpt = f"({marker}) The tax shall be prorated between calendar-year rates."
+    content = _proof_scope_fixture(
+        rule_source=f"Miss. Code section 27-7-5(4)(a){separator}(e)",
+        excerpt=excerpt,
+    )
+    child_blocks = [
+        excerpt
+        if child == marker
+        else f"({child}) Declared fiscal-year step {child}."
+        for child in "abcde"
+    ]
+    child_blocks.insert(
+        2,
+        (
+            "  (1) Nested numbered detail one.\n\n"
+            "  (2) Nested numbered detail two.\n\n"
+            "  (5) Nested numbered detail five."
+        ),
+    )
+    source_text = (
+        "(4) The fiscal-year calculation is determined by:\n\n"
+        + "\n\n".join(child_blocks)
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+@pytest.mark.parametrize(
+    "malformed_range",
+    [
+        "(a)/(e)",
+        "(a),(e)",
+        "(a):(e)",
+        "(a)+(e)",
+        "(a)\N{PLUS-MINUS SIGN}(e)",
+        "(a)--(e)",
+        "(a) to (e)",
+        "(a) through (e)",
+        "a-(e)",
+        "(A)-(e)",
+        "(a)-(E)",
+    ],
+)
+def test_rule_source_scope_does_not_expand_malformed_alphabetic_ranges(
+    malformed_range: str,
+):
+    scope = _rule_source_numeric_parent_alpha_scope(
+        f"Miss. Code section 27-7-5(4){malformed_range}"
+    )
+
+    assert "c" not in {child for children in scope.values() for child in children}
+
+
+def test_rulespec_proof_validator_rejects_alphabetic_range_under_wrong_parent():
+    excerpt = "(c) Wrong paragraph fiscal-year step."
+    source_text = f"""(3) An unrelated paragraph provides:
+
+(a) Unrelated first step.
+
+(b) Unrelated second step.
+
+  (4) A nested numbered item under paragraph (b).
+
+{excerpt}
+
+(4) The declared paragraph provides:
+
+(a) Declared first step.
+
+(b) Declared second step.
+
+(c) Correct paragraph fiscal-year step.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_ambiguous_duplicate_parent_range():
+    excerpt = "(c) Wrong nested paragraph step."
+    source_text = f"""(3) An unrelated outer paragraph provides:
+
+(a) Outer first child.
+
+(b) Outer second child with a nested paragraph:
+
+  (4) The nested paragraph provides:
+
+    (a) Nested first child.
+
+    (b) Nested second child.
+
+    {excerpt}
+
+    (d) Nested fourth child.
+
+    (e) Nested fifth child.
+
+(4) The real outer paragraph provides:
+
+(a) Real first child.
+
+(b) Real second child.
+
+(c) Real third child.
+
+(d) Real fourth child.
+
+(e) Real fifth child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_deeper_expected_alpha_child():
+    excerpt = "(b) Wrong deeper child."
+    source_text = f"""(4) The paragraph provides:
+
+(a) Direct first child with nested content:
+
+  {excerpt}
+
+(b) Correct direct second child.
+
+(c) Correct direct third child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_sole_nested_numeric_parent():
+    excerpt = "(c) Wrong nested third child."
+    source_text = f"""(3) The outer paragraph provides:
+
+(b) An outer child contains a nested paragraph:
+
+  (4) The nested paragraph provides:
+
+    (a) Nested first child.
+
+    (b) Nested second child.
+
+    {excerpt}
+
+    (d) Nested fourth child.
+
+    (e) Nested fifth child.
+
+(5) The next outer paragraph.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_nested_parent_without_numeric_peers():
+    excerpt = "(c) Wrong shallower child."
+    source_text = f"""(b) A shallower structural block.
+
+  (4) A nested numeric paragraph.
+
+(a) Wrong shallower first child.
+
+(b) Wrong shallower second child.
+
+{excerpt}
+
+(d) Wrong shallower fourth child.
+
+(e) Wrong shallower fifth child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize("outer_parent", ["2", "3"])
+def test_rulespec_proof_validator_rejects_flat_nested_numeric_parent(
+    outer_parent: str,
+):
+    excerpt = "(c) Wrong flat nested third child."
+    source_text = f"""({outer_parent}) The outer paragraph provides:
+
+(a) Outer first child.
+
+(b) Outer second child with a nested paragraph:
+
+(4) The nested paragraph provides:
+
+(a) Nested first child.
+
+(b) Nested second child.
+
+{excerpt}
+
+(d) Nested fourth child.
+
+(e) Nested fifth child.
+
+(5) The next outer paragraph.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_flat_nested_owned_numeric_parent():
+    excerpt = "(c) Wrong nested owned-parent child."
+    source_text = f"""(2) The cited outer paragraph provides:
+
+(a) Outer first child.
+
+(b) Outer second child with a nested paragraph:
+
+(4) The nested paragraph provides:
+
+(a) Nested first child.
+
+(b) Nested second child.
+
+{excerpt}
+
+(d) Nested fourth child.
+
+(e) Nested fifth child.
+
+(5) The next outer paragraph.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(2)(b), (4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_allows_outer_range_across_nested_roman_list():
+    excerpt = "(c) Correct outer paragraph step."
+    source_text = f"""(4) The outer paragraph provides:
+
+  (a) First outer child with nested items:
+
+    (1) A nested numeric item provides:
+
+      (i) A nested Roman item.
+
+  (b) Second outer child.
+
+  {excerpt}
+
+  (d) Fourth outer child.
+
+  (e) Fifth outer child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_independently_cited_mixed_marker():
+    excerpt = "(c) Explicitly cited paragraph two child."
+    source_text = f"""(2) A separately cited paragraph provides:
+
+(a) First child.
+
+(b) Second child.
+
+{excerpt}
+
+(4) The ranged paragraph provides:
+
+(a) Ranged first child.
+
+(b) Ranged second child.
+
+(c) Ranged third child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(2)(c), (4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_wrong_parent_in_mixed_marker_scope():
+    excerpt = "(c) Wrong paragraph nine child."
+    source_text = f"""(2) A separately cited paragraph provides:
+
+(a) First child.
+
+(b) Second child.
+
+(c) Correct paragraph two child.
+
+(9) An undeclared paragraph provides:
+
+(a) Wrong first child.
+
+(b) Wrong second child.
+
+{excerpt}
+
+(4) The ranged paragraph provides:
+
+(a) Ranged first child.
+
+(b) Ranged second child.
+
+(c) Ranged third child.
+
+(d) Ranged fourth child.
+
+(e) Ranged fifth child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(2)(c), (4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_wrong_parent_alpha_comma_shorthand():
+    excerpt = "(d) Wrong paragraph nine child."
+    source_text = f"""(2) The explicitly cited paragraph provides:
+
+(a) First child.
+
+(b) Second child.
+
+(c) Correct third child.
+
+(d) Correct fourth child.
+
+(9) An undeclared paragraph provides:
+
+(a) Wrong first child.
+
+(b) Wrong second child.
+
+(c) Wrong third child.
+
+{excerpt}
+
+(4) The ranged paragraph provides:
+
+(a) Ranged first child.
+
+(b) Ranged second child.
+
+(c) Ranged third child.
+
+(d) Ranged fourth child.
+
+(e) Ranged fifth child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(2)(c), (d), (4)(a)-(e)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_uses_rightmost_parent_for_alpha_shorthand():
+    excerpt = "(b) Wrong paragraph two child."
+    source_text = f"""(2) Paragraph two provides:
+
+(a) Paragraph two first child.
+
+{excerpt}
+
+(c) Paragraph two third child.
+
+(4) Paragraph four provides:
+
+(a) Correct paragraph four first child.
+
+(b) Correct paragraph four second child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(2)(c); (4)(a), (b)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_owns_annotated_direct_singleton():
+    excerpt = "(a) Wrong paragraph three child."
+    source_text = f"""(4) Cited paragraph.
+
+(a) Correct paragraph four child.
+
+(3) Uncited paragraph.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a) (effective July 1)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_shorthand_after_unhandled_coordinate():
+    excerpt = "(d) Wrong stale-parent child."
+    source_text = f"""(2) Paragraph two provides:
+
+(a) First child.
+
+(b) Second child.
+
+(c) Third child.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source=(
+            "Miss. Code section 27-7-5(2)(c); "
+            "42 CFR 1(a)(1)(i)-(v), (d)"
+        ),
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_parent_ambiguous_across_evidence_records():
+    excerpt = "(c) Unique current third child."
+    current_record = f"""(4) Current paragraph.
+(a) Current first child.
+(b) Current second child.
+{excerpt}
+"""
+    history_record = """(4) Historical paragraph.
+(a) Historical first child.
+(b) Historical second child.
+(c) Historical third child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)-(c)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={
+            "us-nj/statute/54a:4-7": (
+                current_record
+                + PROOF_EVIDENCE_SEGMENT_SEPARATOR
+                + history_record
+            )
+        },
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_preserves_same_segment_numeric_restriction():
+    excerpt = "(99) An undeclared numeric child."
+    content = _proof_scope_fixture(
+        rule_source=(
+            "Miss. Code section 27-7-5(4)(a)-(e); "
+            "42 CFR 1(f)(1)-(3)"
+        ),
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "Miss. Code section 27-7-5(4)(a)(1)",
+        "Miss. Code section 27-7-5(4)(a)(1)-(3)",
+        "Miss. Code section 27-7-5(4)(a)(1), (2)",
+    ],
+)
+def test_rulespec_proof_validator_preserves_deeper_numeric_restriction(
+    rule_source: str,
+):
+    excerpt = "(99) An undeclared numeric child."
+    content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "Miss. Code section 27-7-5(4)(a)(ii)",
+        "Miss. Code section 27-7-5(4)(a)(ii)-(iv)",
+        "Miss. Code section 27-7-5(4)(a)(IV)",
+        "42 CFR 435.552(e)(2)(i)-(ii)",
+        "Miss. Code section 27-7-5(4)(a)(1)(ii)",
+    ],
+)
+def test_rulespec_proof_validator_rejects_broad_deeper_roman_parent_excerpt(
+    rule_source: str,
+):
+    parent = "e" if "552(e)" in rule_source else "a"
+    excerpt = f"({parent}) Broad parent evidence does not prove the Roman child."
+    content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    ("rule_source", "excerpt"),
+    [
+        ("Miss. Code section 27-7-5(4)(a)(ii)", "(iii) Wrong Roman sibling."),
+        (
+            "Miss. Code section 27-7-5(4)(a)(ii)-(iv)",
+            "(vi) Outside the Roman range.",
+        ),
+        ("Miss. Code section 27-7-5(4)(a)(IV)", "(V) Wrong uppercase sibling."),
+        ("42 CFR 435.552(e)(2)(i)-(ii)", "(iii) Outside the nested range."),
+    ],
+)
+def test_rulespec_proof_validator_fails_closed_for_deeper_roman_evidence(
+    rule_source: str,
+    excerpt: str,
+):
+    content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_preserves_numeric_scope_beside_deeper_roman():
+    excerpt = "(99) An undeclared numeric child."
+    content = _proof_scope_fixture(
+        rule_source=(
+            "Miss. Code section 27-7-5(4)(a)(ii); "
+            "42 CFR 1(f)(1)-(3)"
+        ),
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_allows_independently_broad_roman_parent():
+    excerpt = "(a) Independently broad section two evidence."
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii), section 2(a)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_roman_parent_narrowed_elsewhere():
+    excerpt = "(a) Broad parent evidence is not independently cited."
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii), section 2(a)(1)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    ("rule_source", "excerpt"),
+    [
+        ("section 1(a)(ii)-(iv)", "(iii) Declared interior Roman child."),
+        ("section 1(a)(IV)", "(IV) Declared uppercase Roman child."),
+    ],
+)
+def test_rulespec_proof_validator_allows_declared_roman_members(
+    rule_source: str,
+    excerpt: str,
+):
+    content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "section 1(a)(iv)-(ii)",
+        "section 1(a)(ii)/(iv)",
+        "section 1(a)(iiii)",
+        "section 1(a)(i)-(cc)",
+    ],
+)
+def test_rulespec_proof_validator_fails_closed_for_invalid_roman_scope(
+    rule_source: str,
+):
+    excerpt = "(a) Invalid Roman scope cannot become a broad parent."
+    content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_roman_marker_under_wrong_alpha_parent():
+    excerpt = "(iii) Wrong third child under parent a."
+    source_text = f"""(a) Parent a.
+  (ii) Correct second child under parent a.
+  {excerpt}
+(b) Parent b.
+  (iii) Correct third child under parent b.
+"""
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii); section 1(b)(iii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_roman_marker_under_wrong_numeric_chain():
+    excerpt = "(i) Wrong first Roman child under numeric child one."
+    source_text = f"""(e) Parent e.
+  (1) Numeric child one.
+    {excerpt}
+  (2) Numeric child two.
+    (i) Correct first Roman child under numeric child two.
+    (ii) Correct second Roman child under numeric child two.
+"""
+    content = _proof_scope_fixture(
+        rule_source="42 CFR 435.552(e)(2)(i)-(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_allows_roman_marker_under_exact_numeric_chain():
+    excerpt = "(ii) Correct second Roman child under numeric child two."
+    source_text = f"""(e) Parent e.
+  (1) Numeric child one.
+    (ii) Wrong second Roman child under numeric child one.
+  (2) Numeric child two.
+    {excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="42 CFR 435.552(e)(2)(i)-(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_roman_descendant_of_broad_parent():
+    excerpt = "(iii) Descendant admitted by independently broad parent a."
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii), section 2(a)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_roman_descendant_of_numeric_owned_alpha():
+    excerpt = "(iii) Descendant admitted by broad paragraph four child a."
+    source_text = f"""(3) Narrow outer paragraph three.
+  (a) Narrow alpha child a.
+    (ii) Cited Roman child two.
+(4) Broad outer paragraph four.
+  (a) Broad alpha child a.
+    {excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(3)(a)(ii), (4)(a)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_roman_descendant_of_narrow_numeric_alpha():
+    excerpt = "(iii) Undeclared descendant under narrow paragraph three child a."
+    source_text = f"""(3) Narrow outer paragraph three.
+  (a) Narrow alpha child a.
+    {excerpt}
+(4) Broad outer paragraph four.
+  (a) Broad alpha child a.
+    (iii) Permitted descendant under broad paragraph four child a.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(3)(a)(ii), (4)(a)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    ("rule_source", "source_text"),
+    [
+        (
+            "section 1(b)(ii), section 2(a)",
+            """(a) Broad alpha parent a.
+  (1) Intervening numeric child one.
+    (iii) Deep descendant of broad alpha parent a.
+""",
+        ),
+        (
+            "Miss. Code section 27-7-5(3)(b)(ii), (4)(a)",
+            """(4) Broad numeric parent four.
+  (a) Broad alpha child a.
+    (1) Intervening numeric child one.
+      (iii) Deep descendant of broad paragraph four child a.
+""",
+        ),
+        (
+            "Miss. Code section 27-7-5(3)(b)(ii), (4)(a)(1)",
+            """(4) Numeric parent four.
+  (a) Alpha child a.
+    (1) Broad inner numeric child one.
+      (iii) Descendant of broad inner numeric child one.
+""",
+        ),
+        (
+            "section (3)(b)(ii), section (2)(4)(a)",
+            """(2) Outer numeric parent two.
+  (4) Inner numeric parent four.
+    (a) Broad alpha child a.
+      (iii) Descendant of deep broad alpha child a.
+""",
+        ),
+    ],
+)
+def test_rulespec_proof_validator_allows_unique_broad_chain_prefix(
+    rule_source: str,
+    source_text: str,
+):
+    excerpt = next(
+        line.strip() for line in source_text.splitlines() if "(iii)" in line
+    )
+    content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_does_not_broaden_before_deeper_alpha_child():
+    excerpt = "(iii) Undeclared Roman sibling above narrow alpha child b."
+    source_text = f"""(4) Numeric parent four.
+  (a) Alpha child a.
+    (1) Numeric child one.
+      {excerpt}
+      (b) Narrow ordinary alpha child b.
+"""
+    content = _proof_scope_fixture(
+        rule_source="section (3)(c)(ii), section (4)(a)(1)(b)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "section (3)(a)(ii), section (4)(a), section (5)(a)",
+        "section (3)(a)(ii), section (4)(a)(1), section (4)(a)(2)",
+    ],
+)
+def test_rulespec_proof_validator_rejects_exact_scalar_with_ambiguous_broad_chains(
+    rule_source: str,
+):
+    excerpt = "(iii) Exact scalar with more than one possible broad owner."
+    content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "broad_source",
+    [
+        "section (a)(1)-(3)",
+        "section (a)(1), (2)",
+    ],
+)
+def test_rulespec_proof_validator_allows_roman_descendant_of_broad_numeric_member(
+    broad_source: str,
+):
+    excerpt = "(iii) Descendant of cited numeric child two."
+    source_text = f"""(a) Alpha parent a.
+  (2) Cited numeric child two.
+    {excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source=f"section (b)(ii), {broad_source}",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+@pytest.mark.parametrize(
+    ("broad_source", "child"),
+    [
+        ("section (a)(3)-(1)", "3"),
+        ("section (a)(3)/(1)", "3"),
+        ("section (a)(3)–(1)", "3"),
+        ("section (a)(1)-(202)", "1"),
+    ],
+)
+def test_rulespec_proof_validator_fails_closed_for_invalid_broad_numeric_range(
+    broad_source: str,
+    child: str,
+):
+    excerpt = "(iii) Descendant of an invalid numeric range."
+    source_text = f"""(a) Alpha parent a.
+  ({child}) Invalidly ranged numeric child.
+    {excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source=f"section (b)(ii), {broad_source}",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    ("broad_source", "source_text"),
+    [
+        (
+            "section (a)/(c)",
+            """(a) Invalid slash-range start.
+  (iii) Descendant of invalid slash-range start.
+""",
+        ),
+        (
+            "section (c)-(a)",
+            """(c) Invalid descending-range start.
+  (iii) Descendant of invalid descending-range start.
+""",
+        ),
+        (
+            "section (4)(a)/(c)",
+            """(4) Numeric parent four.
+  (a) Invalid owned slash-range start.
+    (iii) Descendant of invalid owned slash-range start.
+""",
+        ),
+        (
+            "section (4)(c)-(a)",
+            """(4) Numeric parent four.
+  (c) Invalid owned descending-range start.
+    (iii) Descendant of invalid owned descending-range start.
+""",
+        ),
+    ],
+)
+def test_rulespec_proof_validator_fails_closed_for_invalid_broad_alpha_range(
+    broad_source: str,
+    source_text: str,
+):
+    excerpt = next(
+        line.strip() for line in source_text.splitlines() if "(iii)" in line
+    )
+    content = _proof_scope_fixture(
+        rule_source=f"section (b)(ii), {broad_source}",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    ("broad_source", "source_text"),
+    [
+        (
+            "section (4)(a)/(3)(b)",
+            """(4) Invalid left numeric parent four.
+  (a) Invalid left alpha child a.
+    (iii) Descendant of invalid compound slash left side.
+""",
+        ),
+        (
+            "section (4)(a)(1)/(3)(b)",
+            """(4) Invalid left numeric parent four.
+  (a) Invalid left alpha child a.
+    (1) Invalid left numeric child one.
+      (iii) Descendant of invalid deep compound slash left side.
+""",
+        ),
+        (
+            "section (4)(a)(1)-(3)(b)",
+            """(3) Invalid compound dash suffix numeric parent three.
+  (b) Invalid compound dash suffix alpha child b.
+    (iii) Descendant of invalid compound dash suffix.
+""",
+        ),
+    ],
+)
+def test_rulespec_proof_validator_fails_closed_for_compound_range_suffix(
+    broad_source: str,
+    source_text: str,
+):
+    excerpt = next(
+        line.strip() for line in source_text.splitlines() if "(iii)" in line
+    )
+    content = _proof_scope_fixture(
+        rule_source=f"section (c)(ii), {broad_source}",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    ("broad_source", "source_text"),
+    [
+        (
+            "section (4)(a)(ii)/(3)(b)",
+            """(3) Invalid suffix numeric parent three.
+  (b) Invalid suffix alpha child b.
+    (iii) Descendant of suffix after a narrow left side.
+""",
+        ),
+        (
+            "section (a)/(b)/(c)",
+            """(c) Invalid chained slash suffix c.
+  (iii) Descendant of invalid chained slash suffix.
+""",
+        ),
+        (
+            "section (c)-(a)-(b)",
+            """(b) Invalid chained descending suffix b.
+  (iii) Descendant of invalid chained descending suffix.
+""",
+        ),
+        (
+            "section (4)(a)/(3)(b)/(2)(c)",
+            """(2) Invalid final compound numeric parent two.
+  (c) Invalid final compound alpha child c.
+    (iii) Descendant of invalid final compound suffix.
+""",
+        ),
+    ],
+)
+def test_rulespec_proof_validator_suppresses_connected_invalid_range_groups(
+    broad_source: str,
+    source_text: str,
+):
+    excerpt = next(
+        line.strip() for line in source_text.splitlines() if "(iii)" in line
+    )
+    content = _proof_scope_fixture(
+        rule_source=f"section (d)(ii), {broad_source}",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "broad_source",
+    [
+        "section (b)(ii), (d)",
+        "section (a)/(c), (d); section (b)(ii)",
+    ],
+)
+def test_rulespec_proof_validator_suppresses_unowned_comma_alpha_group(
+    broad_source: str,
+):
+    excerpt = "(iii) Descendant of unowned comma alpha group d."
+    source_text = f"""(d) Unowned comma alpha group d.
+  {excerpt}
+"""
+    content = _proof_scope_fixture(rule_source=broad_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_fails_closed_for_huge_numeric_range_endpoint():
+    excerpt = "(iii) Descendant of a malformed huge numeric range."
+    huge_endpoint = "9" * 4301
+    content = _proof_scope_fixture(
+        rule_source=f"section (b)(ii), section (a)(1)-({huge_endpoint})",
+        excerpt=excerpt,
+    )
+    source_text = f"""(a) Alpha parent a.
+  (1) Numeric range start one.
+    {excerpt}
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "section (4)(a)(ii)/(3)(b)",
+        "section (4)(a)/(3)(b)",
+        "section (4)(a)(1)(b)/(3)(c)",
+    ],
+)
+def test_rulespec_proof_validator_rejects_direct_alpha_compound_suffix(
+    rule_source: str,
+):
+    marker = "c" if rule_source.endswith("(c)") else "b"
+    excerpt = f"({marker}) Invalid direct alpha compound suffix."
+    source_text = """(3) Numeric parent three.
+(a) Alpha child a.
+(b) Invalid direct alpha compound suffix.
+(c) Invalid direct alpha compound suffix.
+"""
+    content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_allows_authoritative_pair_beside_invalid_suffix():
+    excerpt = "(b) Correct valid paragraph five child b."
+    source_text = f"""(5) Valid numeric parent five.
+  {excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="section (4)(a)/(3)(b); section (5)(b)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_direct_broad_alpha_beside_invalid_suffix():
+    excerpt = "(b) Correct independently broad alpha child b."
+    content = _proof_scope_fixture(
+        rule_source="section (4)(a)/(3)(b); section 6(b)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        """(5) Numeric parent five.
+  (b) First duplicate child b.
+  (b) Second duplicate child b.
+""",
+        """(5) First numeric parent five.
+  (b) First duplicate child b.
+(5) Second numeric parent five.
+  (b) Second duplicate child b.
+""",
+    ],
+)
+def test_rulespec_proof_validator_rejects_duplicate_numeric_alpha_coordinate(
+    source_text: str,
+):
+    excerpt = "(b) First duplicate child b."
+    content = _proof_scope_fixture(rule_source="section (5)(b)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_allows_owned_h_before_nested_roman_i():
+    excerpt = "(h) Valid direct child h."
+    source_text = f"""(5) Numeric parent five.
+  {excerpt}
+    (1) Nested numeric child one.
+      (i) Nested Roman child i.
+"""
+    content = _proof_scope_fixture(rule_source="section (5)(h)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_unrelated_broad_roman_letter_parent():
+    excerpt = "(c) Independently broad parent c."
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii), section 2(c)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_nested_roman_matching_broad_alpha():
+    excerpt = "(i) Wrong nested Roman child under parent a."
+    source_text = f"""(a) Narrow Roman parent a.
+  {excerpt}
+(i) Correct independently broad alpha parent i.
+"""
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii), section 2(i)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_numeric_nested_roman_as_broad_alpha():
+    excerpt = "(i) Wrong nested Roman child under numeric parent four."
+    source_text = f"""(4) Numeric parent four.
+  {excerpt}
+(i) Correct independently broad alpha parent i.
+"""
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii), section 2(i)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_flat_numeric_roman_as_broad_alpha():
+    excerpt = "(i) Wrong flat nested Roman child under numeric parent four."
+    source_text = f"""(4) Numeric parent four with a nested Roman item:
+{excerpt}
+(5) Next numeric parent.
+"""
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii), section 2(i)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_wrong_outer_numeric_roman_owner():
+    excerpt = "(ii) Wrong Roman child under outer paragraph three."
+    source_text = f"""(3) Outer paragraph three.
+  (a) Alpha parent a.
+    (1) Inner numeric child one.
+      {excerpt}
+(4) Outer paragraph four.
+  (a) Alpha parent a.
+    (1) Inner numeric child one.
+      (ii) Correct Roman child under outer paragraph four.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_duplicate_flat_roman_alpha_role():
+    excerpt = "(i) Wrong flat Roman child under parent a."
+    source_text = f"""(a) Narrow Roman parent a.
+{excerpt}
+(i) Correct independently broad alpha parent i.
+"""
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii), section 2(i)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_keeps_authorized_lowercase_roman_role():
+    excerpt = "(i) Correct Roman child under parent a."
+    source_text = f"""(a) Parent a.
+  {excerpt}
+(i) Parent i.
+  (ii) Correct Roman child under parent i.
+"""
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(i); section 2(i)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_roman_chain_repeated_across_records():
+    excerpt = "(ii) Wrong historical Roman child."
+    historical = f"""(4) Historical outer paragraph.
+  (a) Historical alpha parent.
+    (1) Historical numeric child.
+      {excerpt}
+"""
+    current = """(4) Current outer paragraph.
+  (a) Current alpha parent.
+    (1) Current numeric child.
+      (ii) Correct current Roman child.
+"""
+    source_text = historical + PROOF_EVIDENCE_SEGMENT_SEPARATOR + current
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_roman_chain_repeated_in_one_record():
+    excerpt = "(ii) Wrong first Roman child."
+    source_text = f"""(4) First outer paragraph copy.
+  (a) First alpha parent copy.
+    (1) First numeric child copy.
+      {excerpt}
+(4) Second outer paragraph copy.
+  (a) Second alpha parent copy.
+    (1) Second numeric child copy.
+      (ii) Correct second Roman child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_broad_roman_descendant_repeated():
+    excerpt = "(iii) Wrong historical descendant of broad parent a."
+    historical = f"""(a) Historical broad parent a.
+  {excerpt}
+"""
+    current = """(a) Current broad parent a.
+  (iii) Correct current descendant of broad parent a.
+"""
+    source_text = historical + PROOF_EVIDENCE_SEGMENT_SEPARATOR + current
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii), section 2(a)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_broad_parent_leak_across_roman_parents():
+    excerpt = "(iv) Wrong Roman child under narrow parent a."
+    source_text = f"""(a) Narrow parent a.
+  {excerpt}
+(b) Independently broad parent b.
+  (iv) Permitted Roman child under parent b.
+"""
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(ii); section 2(b)(iii), section 3(b)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_roman_ancestry_from_prior_record():
+    excerpt = "(ii) Orphan Roman child in a separate evidence record."
+    source_text = (
+        "(a) Parent in record one.\n"
+        "  (2) Numeric child in record one."
+        + PROOF_EVIDENCE_SEGMENT_SEPARATOR
+        + f"  {excerpt}\n"
+    )
+    content = _proof_scope_fixture(
+        rule_source="section 1(a)(2)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize("marker", ["c", "d"])
+def test_rulespec_proof_validator_allows_direct_roman_letter_alpha_range(
+    marker: str,
+):
+    excerpt = f"({marker}) Direct alphabetic child {marker}."
+    source_text = "(4) The paragraph provides:\n\n" + "\n\n".join(
+        excerpt if child == marker else f"({child}) Alphabetic child {child}."
+        for child in "abcd"
+    )
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(c)-(d)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_ambiguous_expected_nested_roman():
+    excerpt = "(i) Wrong nested Roman child."
+    outer_prefix = "\n\n".join(
+        f"({child}) Outer alphabetic child {child}." for child in "abcdefgh"
+    )
+    outer_suffix = "\n\n".join(
+        f"({child}) Outer alphabetic child {child}." for child in "ijklm"
+    )
+    source_text = f"""(4) The paragraph provides:
+
+{outer_prefix}
+
+  (1) A nested numeric child provides:
+
+    {excerpt}
+
+{outer_suffix}
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(a)-(m)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_does_not_expand_nested_roman_range():
+    excerpt = "(m) An unrelated nested Roman item."
+    source_text = "(a) Parent.\n\n(1) Child:\n\n" + "\n\n".join(
+        excerpt if marker == "m" else f"({marker}) Nested item {marker}."
+        for marker in "abcdefghijklm"
+    )
+    content = _proof_scope_fixture(
+        rule_source="42 CFR 1(a)(1)(i)-(v)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "Miss. Code section 27-7-5(4)(a)-(e)",
+        "Miss. Code section 27-7-5(4)(e)-(a)",
+        "Miss. Code section 27-7-5(4)(a)/(e)",
+    ],
+)
+def test_rulespec_proof_validator_keeps_alphabetic_ranges_fail_closed(
+    rule_source: str,
+):
+    excerpt = "(f) A different fiscal-year rule applies."
+    if "(e)-(a)" in rule_source or "(a)/(e)" in rule_source:
+        excerpt = "(c) An undeclared interior rule applies."
+    content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
         for issue in result.issues
     )
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -17304,9 +17304,7 @@ def test_rulespec_proof_validator_allows_interior_alphabetic_range_excerpt(
         excerpt=excerpt,
     )
     child_blocks = [
-        excerpt
-        if child == marker
-        else f"({child}) Declared fiscal-year step {child}."
+        excerpt if child == marker else f"({child}) Declared fiscal-year step {child}."
         for child in "abcde"
     ]
     child_blocks.insert(
@@ -17317,9 +17315,8 @@ def test_rulespec_proof_validator_allows_interior_alphabetic_range_excerpt(
             "  (5) Nested numbered detail five."
         ),
     )
-    source_text = (
-        "(4) The fiscal-year calculation is determined by:\n\n"
-        + "\n\n".join(child_blocks)
+    source_text = "(4) The fiscal-year calculation is determined by:\n\n" + "\n\n".join(
+        child_blocks
     )
 
     result = validate_rulespec_proofs(
@@ -17858,10 +17855,7 @@ def test_rulespec_proof_validator_rejects_shorthand_after_unhandled_coordinate()
 {excerpt}
 """
     content = _proof_scope_fixture(
-        rule_source=(
-            "Miss. Code section 27-7-5(2)(c); "
-            "42 CFR 1(a)(1)(i)-(v), (d)"
-        ),
+        rule_source=("Miss. Code section 27-7-5(2)(c); 42 CFR 1(a)(1)(i)-(v), (d)"),
         excerpt=excerpt,
     )
 
@@ -17898,9 +17892,7 @@ def test_rulespec_proof_validator_rejects_parent_ambiguous_across_evidence_recor
         content,
         source_texts={
             "us-nj/statute/54a:4-7": (
-                current_record
-                + PROOF_EVIDENCE_SEGMENT_SEPARATOR
-                + history_record
+                current_record + PROOF_EVIDENCE_SEGMENT_SEPARATOR + history_record
             )
         },
     )
@@ -17915,10 +17907,7 @@ def test_rulespec_proof_validator_rejects_parent_ambiguous_across_evidence_recor
 def test_rulespec_proof_validator_preserves_same_segment_numeric_restriction():
     excerpt = "(99) An undeclared numeric child."
     content = _proof_scope_fixture(
-        rule_source=(
-            "Miss. Code section 27-7-5(4)(a)-(e); "
-            "42 CFR 1(f)(1)-(3)"
-        ),
+        rule_source=("Miss. Code section 27-7-5(4)(a)-(e); 42 CFR 1(f)(1)-(3)"),
         excerpt=excerpt,
     )
 
@@ -18022,10 +18011,7 @@ def test_rulespec_proof_validator_fails_closed_for_deeper_roman_evidence(
 def test_rulespec_proof_validator_preserves_numeric_scope_beside_deeper_roman():
     excerpt = "(99) An undeclared numeric child."
     content = _proof_scope_fixture(
-        rule_source=(
-            "Miss. Code section 27-7-5(4)(a)(ii); "
-            "42 CFR 1(f)(1)-(3)"
-        ),
+        rule_source=("Miss. Code section 27-7-5(4)(a)(ii); 42 CFR 1(f)(1)-(3)"),
         excerpt=excerpt,
     )
 
@@ -18303,9 +18289,7 @@ def test_rulespec_proof_validator_allows_unique_broad_chain_prefix(
     rule_source: str,
     source_text: str,
 ):
-    excerpt = next(
-        line.strip() for line in source_text.splitlines() if "(iii)" in line
-    )
+    excerpt = next(line.strip() for line in source_text.splitlines() if "(iii)" in line)
     content = _proof_scope_fixture(rule_source=rule_source, excerpt=excerpt)
 
     result = validate_rulespec_proofs(
@@ -18466,9 +18450,7 @@ def test_rulespec_proof_validator_fails_closed_for_invalid_broad_alpha_range(
     broad_source: str,
     source_text: str,
 ):
-    excerpt = next(
-        line.strip() for line in source_text.splitlines() if "(iii)" in line
-    )
+    excerpt = next(line.strip() for line in source_text.splitlines() if "(iii)" in line)
     content = _proof_scope_fixture(
         rule_source=f"section (b)(ii), {broad_source}",
         excerpt=excerpt,
@@ -18517,9 +18499,7 @@ def test_rulespec_proof_validator_fails_closed_for_compound_range_suffix(
     broad_source: str,
     source_text: str,
 ):
-    excerpt = next(
-        line.strip() for line in source_text.splitlines() if "(iii)" in line
-    )
+    excerpt = next(line.strip() for line in source_text.splitlines() if "(iii)" in line)
     content = _proof_scope_fixture(
         rule_source=f"section (c)(ii), {broad_source}",
         excerpt=excerpt,
@@ -18572,9 +18552,7 @@ def test_rulespec_proof_validator_suppresses_connected_invalid_range_groups(
     broad_source: str,
     source_text: str,
 ):
-    excerpt = next(
-        line.strip() for line in source_text.splitlines() if "(iii)" in line
-    )
+    excerpt = next(line.strip() for line in source_text.splitlines() if "(iii)" in line)
     content = _proof_scope_fixture(
         rule_source=f"section (d)(ii), {broad_source}",
         excerpt=excerpt,

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1672"')
+        .startswith('__version__ = "0.2.1673"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1672"
+    assert encoder_package["version"] == "0.2.1673"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1672"
+    assert project["project"]["version"] == "0.2.1673"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1672"')
+        .startswith('__version__ = "0.2.1673"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1672"
+    assert encoder_package["version"] == "0.2.1673"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1672"
+    assert project["project"]["version"] == "0.2.1673"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1672"')
+        .startswith('__version__ = "0.2.1673"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1672"
+ENCODER_VERSION = "0.2.1673"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1672"
+version = "0.2.1673"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- preserve full subsection ownership when proof text uses nested numeric, alphabetic, and Roman structural coordinates
- resolve ranges and shorthand only within the uniquely owned source block, failing closed for malformed or ambiguous structures
- keep CLI proof-parity filtering aligned with the shared validator without changing encoder dispatching
- add regression coverage for flat and indented structures, duplicate parents and children, malformed ranges, mixed Roman case, and arbitrary-depth ownership chains
- bump the encoder contract consistently to `0.2.1673`

## Root cause and fix

The Mississippi section 27-7-5 schedule cites `(4)(a)-(e)`, while the proof excerpt can begin at `(c)`. The previous proof-scope logic treated subsection markers mostly as scalar tokens and could reject a valid child because it did not retain its owning parent chain.

This change makes structural ownership explicit. It extracts evidence records and source blocks, tokenizes full coordinates, resolves only unique owned occurrences, preserves parent chains through Roman children, and leaves malformed or ambiguous coordinates unresolved. This is a shared validator/CLI parity fix, not a source-specific exception or dispatch workaround.

## Validation

- `ruff 0.16.2 format --check src/ tests/`
- `ruff 0.16.2 check src/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest tests/test_rulespec_validation.py`: 2,448 passed, 31 skipped
- `uv run pytest tests/test_cli.py`: 1,240 passed, 10 skipped
- affected current-version registry/validator suite: 2,472 passed, 31 skipped
- `UV_PROJECT_ENVIRONMENT=/private/tmp/axiom-encode-pit-source-structure/.venv uv run pytest`: 13,155 passed, 123 skipped
- exact Mississippi A2 artifact replay: no proof-scope errors (`[]`)

## Review cycle

Independent review examined the frozen revision for shared-validator regressions, fail-closed behavior, CLI parity, version provenance, and workflow compliance. The cycle caught and fixed CI formatting plus stale current-version test pins. Two independent re-reviews of exact final commit `ab6ac44d` then returned no actionable findings; no changes were made after those final reviews.

## Scope notes

- no dispatcher redesign
- no secrets or ingest credentials added
- candidate Mississippi output is not adopted by this PR; remaining candidate defects stay separate from this false-rejection fix
