### PR TITLE
Fix authenticated same-act deferral validation

### DIFF
--- a/changelog.d/authenticated-same-act-deferrals.fixed.md
+++ b/changelog.d/authenticated-same-act-deferrals.fixed.md
@@ -1,0 +1,1 @@
+Accept provenance-authenticated same-act deferrals that name a concrete unavailable dependency, including metadata-derived year-act references, while rejecting unrelated inputs and contradictory availability claims.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1675"
+version = "0.2.1676"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1675"
+__version__ = "0.2.1676"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -7729,11 +7729,6 @@ def _reason_names_missing_same_act_dependency(
         )
     if not exact_current_branch:
         return False
-    reason_matches = _same_act_section_dependencies(
-        reason,
-        authenticated_same_act_aliases=authenticated_same_act_aliases,
-    )
-    reason_sections = {section.lower() for section, _start, _end in reason_matches}
     source_sections = {
         match.group("section").lower()
         for match in _SAME_ACT_SECTION_DEPENDENCY.finditer(source_scope_text)
@@ -7743,14 +7738,21 @@ def _reason_names_missing_same_act_dependency(
             flags=re.IGNORECASE,
         )
     }
+    reason_matches = _same_act_section_dependencies(
+        reason,
+        authenticated_same_act_aliases=authenticated_same_act_aliases,
+    )
+    reason_sections = {section.lower() for section, _start, _end in reason_matches}
     matching_sections = reason_sections.intersection(source_sections)
     if not matching_sections:
         return False
     clauses = tuple(re.finditer(r"[^.;\n]+", reason))
+    seen_sections: set[str] = set()
     for dependency_section, dependency_start, _dependency_end in reason_matches:
         identity = dependency_section.lower()
-        if identity not in matching_sections:
+        if identity not in matching_sections or identity in seen_sections:
             continue
