### PR TITLE
Fix flattened Roman proof ownership

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1673"
+version = "0.2.1674"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1673"
+__version__ = "0.2.1674"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -1418,6 +1418,9 @@ def _proof_excerpt_subsection_scope_issues(
         marker is not None and marker in scope and scope[marker] is None
     )
     roman_evidence_marker = re.match(
+        r"^\s*\([a-z]\)\s*\((?P<marker>[ivxlcdmIVXLCDM]+)\)(?:\s|$)",
+        evidence_text,
+    ) or re.match(
         r"^\s*\((?P<marker>[ivxlcdmIVXLCDM]+)\)(?:\s|$)",
         evidence_text,
     )
@@ -1606,7 +1609,233 @@ def _source_roman_coordinate_occurrence_count(
             ):
                 count += 1
             stack.append((indent, raw_marker))
-    return count
+    return count + sum(
+        1
+        for flattened_chain, flattened_marker, _ in (
+            _source_flattened_roman_coordinate_occurrences(source_text)
+        )
+        if flattened_chain == chain and flattened_marker == marker
+    )
+
+
+def _source_flattened_roman_coordinate_occurrences(
+    source_text: str,
+) -> list[tuple[tuple[str, ...], str, int]]:
+    """Recover unambiguous Roman ownership from flat leading coordinates.
+
+    Some released statute text puts compound parents such as ``(1) (a)`` and
+    ``(b) (i)`` at the record's baseline indentation, followed by Roman peers
+    such as ``(ii)`` at that same baseline. The ordinary indentation stack must
+    remain authoritative for structured text, so this fallback considers only
+    baseline, line-leading coordinate bundles. It resets at every evidence
+    record and numeric peer, and carries a Roman continuation only in canonical
+    ascending order from an established alpha owner.
+    """
+    header_pattern = re.compile(
+        r"(?m)^(?P<indent>[ \t]*)(?P<bundle>"
+        rf"(?:\({_STRUCTURAL_COORDINATE_TOKEN}\)[ \t]*)+"
+        r")"
+    )
+    coordinate_pattern = re.compile(rf"\((?P<value>{_STRUCTURAL_COORDINATE_TOKEN})\)")
+    occurrences: list[tuple[tuple[str, ...], str, int]] = []
+    record_offset = 0
+    for record in source_text.split(PROOF_EVIDENCE_SEGMENT_SEPARATOR):
+        headers = list(header_pattern.finditer(record))
+        baseline_indent = min(
+            (len(header.group("indent").expandtabs(2)) for header in headers),
+            default=None,
+        )
+        numeric_prefix: tuple[str, ...] = ()
+        current_chain: tuple[str, ...] | None = None
+        next_roman_value = 1
+        roman_sequence_established = False
+        for header_index, header in enumerate(headers):
+            indent = len(header.group("indent").expandtabs(2))
+            if baseline_indent is None or indent != baseline_indent:
+                continue
+            tokens = [
+                match.group("value")
+                for match in coordinate_pattern.finditer(header.group("bundle"))
+            ]
+            if not tokens:
+                continue
+            header_start = record_offset + header.start("bundle")
+            if len(tokens) == 1:
+                token = tokens[0]
+                if token.isdigit():
+                    numeric_prefix = (token,)
+                    current_chain = None
+                    next_roman_value = 1
+                    roman_sequence_established = False
+                    continue
+                roman_value = (
+                    _canonical_roman_value(token)
+                    if re.fullmatch(r"[ivxlcdmIVXLCDM]+", token) is not None
+                    else None
+                )
+                ambiguous_lower_alpha = len(token) == 1 and token.islower()
+                has_roman_successor = False
+                has_direct_alpha_progression = False
+                if ambiguous_lower_alpha and roman_value is not None:
+                    for successor in headers[header_index + 1 :]:
+                        successor_indent = len(successor.group("indent").expandtabs(2))
+                        if successor_indent != baseline_indent:
+                            continue
+                        successor_tokens = [
+                            match.group("value")
+                            for match in coordinate_pattern.finditer(
+                                successor.group("bundle")
+                            )
+                        ]
+                        successor_roman_value = (
+                            _canonical_roman_value(successor_tokens[0])
+                            if len(successor_tokens) == 1
+                            and re.fullmatch(r"[ivxlcdmIVXLCDM]+", successor_tokens[0])
+                            is not None
+                            else None
+                        )
+                        has_roman_successor = successor_roman_value == roman_value + 1
+                        owner_alpha_index = next(
+                            (
+                                index
+                                for index, coordinate in enumerate(current_chain or ())
+                                if len(coordinate) == 1 and coordinate.islower()
+                            ),
+                            None,
+                        )
+                        owner_alpha = (
+                            current_chain[owner_alpha_index]
+                            if current_chain is not None
+                            and owner_alpha_index is not None
+                            else None
+                        )
+                        successor_alpha_index = next(
+                            (
+                                index
+                                for index, coordinate in enumerate(successor_tokens)
+                                if not coordinate.isdigit()
+                            ),
+                            None,
+                        )
+                        successor_alpha = (
+                            successor_tokens[successor_alpha_index]
+                            if successor_alpha_index is not None
+                            else None
+                        )
+                        successor_owner_prefix = (
+                            tuple(successor_tokens[:successor_alpha_index])
+                            if successor_alpha_index is not None
+                            else ()
+                        )
+                        successor_suffix = (
+                            successor_tokens[successor_alpha_index + 1 :]
+                            if successor_alpha_index is not None
+                            else []
+                        )
+                        successor_roman_suffix = (
+                            successor_suffix[-1]
+                            if successor_suffix
+                            and re.fullmatch(r"[ivxlcdmIVXLCDM]+", successor_suffix[-1])
+                            is not None
+                            else None
+                        )
+                        successor_numeric_suffix = (
+                            successor_suffix[:-1]
+                            if successor_roman_suffix is not None
+                            else successor_suffix
+                        )
+                        has_direct_alpha_progression = (
+                            owner_alpha is not None
+                            and successor_alpha is not None
+                            and len(successor_alpha) == 1
+                            and successor_alpha.islower()
+                            and (
+                                not successor_owner_prefix
+                                or successor_owner_prefix
+                                == current_chain[:owner_alpha_index]
+                            )
+                            and all(
+                                coordinate.isdigit()
+                                for coordinate in successor_numeric_suffix
+                            )
+                            and ord(token) == ord(owner_alpha) + 1
+                            and ord(successor_alpha) == ord(token) + 1
+                        )
+                        break
+                if (
+                    current_chain is not None
+                    and roman_value == next_roman_value
+                    and not has_direct_alpha_progression
+                    and (
+                        not ambiguous_lower_alpha
+                        or roman_sequence_established
+                        or has_roman_successor
+                    )
+                ):
+                    marker = _canonical_roman_marker(roman_value)
+                    occurrences.append((current_chain, marker, header_start))
+                    next_roman_value = roman_value + 1
+                    roman_sequence_established = True
+                    continue
+                if len(token) == 1 and token.islower() and numeric_prefix:
+                    current_chain = (*numeric_prefix, token)
+                    next_roman_value = 1
+                    roman_sequence_established = False
+                else:
+                    current_chain = None
+                    next_roman_value = 1
+                    roman_sequence_established = False
+                continue
+
+            alpha_index = next(
+                (index for index, token in enumerate(tokens) if not token.isdigit()),
+                None,
+            )
+            if alpha_index is None:
+                numeric_prefix = tuple(tokens)
+                current_chain = None
+                next_roman_value = 1
+                roman_sequence_established = False
+                continue
+            alpha = tokens[alpha_index]
+            explicit_numeric_prefix = tuple(tokens[:alpha_index])
+            owner_prefix = explicit_numeric_prefix or numeric_prefix
+            suffix = tokens[alpha_index + 1 :]
+            roman_token = (
+                suffix[-1]
+                if suffix
+                and re.fullmatch(r"[ivxlcdmIVXLCDM]+", suffix[-1]) is not None
+                and all(token.isdigit() for token in suffix[:-1])
+                else None
+            )
+            numeric_suffix = suffix[:-1] if roman_token is not None else suffix
+            if (
+                not owner_prefix
+                or len(alpha) != 1
+                or not alpha.islower()
+                or not all(token.isdigit() for token in numeric_suffix)
+            ):
+                current_chain = None
+                next_roman_value = 1
+                roman_sequence_established = False
+                continue
+            numeric_prefix = owner_prefix
+            current_chain = (*owner_prefix, alpha, *numeric_suffix)
+            next_roman_value = 1
+            roman_sequence_established = False
+            if roman_token is None:
+                continue
+            roman_value = _canonical_roman_value(roman_token)
+            if roman_value is None:
+                current_chain = None
+                roman_sequence_established = False
+                continue
+            marker = _canonical_roman_marker(roman_value)
+            occurrences.append((current_chain, marker, header_start))
+            next_roman_value = roman_value + 1
+            roman_sequence_established = True
+        record_offset += len(record) + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
+    return occurrences
 
 
 def _source_text_is_exact_evidence_scalar(
@@ -1672,12 +1901,21 @@ def _source_roman_evidence_chain(
                 if not coordinate.isdigit()
             ]
             if len(alpha_indexes) != 1:
-                return None
+                break
             alpha = ancestry[alpha_indexes[0]]
             if len(alpha) != 1 or not alpha.islower():
-                return None
+                break
             return ancestry
         stack.append((indent, header.group("marker")))
+    flattened_chains = {
+        chain
+        for chain, _, header_start in _source_flattened_roman_coordinate_occurrences(
+            source_text
+        )
+        if header_start == evidence_match.start()
+    }
+    if len(flattened_chains) == 1:
+        return next(iter(flattened_chains))
     return None
 
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1673"
+ENCODER_VERSION = "0.2.1674"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1673"
+ENCODER_VERSION = "0.2.1674"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1673"
+ENCODER_VERSION = "0.2.1674"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1673"
+ENCODER_VERSION = "0.2.1674"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1673"
+ENCODER_VERSION = "0.2.1674"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1673"
+ENCODER_VERSION = "0.2.1674"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1673"
+ENCODER_VERSION = "0.2.1674"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1673"')
+        .startswith('__version__ = "0.2.1674"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1673"
+    assert encoder_package["version"] == "0.2.1674"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1673"
+    assert project["project"]["version"] == "0.2.1674"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1673"')
+        .startswith('__version__ = "0.2.1674"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1673"
+    assert encoder_package["version"] == "0.2.1674"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1673"
+    assert project["project"]["version"] == "0.2.1674"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1673"')
+        .startswith('__version__ = "0.2.1674"')
     )
 
 
@@ -16777,7 +16777,12 @@ rules:
     )
 
 
-def _proof_scope_fixture(*, rule_source: str, excerpt: str) -> str:
+def _proof_scope_fixture(
+    *,
+    rule_source: str,
+    excerpt: str,
+    citation_path: str = "us-nj/statute/54a:4-7",
+) -> str:
     return f"""format: rulespec/v1
 rules:
   - name: credit_before_proration
@@ -16790,7 +16795,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-nj/statute/54a:4-7
+              corpus_citation_path: {citation_path}
               excerpt: {excerpt!r}
     versions:
       - effective_from: '2026-01-01'
@@ -18082,6 +18087,409 @@ def test_rulespec_proof_validator_allows_declared_roman_members(
 
     assert result.passed is True
     assert result.issues == []
+
+
+_FLAT_MS_CITATION_PATH = "us-ms/statute/27-7-5"
+_FLAT_MS_COMPOUND_ROMAN_SOURCE = """(1) (a) The tax applies at these rates:
+
+(i) The first band applies.
+
+(ii) The second band applies.
+
+(iii) The third band applies.
+
+(b) (i) For calendar year 2023 and all calendar years thereafter, there shall be no tax levied under subparagraph (ii) of paragraph (a) of this subsection; and
+
+(ii) For calendar year 2024 and all calendar years thereafter, the tax imposed under subparagraph (iii) of paragraph (a) of this subsection shall be at the following rates:
+
+(2) The next subsection applies.
+"""
+
+
+def test_rulespec_proof_validator_allows_flat_compound_alpha_roman_excerpt():
+    excerpt = (
+        "(b) (i) For calendar year 2023 and all calendar years thereafter, "
+        "there shall be no tax levied under subparagraph (ii) of paragraph "
+        "(a) of this subsection; and"
+    )
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(a)(ii), (1)(b)(i)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={
+            _FLAT_MS_CITATION_PATH: _FLAT_MS_COMPOUND_ROMAN_SOURCE,
+        },
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_flat_roman_continuation():
+    excerpt = (
+        "(ii) For calendar year 2024 and all calendar years thereafter, the "
+        "tax imposed under subparagraph (iii) of paragraph (a) of this "
+        "subsection shall be at the following rates:"
+    )
+    content = _proof_scope_fixture(
+        rule_source=("Miss. Code section 27-7-5(1)(a)(i)-(iii), (1)(b)(i)-(ii)"),
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={
+            _FLAT_MS_CITATION_PATH: _FLAT_MS_COMPOUND_ROMAN_SOURCE,
+        },
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_flat_roman_under_wrong_alpha_parent():
+    excerpt = "(ii) Wrong Roman child under alpha parent a."
+    source_text = f"""(1) (a) Parent a.
+
+(i) First Roman child under parent a.
+
+{excerpt}
+
+(b) (i) First Roman child under parent b.
+
+(ii) Correct Roman child under parent b.
+
+(2) Numeric peer two.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(b)(i)-(ii)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_flat_roman_under_wrong_numeric_parent():
+    excerpt = "(ii) Wrong Roman child under numeric parent three."
+    source_text = f"""(3) (a) Parent three alpha a.
+
+(b) (i) First Roman child under parent three alpha b.
+
+{excerpt}
+
+(4) (a) Parent four alpha a.
+
+(b) (i) First Roman child under parent four alpha b.
+
+(ii) Correct Roman child under parent four alpha b.
+
+(5) Numeric peer five.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(4)(b)(i)-(ii)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_duplicate_flat_roman_chain():
+    excerpt = "(ii) Wrong first occurrence under parent b."
+    source_text = f"""(1) (a) Parent a.
+
+(b) (i) First sequence under parent b.
+
+{excerpt}
+
+(b) (i) Repeated sequence under parent b.
+
+(ii) Correct second occurrence under parent b.
+
+(2) Numeric peer two.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(b)(i)-(ii)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_resets_flat_roman_owner_between_records():
+    excerpt = "(ii) Orphan Roman continuation in record two."
+    source_text = (
+        "(1) (a) Parent a.\n\n(b) (i) Parent b first Roman child."
+        + PROOF_EVIDENCE_SEGMENT_SEPARATOR
+        + excerpt
+    )
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(b)(i)-(ii)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_resets_flat_roman_owner_at_numeric_peer():
+    excerpt = "(ii) Orphan Roman continuation under numeric peer two."
+    source_text = f"""(1) (a) Parent a.
+
+(b) (i) Parent b first Roman child.
+
+(2) Numeric peer two.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(b)(i)-(ii)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_descending_flat_roman_continuation():
+    excerpt = "(i) Descending Roman continuation under parent b."
+    source_text = f"""(1) (a) Parent a.
+
+(b) (ii) Second Roman child appears first.
+
+{excerpt}
+
+(2) Numeric peer two.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(b)(i)-(ii)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_flat_direct_alpha_i_as_roman_child():
+    excerpt = "(i) Direct alphabetic sibling i."
+    source_text = f"""(1) (h) Direct alphabetic sibling h.
+
+{excerpt}
+
+(j) Direct alphabetic sibling j.
+
+(2) Numeric peer two.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(h)(i)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_flat_roman_alpha_i_collision():
+    excerpt = "(i) Claimed Roman child under alphabetic parent a."
+    source_text = f"""(1) (a) Direct alphabetic sibling a.
+
+{excerpt}
+
+(i) Direct alphabetic sibling i.
+
+(2) Numeric peer two.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(a)(i)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_allows_terminal_single_letter_flat_roman():
+    excerpt = "(v) Terminal fifth Roman child under alphabetic parent a."
+    source_text = f"""(1) (a) Alphabetic parent a.
+
+(i) First Roman child.
+
+(ii) Second Roman child.
+
+(iii) Third Roman child.
+
+(iv) Fourth Roman child.
+
+{excerpt}
+
+(2) Numeric peer two.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(a)(v)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_established_roman_to_alpha_progression():
+    excerpt = "(v) Direct alphabetic sibling v."
+    source_text = f"""(1) (u) Direct alphabetic sibling u.
+
+(i) First Roman child under alphabetic parent u.
+
+(ii) Second Roman child under alphabetic parent u.
+
+(iii) Third Roman child under alphabetic parent u.
+
+(iv) Fourth Roman child under alphabetic parent u.
+
+{excerpt}
+
+(w) Direct alphabetic sibling w.
+
+(2) Numeric peer two.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(u)(v)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_roman_to_compound_alpha_progression():
+    excerpt = "(v) Direct alphabetic sibling v."
+    source_text = f"""(1) (u) Direct alphabetic sibling u.
+
+(i) First Roman child under alphabetic parent u.
+
+(ii) Second Roman child under alphabetic parent u.
+
+(iii) Third Roman child under alphabetic parent u.
+
+(iv) Fourth Roman child under alphabetic parent u.
+
+{excerpt}
+
+(w) (i) Direct alphabetic sibling w with its first Roman child.
+
+(ii) Second Roman child under alphabetic parent w.
+
+(2) Numeric peer two.
+"""
+    content = _proof_scope_fixture(
+        rule_source="Miss. Code section 27-7-5(1)(u)(v)",
+        excerpt=excerpt,
+        citation_path=_FLAT_MS_CITATION_PATH,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={_FLAT_MS_CITATION_PATH: source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1673"
+ENCODER_VERSION = "0.2.1674"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1673"
+version = "0.2.1674"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- recognize record-local flattened compound alpha-to-Roman source structures in proof validation
- preserve strict ownership boundaries across numeric peers, alpha owners, malformed bundles, and records
- reject ambiguous direct-alpha progressions and duplicate/colliding coordinates
- bump the encoder version to 0.2.1674

This is a generic source-structure validation fix. It does not change workflow dispatching, state-specific allowlists, publication rules, or signing behavior.

## Validation

- full repository suite: 13,168 passed, 123 skipped
- focused proof-validator suite: 262 passed
- broader modified validation/oracle suite: 2,485 passed, 31 skipped
- ruff: passed
- compileall: passed
- git diff check: passed

## Review cycle

An independent reviewer found and drove fixes for direct alpha h-to-i-to-j ambiguity, prefixed alpha/Roman collisions, terminal Roman v handling, established-Roman-to-alpha transitions, and compound successor variants. The reviewer reran the focused and broad matrices after the fixes and reported no remaining actionable findings.