+        seen_sections.add(identity)
         clause_index = next(
             (
                 index
@@ -7762,16 +7764,16 @@ def _reason_names_missing_same_act_dependency(
         if clause_index is None:
             continue
         section = re.escape(dependency_section)
-        for clause in clauses[clause_index : clause_index + 2]:
-            clause_text = clause.group(0)
-            if not re.search(rf"\bsection\s+{section}\b", clause_text, re.IGNORECASE):
-                continue
-            if _same_act_clause_names_missing_dependency(
-                clause_text,
-                section=section,
-                authenticated_same_act_aliases=authenticated_same_act_aliases,
-            ):
-                return True
+        # Keep the authenticated reference clause in view while checking the
+        # next missing-state claim and any immediately following reversal.
+        clause_end = clauses[min(clause_index + 2, len(clauses) - 1)].end()
+        clause_text = reason[clauses[clause_index].start() : clause_end]
+        if _same_act_clause_names_missing_dependency(
+            clause_text,
+            section=section,
+            authenticated_same_act_aliases=authenticated_same_act_aliases,
+        ):
+            return True
     return False
 
 
@@ -7800,7 +7802,57 @@ def _same_act_section_dependencies(
             (match.group("section"), match.start(), match.end())
             for match in pattern.finditer(text)
         )
-    return tuple(dict.fromkeys(matches))
+        authenticated_year = re.match(r"(?P<year>\d{4})\b", normalized_alias)
+        if authenticated_year:
+            # A year-only "the 2025 act" reference is meaningful only in the
+            # context of a provenance-authenticated current-row act alias. It
+            # is never accepted without that metadata-bound alias.
+            year_pattern = re.compile(
+                r"\bsection\s+(?P<section>\d+[a-z]?)\s+of\s+(?:the\s+)?"
+                + re.escape(authenticated_year.group("year"))
+                + r"\s+act\b",
+                flags=re.IGNORECASE,
+            )
+            matches.extend(
+                (match.group("section"), match.start(), match.end())
+                for match in year_pattern.finditer(text)
+            )
+    return tuple(sorted(dict.fromkeys(matches), key=lambda match: (match[1], match[2])))
+
+
+_SAME_ACT_DEPENDENCY_OBJECT = (
+    r"(?:(?:the|that|those)\s+)?(?:(?:exact|external|legal|operative|same-act|"
+    r"source-(?:bound|stated)|runtime)\s+){0,3}"
+    r"(?:(?:displacement|dependency|implementation|rate)\s+){0,2}"
+    r"(?:capabilit(?:y|ies)|conditions?|dependenc(?:y|ies)|requirements?)"
+    r"(?:\s+(?:needed|required)\s+to\s+"
+    r"(?:apply|compute|determine|encode|implement|resolve)\s+"
+    r"(?:(?:the|that)\s+)?(?:controlling\s+)?"
+    r"(?:amount|conditions?|effect|rate|result|rule))?"
+)
+_SAME_ACT_EXECUTABLE_OBJECT = (
+    r"executable\s+(?:(?:exact|same-act|source-bound|rulespec)\s+){0,2}"
+    r"(?:capabilit(?:y|ies)|exports?|implementations?|outputs?|rules?)"
+)
+
+
+def _same_act_identity_pattern(
+    authenticated_same_act_aliases: Sequence[str],
+) -> str:
+    """Build canonical and provenance-authenticated current-act identities."""
+
+    identities = [r"(?:this|the)\s+act"]
+    for alias in dict.fromkeys(authenticated_same_act_aliases):
+        normalized_alias = " ".join(str(alias).split())
+        if not normalized_alias:
+            continue
+        identities.append(re.escape(normalized_alias))
+        authenticated_year = re.match(r"(?P<year>\d{4})\b", normalized_alias)
+        if authenticated_year:
+            identities.append(
+                rf"(?:the\s+)?{re.escape(authenticated_year.group('year'))}\s+act"
+            )
+    return rf"(?:{'|'.join(identities)})"
 
 
 def _same_act_clause_names_missing_dependency(
@@ -7809,14 +7861,9 @@ def _same_act_clause_names_missing_dependency(
     section: str,
     authenticated_same_act_aliases: Sequence[str] = (),
 ) -> bool:
-    alias_alternatives = "|".join(
-        re.escape(" ".join(str(alias).split()))
-        for alias in dict.fromkeys(authenticated_same_act_aliases)
-        if " ".join(str(alias).split())
+    act_identity = _same_act_identity_pattern(
+        authenticated_same_act_aliases,
     )
-    act_identity = r"(?:this|the)\s+act"
-    if alias_alternatives:
-        act_identity = rf"(?:{act_identity}|{alias_alternatives})"
     reference = rf"\bsection\s+{section}(?:\s+of\s+{act_identity})?\b"
     direct_state = (
         r"\s*(?:,\s*)?(?:(?:which|that)\s+|whose\s+(?:text|body)\s+)?"
@@ -7828,10 +7875,30 @@ def _same_act_clause_names_missing_dependency(
         clause_text,
         direct_match,
         section=section,
+        authenticated_same_act_aliases=authenticated_same_act_aliases,
+    ):
+        return True
+    named_object_state = re.search(
+        reference + rf"(?P<object>\s+{_SAME_ACT_DEPENDENCY_OBJECT})\s+"
+        r"(?:is|are|remains)\s+"
+        r"(?:missing|unavailable|not\s+(?:available|encoded|implemented|supplied))\b",
+        clause_text,
+        flags=re.IGNORECASE,
+    )
+    if (
+        named_object_state
+        and not _ADVERSATIVE_LANGUAGE.search(named_object_state.group("object"))
+        and not _same_act_dependency_state_is_reversed(
+            clause_text,
+            named_object_state,
+            section=section,
+            authenticated_same_act_aliases=authenticated_same_act_aliases,
+        )
     ):
         return True
     no_executable_for_section = (
-        r"\bno\s+executable\b[^,;]{0,100}\b(?:for|from|under)\s+(?:the\s+)?" + reference
+        rf"\bno\s+{_SAME_ACT_EXECUTABLE_OBJECT}\b[^,;.\n]{{0,100}}"
+        r"\b(?:for|from|under)\s+(?:the\s+)?" + reference
     )
     no_executable_match = re.search(
         no_executable_for_section,
@@ -7842,6 +7909,7 @@ def _same_act_clause_names_missing_dependency(
         clause_text,
         no_executable_match,
         section=section,
+        authenticated_same_act_aliases=authenticated_same_act_aliases,
     ):
         return True
     same_act_text_state = re.search(
@@ -7857,6 +7925,7 @@ def _same_act_clause_names_missing_dependency(
         clause_text,
         same_act_text_state,
         section=section,
+        authenticated_same_act_aliases=authenticated_same_act_aliases,
     ):
         return True
     dependency_bridge = (
@@ -7871,6 +7940,7 @@ def _same_act_clause_names_missing_dependency(
             clause_text,
             bridge_match,
             section=section,
+            authenticated_same_act_aliases=authenticated_same_act_aliases,
         )
     )
 
@@ -7880,12 +7950,11 @@ def _same_act_dependency_state_is_reversed(
     dependency_match: re.Match[str],
     *,
     section: str,
+    authenticated_same_act_aliases: Sequence[str] = (),
 ) -> bool:
     """Reject bounded negation or a coordinated reversal of this dependency."""
 
-    prefix = clause_text[
-        max(0, dependency_match.start() - 80) : dependency_match.start()
-    ]
+    prefix = clause_text[: dependency_match.start()]
     if re.search(
         r"\b(?:"
         r"(?:it\s+is\s+)?(?:false|untrue|not\s+true)\s+that"
@@ -7897,25 +7966,111 @@ def _same_act_dependency_state_is_reversed(
         flags=re.IGNORECASE,
     ):
         return True
+    act_identity = _same_act_identity_pattern(authenticated_same_act_aliases)
+    same_section_identity = (
+        rf"(?:(?:that|the)\s+|(?:the\s+)?same[- ]act\s+)?section\s+{section}"
+        rf"(?:\s+of\s+{act_identity})?"
+    )
+    same_section_subject = (
+        same_section_identity + rf"(?:\s*,?\s*(?:whose\s+)?(?:body|text|"
+        rf"{_SAME_ACT_DEPENDENCY_OBJECT}))?"
+    )
+    state_link = r"(?:(?:is|are|remains)|(?:has|have)\s+been)"
+    positive_state = (
+        state_link + r"\s+(?:(?:actually|fully|in\s+fact)\s+)?"
+        r"(?:accessible|available|encoded|implemented|present|provided|supplied)\b"
+        r"(?:\s+in\s+full)?"
+    )
+    no_executable_claim = bool(
+        re.match(r"\s*no\s+executable\b", dependency_match.group(0), re.IGNORECASE)
+    )
+    executable_subject = (
+        rf"(?:(?:a|an|the|that|this)\s+)?{_SAME_ACT_EXECUTABLE_OBJECT}"
+        rf"(?:\s+(?:for|from|under)\s+(?:the\s+)?{same_section_identity})?"
+        r"(?!\s+(?:for|from|under)\b)"
+    )
+    possessive_executable_subject = (
+        rf"(?:its|{same_section_identity}'s|(?:the|that)\s+section's)\s+"
+        rf"{_SAME_ACT_EXECUTABLE_OBJECT}"
+    )
+    prior_positive_subject = (
+        executable_subject if no_executable_claim else same_section_subject
+    )
+    if re.search(
+        rf"\b{prior_positive_subject}\s*,?\s*(?:which\s+)?{positive_state}",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    implementation_state = (
+        state_link + r"\s+(?:(?:actually|fully|in\s+fact)\s+)?"
+        r"(?:encoded|implemented)\b"
+    )
+    if no_executable_claim and re.search(
+        rf"\b{same_section_identity}\s+{implementation_state}",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return True
     suffix = clause_text[dependency_match.end() :]
     reversal_subject = (
-        rf"(?:it|that\s+section|the\s+section|"
-        rf"section\s+{section}(?:\s+of\s+(?:this|the)\s+act)?|"
-        r"an?\s+executable\s+(?:output|rule))"
+        rf"(?:it|they|{executable_subject}|{possessive_executable_subject})"
     )
+    if not no_executable_claim:
+        reversal_subject = (
+            rf"(?:it|they|that\s+section|the\s+section|{same_section_subject}|"
+            rf"{executable_subject}|{possessive_executable_subject})"
+        )
     reversal_state = (
-        r"(?:is|remains)\s+(?:(?:actually|fully|in\s+fact)\s+)?"
-        r"(?:available|encoded|implemented|"
-        r"supplied|not\s+(?:missing|required|unavailable))|"
+        state_link + r"\s+(?:(?:actually|fully|in\s+fact)\s+)?"
+        r"(?:accessible|available|encoded|implemented|present|provided|supplied|"
+        r"not\s+(?:missing|required|unavailable))|"
         r"(?:is\s+)?not\s+required|(?:does\s+)?exists?"
     )
-    return bool(
-        re.search(
-            rf"\b(?:although|but|however|nevertheless|nonetheless|though|yet)\b"
-            rf"[^.;\n]{{0,100}}?\b{reversal_subject}\s+{reversal_state}\b",
+    explicit_reversal = re.search(
+        rf"\b(?:although|but|however|nevertheless|nonetheless|though|yet|and)\b"
+        rf"[^.;\n]{{0,100}}?\b{reversal_subject}\s+{reversal_state}\b",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    section_implementation_reversal = None
+    executable_existence_reversal = None
+    if no_executable_claim:
+        reversal_boundary = (
+            r"(?:\b(?:although|but|however|nevertheless|nonetheless|though|yet|and)\b"
+            r"[^.;\n]{0,100}?|[.;]\s*)"
+        )
+        section_implementation_reversal = re.search(
+            rf"{reversal_boundary}\b{same_section_identity}\s+"
+            rf"{implementation_state}\b",
             suffix,
             flags=re.IGNORECASE,
         )
+        executable_existence_reversal = re.search(
+            rf"{reversal_boundary}\b(?:there\s+(?:is|are)\s+{executable_subject}|"
+            rf"{same_section_identity}\s+(?:has|have)\s+{executable_subject})\b",
+            suffix,
+            flags=re.IGNORECASE,
+        )
+    elliptical_reversal = re.match(
+        rf"\s*[^.;\n]{{0,100}}?\b"
+        rf"(?:although|but|however|nevertheless|nonetheless|though|yet|and)\b"
+        rf"\s+(?:(?:it|they)\s+)?{reversal_state}\b",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    adjacent_clause_reversal = re.match(
+        rf"\s*[^.;\n]{{0,100}}?[.;]\s*"
+        rf"{reversal_subject}\s+{reversal_state}\b",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    return bool(
+        explicit_reversal
+        or section_implementation_reversal
+        or executable_existence_reversal
+        or elliptical_reversal
+        or adjacent_clause_reversal
     )
 
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1675"
+ENCODER_VERSION = "0.2.1676"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1675"
+ENCODER_VERSION = "0.2.1676"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1675"
+ENCODER_VERSION = "0.2.1676"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_live_run_telemetry.py
+++ b/tests/test_live_run_telemetry.py
@@ -95,7 +95,7 @@ class TestLiveRunTelemetry:
                 citation="us/statute/26/32",
                 backend="codex",
                 model="gpt-5.5",
-                encoder_version="0.2.1675",
+                encoder_version="0.2.1676",
             ) as live:
                 live.set_attempt(2, "gpt-5.5-max")
                 live.finish("completed", run_id="abc12345")

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1675"
+ENCODER_VERSION = "0.2.1676"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1675"
+ENCODER_VERSION = "0.2.1676"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1675"
+ENCODER_VERSION = "0.2.1676"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1675"
+ENCODER_VERSION = "0.2.1676"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1675"')
+        .startswith('__version__ = "0.2.1676"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1675"
+    assert encoder_package["version"] == "0.2.1676"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1675"
+    assert project["project"]["version"] == "0.2.1676"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1675"')
+        .startswith('__version__ = "0.2.1676"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1675"
+    assert encoder_package["version"] == "0.2.1676"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1675"
+    assert project["project"]["version"] == "0.2.1676"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1675"')
+        .startswith('__version__ = "0.2.1676"')
     )
 
 
@@ -34379,6 +34379,90 @@ rules: []
 """
     source_text = """(1) For calendar year 2030 and later, except as otherwise
 provided in Section 2 of this act, the rate shall be three percent (3%).
+"""
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-us/us-ms",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        local_corpus_release=None,
+        enable_oracles=False,
+        require_complete_source_unit=True,
+        source_citation_path=citation_path,
+        source_metadata={
+            "source_attestation": {
+                "row": {
+                    "source_path": (
+                        "sources/us-ms/statute/release/mississippi-legislature/"
+                        "2025-hb-1-sg.html"
+                    )
+                }
+            }
+        },
+    )
+
+    issues = pipeline._complete_source_unit_issues(
+        content,
+        validation_source_texts={citation_path: source_text},
+        test_cases=[],
+    )
+
+    assert not any(
+        issue.startswith("[complete-source-unit:deferral]") for issue in issues
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "us-ms/statute/27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and that Section 2 legal dependency is not "
+            "supplied in the available context."
+        ),
+        (
+            "us-ms/statute/27-7-5(1)(b)(ii)(7) makes the rate subject to Section "
+            "2 of the 2025 act; the operative Section 2 displacement conditions "
+            "needed to determine the controlling rate are not supplied in the "
+            "available legal context."
+        ),
+    ),
+)
+def test_complete_source_accepts_bound_not_supplied_same_act_dependency(
+    tmp_path,
+    reason: str,
+):
+    citation_path = "us-ms/statute/27-7-5"
+    content = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ms/statute/27-7-5
+  deferred_outputs:
+    - output: us-ms:statutes/27-7-5/1/b/ii/7#individual_excess_income_rate
+      reason: >-
+        {reason}
+rules: []
+"""
+    source_text = """(1) (a) The former schedule applies at these rates:
+
+(i) The first band applies.
+
+(ii) The second band applies.
+
+(iii) The third band applies.
+
+(b) (i) For calendar year 2023 and later, the middle band changes; and
+
+(ii) For calendar year 2024 and later, the excess-income rate is as follows:
+
+1. For calendar year 2024, the rate is 4.7%;
+2. For calendar year 2025, the rate is 4.4%;
+3. For calendar year 2026, the rate is 4%;
+4. For calendar year 2027, the rate is 3.75%;
+5. For calendar year 2028, the rate is 3.5%;
+6. For calendar year 2029, the rate is 3.25%; and
+7. For calendar year 2030 and later, except as otherwise provided in Section 2
+of this act, the rate is 3%.
+
+(2) The next subsection applies.
 """
     pipeline = ValidatorPipeline(
         policy_repo_path=tmp_path / "rulespec-us/us-ms",

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1675"
+ENCODER_VERSION = "0.2.1676"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -13442,6 +13442,509 @@ def test_same_act_section_dependency_accepts_truthful_missing_text_possessive():
     )
 
 
+def test_same_act_section_dependency_accepts_bound_not_supplied_object():
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+        "Section 2 of this act, and that Section 2 legal dependency is not "
+        "supplied in the available context."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+def test_same_act_section_dependency_accepts_authenticated_year_act_alias():
+    reason = (
+        "us-ms/statute/27-7-5(1)(b)(ii)(7) makes the rate subject to Section 2 "
+        "of the 2025 act; the operative Section 2 displacement conditions needed "
+        "to determine the controlling rate are not supplied in the available "
+        "legal context."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+        authenticated_same_act_aliases=("2025 House Bill 1",),
+    )
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+        authenticated_same_act_aliases=("2024 House Bill 1",),
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "us-ms/statute/27-7-5(1)(b)(ii)(7) makes the rate subject to Section 2 "
+            "of the 2025 act legal dependency is supplied; Section 2 of this act "
+            "legal dependency is not supplied."
+        ),
+        (
+            "us-ms/statute/27-7-5(1)(b)(ii)(7) makes the rate subject to Section 2 "
+            "of 2025 House Bill 1 legal dependency is supplied; Section 2 of this "
+            "act legal dependency is not supplied."
+        ),
+        (
+            "us-ms/statute/27-7-5(1)(b)(ii)(7) makes the rate subject to Section 2 "
+            "of the 2025 act, which is available; Section 2 of this act legal "
+            "dependency is not supplied."
+        ),
+    ),
+)
+def test_same_act_section_dependency_rejects_authenticated_alias_reversal(
+    reason: str,
+):
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+        authenticated_same_act_aliases=("2025 House Bill 1",),
+    )
+
+
+def test_same_act_section_dependency_accepts_authenticated_year_direct_state():
+    reason = (
+        "us-ms/statute/27-7-5(1)(b)(ii)(7) cannot be encoded because Section 2 "
+        "of the 2025 act is unavailable."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+    kwargs = {
+        "corpus_citation_path": "us-ms/statute/27-7-5",
+        "path": ("1", "b", "ii", "7"),
+    }
+
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        authenticated_same_act_aliases=("2025 House Bill 1",),
+        **kwargs,
+    )
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        **kwargs,
+    )
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        authenticated_same_act_aliases=("2024 House Bill 1",),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, but the taxpayer income input is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 3 of this act, and that Section 3 legal dependency is not "
+            "supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and that Section 2 legal dependency is not "
+            "supplied, but it is actually supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and that Section 2 legal dependency is not "
+            "supplied and is supplied in full."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and that Section 2 legal dependency is not "
+            "supplied; it is supplied in full."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and the taxpayer income input is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act because the taxpayer income input is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, whose taxpayer income input is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and an unrelated runtime capability is unavailable."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and its conditions for taxpayer income input "
+            "are not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and that Section 2 legal dependency is not "
+            "supplied in the available context and is supplied in full."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and that Section 2 legal dependency is not "
+            "supplied in the available context; it is supplied in full."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and that Section 2 legal dependency is not "
+            "supplied in the available context. It is supplied in full."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, which is available; Section 2 legal "
+            "dependency is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and Section 2 legal dependency is not supplied, "
+            "although the same-act Section 2 text is available."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act. That Section 2 is supplied in full. Section 2 "
+            "legal dependency is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, which is fully supplied, and Section 2 legal "
+            "dependency is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and that Section 2 legal dependency is not "
+            "supplied in the currently available context, and is supplied in full."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, and that Section 2 legal dependency is not "
+            "supplied anywhere relevant, and is supplied in full."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act legal dependency is supplied; Section 2 legal "
+            "dependency is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, whose legal dependency is supplied; Section 2 "
+            "legal dependency is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and Section 2 legal dependency is not supplied, "
+            "but Section 2 legal dependency is supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and Section 2 legal dependency is not supplied, "
+            "although that Section 2 legal dependency is supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, which is accessible; Section 2 legal dependency "
+            "is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, which is present; Section 2 legal dependency is "
+            "not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and Section 2 legal dependency is not supplied, "
+            "but Section 2 legal dependency is accessible."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and Section 2 legal dependency is not supplied, "
+            "but Section 2 legal dependency is present."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and Section 2 legal dependency is not supplied, "
+            "but Section 2 legal dependency is provided."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act. Those Section 2 legal dependencies are supplied "
+            "in full. Section 2 legal dependencies are not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and Section 2 legal dependencies are not supplied, "
+            "but they are supplied in full."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and Section 2 legal dependencies are not supplied; "
+            "they are supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act and Section 2 legal dependencies are not supplied, "
+            "but Section 2 legal dependencies are supplied in full."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act legal dependency is supplied; Section 2 of this "
+            "act legal dependency is not supplied."
+        ),
+        (
+            "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+            "Section 2 of this act, which is available; Section 2 of this act legal "
+            "dependency is not supplied."
+        ),
+    ),
+)
+def test_same_act_section_dependency_rejects_unbound_not_supplied_object(
+    reason: str,
+):
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+def test_same_act_section_dependency_accepts_plural_bound_not_supplied_object():
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+        "Section 2 of this act, and those Section 2 legal dependencies are not "
+        "supplied in the available context."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+def test_same_act_section_dependency_accepts_missing_executable_with_available_text():
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+        "Section 2 of this act, whose text is available; no executable output is "
+        "available for Section 2 of this act."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+@pytest.mark.parametrize("separator", (". ", "; "))
+def test_same_act_section_dependency_rejects_missing_executable_then_implemented(
+    separator: str,
+):
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+        "Section 2 of this act. No executable output is available for Section 2 "
+        f"of this act{separator}Section 2 is implemented."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+@pytest.mark.parametrize(
+    "reversal",
+    (
+        "An executable rule for Section 2 is available.",
+        "Section 2 has been implemented.",
+        "The executable output for Section 2 is available.",
+        "That executable output for Section 2 is available.",
+        "This executable output for Section 2 is available.",
+        "Its executable output is available.",
+        "Section 2's executable output is available.",
+        "The section's executable output is available.",
+        "There is an executable output for Section 2.",
+        "Section 2 has an executable output.",
+    ),
+)
+def test_same_act_section_dependency_rejects_missing_executable_exact_inverse(
+    reversal: str,
+):
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+        "Section 2 of this act. No executable output is available for Section 2 "
+        f"of this act. {reversal}"
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "separator", "reversal"),
+    (
+        (
+            "No executable output is available for Section 2 of this act",
+            ". ",
+            "Executable output for Section 2 is available",
+        ),
+        (
+            "No executable outputs are available for Section 2 of this act",
+            ". ",
+            "Executable outputs for Section 2 are available",
+        ),
+        (
+            "No executable rule is available for Section 2 of this act",
+            "; ",
+            "executable rule under Section 2 has been provided",
+        ),
+        (
+            "No executable capability is available for Section 2 of this act",
+            ". ",
+            "Executable capability for Section 2 is available",
+        ),
+        (
+            "No executable RuleSpec export is available for Section 2 of this act",
+            ". ",
+            "Executable RuleSpec export for Section 2 has been provided",
+        ),
+        (
+            "No executable implementation is available for Section 2 of this act",
+            "; ",
+            "executable implementation under Section 2 is present",
+        ),
+    ),
+)
+def test_same_act_section_dependency_rejects_article_plural_executable_inverse(
+    missing: str,
+    separator: str,
+    reversal: str,
+):
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+        f"Section 2 of this act. {missing}{separator}{reversal}."
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+@pytest.mark.parametrize(
+    "unrelated_availability",
+    (
+        "There is an executable output for Section 3.",
+        "There is an executable output for the federal rule.",
+        "Section 2 has an executable output for Section 3.",
+    ),
+)
+def test_same_act_section_dependency_keeps_unrelated_executable_availability(
+    unrelated_availability: str,
+):
+    reason = (
+        "Miss. Code section 27-7-5(1)(b)(ii)(7) makes the rate subject to "
+        "Section 2 of this act. No executable output is available for Section 2 "
+        f"of this act. {unrelated_availability}"
+    )
+    source = (
+        "For calendar year 2030 and later, except as otherwise provided in "
+        "Section 2 of this act, the rate shall be three percent (3%)."
+    )
+
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-ms/statute/27-7-5",
+        path=("1", "b", "ii", "7"),
+    )
+
+
+def test_external_dependency_rejects_unrelated_not_supplied_input():
+    reason = "The household income input is not supplied, under Section 26."
+    source = "The tax is computed under Section 26."
+
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="de/statute/estg/32a/6",
+        path=("1",),
+    )
+
+
 def test_same_act_section_dependency_accepts_authenticated_bill_alias():
     reason = (
         "us-ms/statute/27-7-5(1)(b)(ii)(7) makes the 2030 rate subject to "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1675"
+version = "0.2.1676"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- authenticate canonical, full-alias, and metadata-derived year-act same-act references consistently
- accept tightly bounded, truthful not-supplied dependency deferrals while rejecting unrelated-input laundering
- reject prior, suffix, plural, repeated-reference, and executable-object contradictions without confusing available source text with an absent executable dependency
- bump the encoder package to 0.2.1676, as required for an encoder-affecting validator change

## Validation

- Ruff, format, compileall, lockfile, and diff checks are clean
- focused same-act matrix: 87 passed
- focused pipeline integration: 2 passed
- complete source-completeness + RuleSpec validation + version provenance: 8278 passed, 31 skipped
- affected version/registry/telemetry tests: 42 passed independently; 40 passed in the local combined run
- pre-version full repository suite: 13234 passed, 123 skipped

## Review cycle

Two independent reviewers iterated on exact adversarial probes covering laundering, contradiction windows, aliases, singular/plural and determiner/possessive/existential forms, and unrelated-section compatibility. Both returned CLEAN on the final validator source/test bytes. The retained Batch 020 Mississippi Terra and Sol artifacts each have zero deferral issues with real authenticated source metadata; unrelated candidate defects remain visible.

The first PR CI run correctly rejected the encoder-affecting source change because it lacked a new package version. The fix adds version 0.2.1676, updates every current-version assertion and fixture, and adds a Fixed changelog fragment. A second independent review-fix cycle is CLEAN on amended commit b9c016c5, and the version-provenance gate passes locally. Fresh protected CI/signing runs are required and pending.

## Scope

This is a shared validator fix. It does not change dispatcher, workflow, signing, campaign-state, or oracle ownership behavior.