### PR TITLE
Add constrained candidate test repair mode

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -38,6 +38,11 @@ on:
         description: Prior failed protected run whose final candidate is replayed as untrusted repair context
         required: false
         type: string
+      repair_candidate_tests_only:
+        description: Preserve the repair candidate RuleSpec byte-for-byte and expand only its companion tests under a v2 contract
+        required: false
+        default: false
+        type: boolean
       source_bundle_json:
         description: JSON citation array, canonical_refresh_bundle object, or atomic-source-transaction/v2 envelope for an independent refresh transaction
         required: false
@@ -364,6 +369,7 @@ jobs:
           LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           QUEUE_ID: ${{ inputs.queue_id }}
           REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
+          REPAIR_TESTS_ONLY: ${{ inputs.repair_candidate_tests_only }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
@@ -373,6 +379,7 @@ jobs:
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
         run: |
           set -euo pipefail
+          : "${REPAIR_TESTS_ONLY:=false}"
           atomic_source_payload="$(
             python \
               axiom-encode/scripts/prepare_signed_backfill.py \
@@ -384,6 +391,19 @@ jobs:
             <<< "$atomic_source_payload")"
           primary_required_test_cases_json="$(jq -cer \
             '.primary_required_test_cases' <<< "$atomic_source_payload")"
+          if [ "$REPAIR_TESTS_ONLY" = "true" ]; then
+            jq -e 'type == "array" and length > 0' \
+              <<< "$primary_required_test_cases_json" > /dev/null || {
+                echo "tests-only repair requires primary required test cases" >&2
+                exit 1
+              }
+          else
+            jq -e 'type == "array" and length == 0' \
+              <<< "$primary_required_test_cases_json" > /dev/null || {
+                echo "repair test cases require tests-only repair mode" >&2
+                exit 1
+              }
+          fi
           if [[ ! "$REPAIR_RUN_ID" =~ ^[0-9]+$ ]] || \
              [ "$REPAIR_RUN_ID" = "$GITHUB_RUN_ID" ]; then
             echo "repair_run_id must identify a different decimal workflow run" >&2
@@ -400,8 +420,6 @@ jobs:
                <<< "$canonical_refresh_bundle_json" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
                <<< "$source_bundle_json" > /dev/null || \
-             ! jq -e 'type == "array" and length == 0' \
-               <<< "$primary_required_test_cases_json" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
                <<< "${EXISTING_SIGNED_IMPORTS_JSON:-[]}" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
@@ -553,6 +571,7 @@ jobs:
           LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           QUEUE_ID: ${{ inputs.queue_id }}
           REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
+          REPAIR_TESTS_ONLY: ${{ inputs.repair_candidate_tests_only }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
@@ -560,6 +579,7 @@ jobs:
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
         run: |
           set -euo pipefail
+          : "${REPAIR_TESTS_ONLY:=false}"
           atomic_source_payload="$(
             axiom-encode/.venv/bin/python \
               axiom-encode/scripts/prepare_signed_backfill.py \
@@ -571,6 +591,10 @@ jobs:
             <<< "$atomic_source_payload")"
           primary_required_test_cases_json="$(jq -cer \
             '.primary_required_test_cases' <<< "$atomic_source_payload")"
+          if [ "$REPAIR_TESTS_ONLY" = "true" ] && [ -z "$REPAIR_RUN_ID" ]; then
+            echo "tests-only repair requires repair_run_id" >&2
+            exit 1
+          fi
           source_bundle_args=(
             axiom-encode/.venv/bin/python
             axiom-encode/scripts/prepare_signed_backfill.py
@@ -1024,6 +1048,7 @@ jobs:
           REPAIR_CANDIDATE_ROOT: ${{ steps.repair_candidate.outputs.root }}
           REPAIR_CANDIDATE_RULESPEC_SHA256: ${{ steps.repair_candidate.outputs.rulespec_sha256 }}
           REPAIR_CANDIDATE_TESTS_SHA256: ${{ steps.repair_candidate.outputs.tests_sha256 }}
+          REPAIR_TESTS_ONLY: ${{ inputs.repair_candidate_tests_only }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
@@ -1039,6 +1064,7 @@ jobs:
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
           set -euo pipefail
+          : "${REPAIR_TESTS_ONLY:=false}"
           : "${QUEUE_ID:=}"
           : "${REPLACE_RULESPEC_PATH:=}"
           : "${REPLACE_LEGACY_RULESPEC_PATH:=}"
@@ -1197,6 +1223,9 @@ jobs:
                 --repair-candidate-tests-sha256 \
                   "$REPAIR_CANDIDATE_TESTS_SHA256"
               )
+              if [ "$REPAIR_TESTS_ONLY" = "true" ]; then
+                args+=(--repair-candidate-tests-only)
+              fi
             fi
             args+=("$citation")
 
@@ -1579,7 +1608,8 @@ jobs:
               run_signed_encode \
                 "$CITATION" "$REVIEW_FINDING" true target \
                 "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH" \
-                "$required_imports_enabled"
+                "$required_imports_enabled" "[]" \
+                "$primary_required_test_cases_json"
               dependent_target_only=false
               if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
                 dependent_target_only=true
@@ -1597,7 +1627,8 @@ jobs:
                 "$CITATION" "$REVIEW_FINDING" false \
                 target "$REPLACE_RULESPEC_PATH" \
                 "$REPLACE_LEGACY_RULESPEC_PATH" \
-                "$required_imports_enabled"
+                "$required_imports_enabled" "[]" \
+                "$primary_required_test_cases_json"
             fi
 
             if [ "$source_bundle_enabled" = "false" ] && \

--- a/changelog.d/constrained-candidate-test-repair.added.md
+++ b/changelog.d/constrained-candidate-test-repair.added.md
@@ -1,0 +1,1 @@
+Add a hash-bound, apply-only repair mode that can expand a preserved candidate's companion tests without permitting RuleSpec changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1676"
+version = "0.2.1677"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1676"
+__version__ = "0.2.1677"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -187,6 +187,7 @@ from .harness.evals import (
     _git_checkout_execution_identity,
     _load_eval_suite_resume_state,
     _open_secure_eval_parent,
+    _preserves_companion_test_cases,
     _render_eval_result_verdict_evidence,
     _resolve_eval_output_path,
     _rulespec_root_execution_identity,
@@ -2759,6 +2760,15 @@ def main():
     encode_parser.add_argument(
         "--repair-candidate-tests-sha256",
         help="Expected SHA-256 of the preserved repair candidate companion tests",
+    )
+    encode_parser.add_argument(
+        "--repair-candidate-tests-only",
+        action="store_true",
+        help=(
+            "Keep the hash-bound repair candidate RuleSpec immutable and permit "
+            "only a non-weakening companion-test expansion required by a v2 "
+            "review contract"
+        ),
     )
     encode_parser.add_argument(
         "--policyengine-rule-hint",
@@ -26173,6 +26183,58 @@ def _load_initial_validation_retry_candidate(
     )
 
 
+def _validate_tests_only_repair_contract(
+    args: Any,
+    candidate: ValidationRetryCandidate | None,
+) -> None:
+    """Fail closed unless tests-only repair is fully identity and contract bound."""
+
+    if getattr(args, "repair_candidate_tests_only", False) is not True:
+        return
+    contract = getattr(args, "review_contract_json", None)
+    candidate_path = getattr(args, "repair_candidate_path", None)
+    replacement_path = getattr(args, "replace_rulespec_path", None)
+    if candidate is None or candidate.tests is None:
+        raise ValueError("tests-only repair requires a complete repair candidate")
+    if getattr(args, "apply", False) is not True:
+        raise ValueError("tests-only repair requires encode --apply")
+    legacy_options = (
+        getattr(args, "replace_legacy_rulespec_path", None),
+        *tuple(getattr(args, "legacy_dependent_rulespec_path", ()) or ()),
+        *tuple(getattr(args, "legacy_exact_dependent_rulespec_path", ()) or ()),
+        *tuple(getattr(args, "legacy_retained_successor_rulespec_path", ()) or ()),
+    )
+    if any(option is not None for option in legacy_options):
+        raise ValueError("tests-only repair cannot perform a legacy migration")
+    if contract is None or not contract.required_test_cases:
+        raise ValueError(
+            "tests-only repair requires a nonempty v2 required-test-case contract"
+        )
+    if contract.required_deferred_outputs:
+        raise ValueError("tests-only repair cannot include deferred-output contracts")
+    if contract.citation != str(args.citation):
+        raise ValueError("tests-only repair contract citation mismatch")
+    normalized_replacement_path = (
+        Path(replacement_path).as_posix() if replacement_path is not None else None
+    )
+    if contract.rulespec_path != normalized_replacement_path:
+        raise ValueError("tests-only repair contract path mismatch")
+    replacement_parts = Path(normalized_replacement_path).parts
+    candidate_parts = Path(candidate_path).parts
+    if candidate_parts[0] in RULESPEC_ATOMIC_MODULE_ROOTS:
+        candidate_module_parts = candidate_parts
+    elif (
+        len(candidate_parts) >= 2
+        and candidate_parts[0] == replacement_parts[0]
+        and candidate_parts[1] in RULESPEC_ATOMIC_MODULE_ROOTS
+    ):
+        candidate_module_parts = candidate_parts[1:]
+    else:
+        candidate_module_parts = ()
+    if candidate_module_parts != replacement_parts[1:]:
+        raise ValueError("tests-only repair replacement path mismatch")
+
+
 def _latest_validation_retry_candidate(
     prior_attempts: Sequence[_FailedEncodeAttempt],
 ) -> ValidationRetryCandidate | None:
@@ -26362,11 +26424,18 @@ def _encode_validation_retry_context(
     prior_attempts: Sequence[_FailedEncodeAttempt],
     *,
     initial_retry_candidate: ValidationRetryCandidate | None,
+    preserve_initial_candidate: bool = False,
 ) -> tuple[tuple[str, ...], ValidationRetryCandidate | None]:
     """Bind validator feedback to the exact candidate that produced it."""
 
     if not prior_attempts:
         return (), initial_retry_candidate
+    if preserve_initial_candidate:
+        if initial_retry_candidate is None:
+            raise RuntimeError("Preserved validation retry candidate is unavailable")
+        return _encode_validation_retry_feedback(
+            prior_attempts
+        ), initial_retry_candidate
     candidate = _latest_validation_retry_candidate(prior_attempts)
     if candidate is None:
         raise RuntimeError(
@@ -26391,6 +26460,62 @@ class _EncodeReplacementTarget(NamedTuple):
 
 _LEGACY_REPLACEMENT_ATTR = "_axiom_legacy_replacement_contract"
 _REPLACEMENT_OVERLAY_SCOPE_ATTR = "_axiom_replacement_overlay_scope"
+_IMMUTABLE_RULESPEC_SHA256_ATTR = "_axiom_immutable_rulespec_sha256"
+_PRESERVED_COMPANION_TESTS_ATTR = "_axiom_preserved_companion_tests"
+_REQUIRED_TEST_CASE_CONTRACTS_ATTR = "_axiom_required_test_case_contracts"
+
+
+def _immutable_rulespec_digest_issue(result: Any, output_file: Path) -> str | None:
+    """Return an issue when a constrained repair's RuleSpec bytes changed."""
+
+    expected = vars(result).get(_IMMUTABLE_RULESPEC_SHA256_ATTR)
+    if expected is None:
+        return None
+    try:
+        actual = _sha256_file(output_file)
+    except OSError:
+        return "Tests-only repair could not verify immutable RuleSpec bytes"
+    if actual != expected:
+        return "Tests-only repair changed the hash-bound RuleSpec bytes"
+    return None
+
+
+def _immutable_planned_rulespec_digest_issue(
+    result: Any,
+    planned: Mapping[Path, bytes],
+    relative_output: Path,
+) -> str | None:
+    """Return an issue when planned apply bytes replace an immutable RuleSpec."""
+
+    expected = vars(result).get(_IMMUTABLE_RULESPEC_SHA256_ATTR)
+    if expected is None:
+        return None
+    primary = planned.get(_canonical_apply_relative_path(relative_output))
+    if primary is None or hashlib.sha256(primary).hexdigest() != expected:
+        return "Tests-only repair changed the planned hash-bound RuleSpec bytes"
+    return None
+
+
+def _tests_only_companion_preservation_issue(
+    result: Any,
+    test_file: Path,
+) -> str | None:
+    """Return an issue when apply-time repairs escape the signed test contract."""
+
+    attributes = vars(result)
+    original = attributes.get(_PRESERVED_COMPANION_TESTS_ATTR)
+    contracts = attributes.get(_REQUIRED_TEST_CASE_CONTRACTS_ATTR)
+    if original is None and contracts is None:
+        return None
+    if not isinstance(original, str) or not isinstance(contracts, tuple):
+        return "Tests-only repair companion preservation state is malformed"
+    try:
+        proposed = test_file.read_text()
+    except (OSError, UnicodeError):
+        return "Tests-only repair could not verify the final companion tests"
+    if not _preserves_companion_test_cases(original, proposed, contracts):
+        return "Tests-only repair changed companion tests outside the bound contract"
+    return None
 
 
 def _resolve_required_import_rulespec_paths(
@@ -28644,6 +28769,7 @@ def _run_encode_attempts_with_retries(
 ):
     """Bounded validator-retry loop for one encode invocation."""
     initial_retry_candidate = _load_initial_validation_retry_candidate(args)
+    _validate_tests_only_repair_contract(args, initial_retry_candidate)
     failed_attempts: tuple[_FailedEncodeAttempt, ...] = ()
     current_model = config.initial_model
 
@@ -28906,6 +29032,9 @@ def _run_encode_attempt(
         _encode_validation_retry_context(
             prior_attempts,
             initial_retry_candidate=initial_retry_candidate,
+            preserve_initial_candidate=(
+                getattr(args, "repair_candidate_tests_only", False) is True
+            ),
         )
     )
     results = run_model_eval(
@@ -28932,6 +29061,9 @@ def _run_encode_attempt(
         ),
         validation_retry_feedback=validation_retry_feedback,
         validation_retry_candidate=validation_retry_candidate,
+        repair_candidate_tests_only=(
+            getattr(args, "repair_candidate_tests_only", False) is True
+        ),
         required_deferred_output_contracts=(
             deferred_output_review_contract.required_deferred_outputs
             if deferred_output_review_contract is not None
@@ -28960,6 +29092,33 @@ def _run_encode_attempt(
     )
 
     result = results[0]
+    if getattr(args, "repair_candidate_tests_only", False) is True:
+        assert initial_retry_candidate is not None
+        assert initial_retry_candidate.tests is not None
+        setattr(
+            result,
+            _IMMUTABLE_RULESPEC_SHA256_ATTR,
+            initial_retry_candidate.rulespec_sha256,
+        )
+        setattr(
+            result,
+            _PRESERVED_COMPANION_TESTS_ATTR,
+            initial_retry_candidate.tests,
+        )
+        assert deferred_output_review_contract is not None
+        setattr(
+            result,
+            _REQUIRED_TEST_CASE_CONTRACTS_ATTR,
+            tuple(
+                {
+                    "name": contract.name,
+                    "period": contract.period,
+                    "input": contract.input,
+                    "required_output": contract.required_output,
+                }
+                for contract in deferred_output_review_contract.required_test_cases
+            ),
+        )
     setattr(
         result,
         _LEGACY_REPLACEMENT_ATTR,
@@ -52492,13 +52651,25 @@ def _apply_generated_encoding_result(
             "Cannot apply supplemental source-verifying RuleSpec(s): "
             + "; ".join(supplemental_source_issues)
         )
+    immutable_issue = _immutable_rulespec_digest_issue(result, output_file)
+    if immutable_issue is not None:
+        raise RuntimeError(immutable_issue)
     _stamp_generated_source_attestation_for_apply(result, output_file)
+    immutable_issue = _immutable_rulespec_digest_issue(result, output_file)
+    if immutable_issue is not None:
+        raise RuntimeError(immutable_issue)
 
     _enforce_canonical_concept_registry(
         candidate_files=[output_file, _rulespec_test_path(output_file)],
         relative_output=relative_output,
         policy_repo_path=policy_repo_path,
     )
+    companion_issue = _tests_only_companion_preservation_issue(
+        result,
+        _rulespec_test_path(output_file),
+    )
+    if companion_issue is not None:
+        raise RuntimeError(companion_issue)
 
     local_corpus_release = load_rulespec_local_corpus_release(
         content_root,
@@ -52521,6 +52692,13 @@ def _apply_generated_encoding_result(
         relative_output=relative_output,
         supplemental_files=supplemental_files,
     )
+    immutable_issue = _immutable_planned_rulespec_digest_issue(
+        result,
+        planned,
+        relative_output,
+    )
+    if immutable_issue is not None:
+        raise RuntimeError(immutable_issue)
     _require_planned_apply_bytes_match_validation_snapshot(
         result,
         planned,
@@ -53336,6 +53514,9 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         )
     except RuntimeError as exc:
         return False, [str(exc)], {}
+    immutable_issue = _immutable_rulespec_digest_issue(result, output_file)
+    if immutable_issue is not None:
+        return False, [immutable_issue], {}
     try:
         _stamp_generated_source_attestation_for_apply(result, output_file)
         source_metadata = _generated_result_source_metadata(result)
@@ -53344,6 +53525,9 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         if detail.startswith(_GENERATED_RULESPEC_NONRETRYABLE_PREFIXES):
             return False, [detail], {}
         return False, [f"{relative_output}: {detail}"], {}
+    immutable_issue = _immutable_rulespec_digest_issue(result, output_file)
+    if immutable_issue is not None:
+        return False, [immutable_issue], {}
 
     generated_content = output_file.read_text()
     output_test = _rulespec_test_path(output_file)

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1516,6 +1516,7 @@ def run_model_eval(
     legacy_replacement: LegacyReplacementContract | None = None,
     replacement_overlay_scope: bool = False,
     validation_retry_candidate: ValidationRetryCandidate | None = None,
+    repair_candidate_tests_only: bool = False,
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one or more citations."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
@@ -1527,7 +1528,13 @@ def run_model_eval(
         raise ValueError(
             "Replacement overlay scope requires an explicit target RuleSpec output"
         )
-    include_tests = include_tests or require_complete_source_unit
+    if repair_candidate_tests_only and validation_retry_candidate is None:
+        raise ValueError("Tests-only repair requires a validation retry candidate")
+    if repair_candidate_tests_only and validation_retry_candidate.tests is None:
+        raise ValueError("Tests-only repair requires preserved companion tests")
+    include_tests = (
+        include_tests or require_complete_source_unit or repair_candidate_tests_only
+    )
     results: list[EvalResult] = []
     runners = [parse_runner_spec(spec) for spec in runner_specs]
     resolved_sources = [
@@ -1564,6 +1571,7 @@ def run_model_eval(
                         ),
                         required_test_case_contracts=required_test_case_contracts,
                         validation_retry_candidate=validation_retry_candidate,
+                        repair_candidate_tests_only=repair_candidate_tests_only,
                         required_import_targets=required_import_targets,
                         legacy_replacement=legacy_replacement,
                         replacement_overlay_scope=replacement_overlay_scope,
@@ -7666,6 +7674,7 @@ def _evaluate_generated_artifact_with_repairs(
     protected_review_excerpts: frozenset[str] = frozenset(),
     legacy_replacement: LegacyReplacementContract | None = None,
     replacement_overlay_scope: bool = False,
+    allow_artifact_repairs: bool = True,
 ) -> EvalArtifactMetrics | None:
     evaluated_states: set[tuple[bytes | None, bytes | None]] = set()
     while True:
@@ -7694,6 +7703,8 @@ def _evaluate_generated_artifact_with_repairs(
         )
         if metrics is None:
             return None
+        if not allow_artifact_repairs:
+            return metrics
         if artifact_state in evaluated_states:
             return metrics
         evaluated_states.add(artifact_state)
@@ -8296,10 +8307,15 @@ def _build_empty_artifact_retry_prompt(
     original_prompt: str,
     target_file_name: str,
     include_tests: bool,
+    repair_candidate_tests_only: bool = False,
 ) -> str:
     """Build the one-shot repair prompt for narrative-only eval responses."""
     output_contract = (
-        f"Return exactly this two-file bundle and nothing else, beginning with "
+        f"Return only the companion test bundle `=== FILE: "
+        f"{_rulespec_test_path(Path(target_file_name)).name} ===`; do not return "
+        "or modify the RuleSpec file."
+        if repair_candidate_tests_only
+        else f"Return exactly this two-file bundle and nothing else, beginning with "
         f"`=== FILE: {target_file_name} ===`."
         if include_tests
         else (
@@ -8334,6 +8350,8 @@ def _run_prompt_eval_with_empty_artifact_retry(
     include_tests: bool,
     policyengine_rule_hint: str | None = None,
     artifact_root: Path | None = None,
+    repair_candidate: ValidationRetryCandidate | None = None,
+    required_test_case_contracts: Sequence[Mapping[str, object]] = (),
 ) -> tuple[EvalPromptResponse, bool, int, frozenset[Path]]:
     """Run an eval within the execution-identity-bound artifact attempt limit."""
 
@@ -8364,6 +8382,8 @@ def _run_prompt_eval_with_empty_artifact_retry(
                 policyengine_rule_hint=policyengine_rule_hint,
                 artifact_root=artifact_root,
                 materialized_paths=materialized_paths,
+                repair_candidate=repair_candidate,
+                required_test_case_contracts=required_test_case_contracts,
             )
         if _discard_artifacts_after_case_budget(
             response,
@@ -8380,6 +8400,7 @@ def _run_prompt_eval_with_empty_artifact_retry(
             prompt,
             target_file_name=target_file_name,
             include_tests=include_tests,
+            repair_candidate_tests_only=repair_candidate is not None,
         )
         retry_count = 0
         for _attempt in range(1, _EMPTY_ARTIFACT_MAX_ATTEMPTS):
@@ -8403,6 +8424,8 @@ def _run_prompt_eval_with_empty_artifact_retry(
                     policyengine_rule_hint=policyengine_rule_hint,
                     artifact_root=artifact_root,
                     materialized_paths=materialized_paths,
+                    repair_candidate=repair_candidate,
+                    required_test_case_contracts=required_test_case_contracts,
                 )
             if _discard_artifacts_after_case_budget(
                 response,
@@ -8550,6 +8573,7 @@ def _run_single_eval(
     legacy_replacement: LegacyReplacementContract | None = None,
     replacement_overlay_scope: bool = False,
     validation_retry_candidate: ValidationRetryCandidate | None = None,
+    repair_candidate_tests_only: bool = False,
 ) -> EvalResult:
     include_tests = include_tests or require_complete_source_unit
     if source_unit is None:
@@ -8622,6 +8646,7 @@ def _run_single_eval(
         required_deferred_output_contracts=required_deferred_output_contracts,
         required_test_case_contracts=required_test_case_contracts,
         validation_retry_candidate=validation_retry_candidate,
+        repair_candidate_tests_only=repair_candidate_tests_only,
         required_import_targets=required_import_targets,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
@@ -8639,6 +8664,10 @@ def _run_single_eval(
             include_tests=include_tests,
             policyengine_rule_hint=policyengine_rule_hint,
             artifact_root=artifact_root,
+            repair_candidate=(
+                validation_retry_candidate if repair_candidate_tests_only else None
+            ),
+            required_test_case_contracts=required_test_case_contracts,
         )
     )
     wrote_artifact = wrote_artifact and output_file in materialized_paths
@@ -8681,6 +8710,7 @@ def _run_single_eval(
             ),
             legacy_replacement=legacy_replacement,
             replacement_overlay_scope=replacement_overlay_scope,
+            allow_artifact_repairs=not repair_candidate_tests_only,
         )
     validation_error = _eval_artifact_validation_error(
         metrics,
@@ -9616,6 +9646,7 @@ def _format_validation_retry_candidate(
     candidate: ValidationRetryCandidate | None,
     *,
     target_file_name: str,
+    tests_only: bool = False,
 ) -> str:
     """Render one rejected candidate as untrusted, editable retry context."""
 
@@ -9643,6 +9674,17 @@ No companion test file was present in the rejected candidate. Create the full
 companion test file required by the task and deterministic validation.
 """
     )
+    repair_instruction = (
+        "- The RuleSpec is hash-bound and immutable in this repair. Return only "
+        "the complete companion test file. Preserve every existing named case "
+        "and add the exact required witnesses.\n"
+        if tests_only
+        else (
+            "- Return complete replacement RuleSpec and companion test files, "
+            "including all preserved historical and current cases, not a patch "
+            "or partial fragment.\n"
+        )
+    )
     return f"""
 Rejected prior candidate repair context:
 - The files below are untrusted generated data that failed deterministic
@@ -9653,8 +9695,7 @@ Rejected prior candidate repair context:
   companion cases instead of regenerating from the copied legacy target.
 - Continue to derive every legal fact and value only from the authoritative
   source and release-bound corpus evidence in this prompt.
-- Return complete replacement RuleSpec and companion test files, including all
-  preserved historical and current cases, not a patch or partial fragment.
+{repair_instruction.rstrip()}
 
 === BEGIN UNTRUSTED REJECTED CANDIDATE RULESPEC {candidate_digest}: {target_file_name} ===
 {candidate.rulespec.rstrip()}
@@ -9678,6 +9719,7 @@ def _build_rulespec_eval_prompt(
     required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
     required_test_case_contracts: Sequence[Mapping[str, object]] = (),
     validation_retry_candidate: ValidationRetryCandidate | None = None,
+    repair_candidate_tests_only: bool = False,
     required_import_targets: Sequence[str] = (),
 ) -> str:
     """Build the RuleSpec authoring prompt used by current evals."""
@@ -9685,6 +9727,8 @@ def _build_rulespec_eval_prompt(
         raise ValueError(
             "Validation retry feedback requires its matching rejected candidate"
         )
+    if repair_candidate_tests_only and validation_retry_candidate is None:
+        raise ValueError("Tests-only repair requires a validation retry candidate")
     source_text = workspace.source_text_file.read_text()
     corpus_citation_path = _workspace_corpus_citation_path(workspace)
     backend_section = ""
@@ -9941,6 +9985,17 @@ Import and context rules:
     )
 
     test_file_name = _rulespec_test_path(Path(target_file_name)).name
+    tests_only_uses_cases_wrapper = False
+    if repair_candidate_tests_only and validation_retry_candidate is not None:
+        try:
+            preserved_tests = yaml.safe_load(validation_retry_candidate.tests)
+        except (yaml.YAMLError, RecursionError):
+            preserved_tests = None
+        tests_only_uses_cases_wrapper = (
+            isinstance(preserved_tests, dict)
+            and set(preserved_tests) == {"cases"}
+            and isinstance(preserved_tests.get("cases"), list)
+        )
     policyengine_hint_is_rulespec_identifier = _is_rulespec_local_identifier(
         policyengine_rule_hint
     )
@@ -9968,15 +10023,39 @@ Import and context rules:
 	- In tests for this file, use `{target_ref_prefix}#input.<fact>` for local factual inputs and `{target_ref_prefix}#<rule>` for outputs. Never use `{target_file_name}#...` keys.
 	"""
         proration_test_guidance = _format_proration_test_guidance(source_text)
-        output_rules = f"""
-Return exactly this two-file bundle and nothing else:
+        tests_only_payload_description = (
+            "<complete YAML mapping with exactly one `cases` test-case list>"
+            if tests_only_uses_cases_wrapper
+            else "<complete YAML list of test cases>"
+        )
+        test_container_rule = (
+            f"- `{test_file_name}` must preserve its top-level `cases:` mapping; "
+            "put all `- name:` entries inside that list."
+            if tests_only_uses_cases_wrapper
+            else f"- `{test_file_name}` must be a YAML list beginning with "
+            "`- name:` entries."
+        )
+        bundle_contract = (
+            f"""Return exactly this one-file bundle and nothing else:
+=== FILE: {test_file_name} ===
+{tests_only_payload_description}
+
+The RuleSpec `{target_file_name}` is immutable in this repair. Do not emit it.
+Preserve every existing named companion case without changing its period, input,
+or existing expected outputs. New cases and additional expected outputs are
+allowed only when required by the bound test contract."""
+            if repair_candidate_tests_only
+            else f"""Return exactly this two-file bundle and nothing else:
 === FILE: {target_file_name} ===
 <RuleSpec YAML>
 === FILE: {test_file_name} ===
-<YAML list of test cases>
+<YAML list of test cases>"""
+        )
+        output_rules = f"""
+{bundle_contract}
 
 Test file rules:
-- `{test_file_name}` must be a YAML list beginning with `- name:` entries.
+{test_container_rule}
 - Use `period`, `input`, and `output` keys. Use concrete scalar values, not formula strings.
 - Do not use bare year periods like `2024`; they are ambiguous across jurisdictions.
 - For monthly outputs, use `period: YYYY-MM`.
@@ -10241,6 +10320,7 @@ Preferred principal output:
     validation_retry_candidate_section = _format_validation_retry_candidate(
         validation_retry_candidate,
         target_file_name=target_file_name,
+        tests_only=repair_candidate_tests_only,
     )
     required_import_section = ""
     if required_import_targets:
@@ -11205,6 +11285,7 @@ def _build_eval_prompt(
     required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
     required_test_case_contracts: Sequence[Mapping[str, object]] = (),
     validation_retry_candidate: ValidationRetryCandidate | None = None,
+    repair_candidate_tests_only: bool = False,
     required_import_targets: Sequence[str] = (),
 ) -> str:
     """Build a prompt-only eval request with explicit provenance rules."""
@@ -11224,6 +11305,7 @@ def _build_eval_prompt(
         required_deferred_output_contracts=required_deferred_output_contracts,
         required_test_case_contracts=required_test_case_contracts,
         validation_retry_candidate=validation_retry_candidate,
+        repair_candidate_tests_only=repair_candidate_tests_only,
         required_import_targets=required_import_targets,
     )
 
@@ -16278,12 +16360,26 @@ def _materialize_eval_artifact(
     policyengine_rule_hint: str | None = None,
     artifact_root: Path | None = None,
     materialized_paths: set[Path] | None = None,
+    repair_candidate: ValidationRetryCandidate | None = None,
+    required_test_case_contracts: Sequence[Mapping[str, object]] = (),
 ) -> bool:
     """Write an eval artifact and optional companion test file from model output."""
     single_amount_table_slice = bool(
         source_text and _is_single_amount_table_slice(source_text)
     )
     expected_test_path = _rulespec_test_path(expected_path)
+
+    if repair_candidate is not None:
+        return _materialize_tests_only_repair_artifact(
+            llm_response,
+            expected_path=expected_path,
+            expected_test_path=expected_test_path,
+            workspace_root=workspace_root,
+            artifact_root=artifact_root,
+            materialized_paths=materialized_paths,
+            repair_candidate=repair_candidate,
+            required_test_case_contracts=required_test_case_contracts,
+        )
 
     if workspace_root is not None:
         wrote_from_workspace = _materialize_workspace_artifacts(
@@ -16417,6 +16513,192 @@ def _materialize_eval_artifact(
     _write_eval_artifact_text(expected_path, rulespec_content, artifact_root)
     if materialized_paths is not None:
         materialized_paths.add(expected_path)
+    return True
+
+
+def _preserves_companion_test_cases(
+    original_content: str,
+    proposed_content: str,
+    required_test_case_contracts: Sequence[Mapping[str, object]],
+) -> bool:
+    """Return whether proposed tests make only contract-authorized additions."""
+
+    try:
+        original = yaml.safe_load(original_content)
+        proposed = yaml.safe_load(proposed_content)
+    except (yaml.YAMLError, RecursionError):
+        return False
+
+    def case_list(payload: object) -> list[object] | None:
+        if isinstance(payload, list):
+            return payload
+        if (
+            isinstance(payload, dict)
+            and set(payload) == {"cases"}
+            and isinstance(payload.get("cases"), list)
+        ):
+            return payload["cases"]
+        return None
+
+    original_cases = case_list(original)
+    proposed_cases = case_list(proposed)
+    if original_cases is None or proposed_cases is None:
+        return False
+    if isinstance(original, dict) != isinstance(proposed, dict):
+        return False
+
+    def by_name(cases: list[object]) -> dict[str, dict[str, object]] | None:
+        indexed: dict[str, dict[str, object]] = {}
+        for case in cases:
+            if not isinstance(case, dict):
+                return None
+            name = case.get("name")
+            if not isinstance(name, str) or not name or name in indexed:
+                return None
+            indexed[name] = case
+        return indexed
+
+    original_by_name = by_name(original_cases)
+    proposed_by_name = by_name(proposed_cases)
+    if original_by_name is None or proposed_by_name is None:
+        return False
+    contracts_by_name = {
+        contract.get("name"): contract for contract in required_test_case_contracts
+    }
+    if (
+        not contracts_by_name
+        or None in contracts_by_name
+        or len(contracts_by_name) != len(required_test_case_contracts)
+    ):
+        return False
+
+    def values_equal(left: object, right: object) -> bool:
+        if type(left) is not type(right):
+            return False
+        if isinstance(left, dict):
+            return set(left) == set(right) and all(
+                values_equal(left[key], right[key]) for key in left
+            )
+        if isinstance(left, list):
+            return len(left) == len(right) and all(
+                values_equal(left_item, right_item)
+                for left_item, right_item in zip(left, right, strict=True)
+            )
+        return left == right
+
+    try:
+        if not set(proposed_by_name).issubset(
+            set(original_by_name) | set(contracts_by_name)
+        ):
+            return False
+        for name, original_case in original_by_name.items():
+            proposed_case = proposed_by_name.get(name)
+            if proposed_case is None:
+                return False
+            original_without_output = {
+                key: value for key, value in original_case.items() if key != "output"
+            }
+            proposed_without_output = {
+                key: value for key, value in proposed_case.items() if key != "output"
+            }
+            if not values_equal(proposed_without_output, original_without_output):
+                return False
+            original_output = original_case.get("output")
+            proposed_output = proposed_case.get("output")
+            if not isinstance(original_output, dict) or not isinstance(
+                proposed_output, dict
+            ):
+                return False
+            contract = contracts_by_name.get(name)
+            required_output = (
+                contract.get("required_output", {})
+                if isinstance(contract, Mapping)
+                else {}
+            )
+            if not isinstance(required_output, dict):
+                return False
+            if contract is None and set(proposed_output) - set(original_output):
+                return False
+            if any(
+                key not in proposed_output
+                or not values_equal(proposed_output[key], value)
+                for key, value in original_output.items()
+            ):
+                return False
+            if any(
+                key not in proposed_output
+                or not values_equal(proposed_output[key], value)
+                for key, value in required_output.items()
+            ):
+                return False
+        for name in set(proposed_by_name) - set(original_by_name):
+            case = proposed_by_name[name]
+            contract = contracts_by_name[name]
+            if set(case) != {"name", "period", "input", "output"}:
+                return False
+            if not values_equal(case.get("name"), name):
+                return False
+            if not values_equal(case.get("period"), contract.get("period")):
+                return False
+            if not values_equal(case.get("input"), contract.get("input")):
+                return False
+            output = case.get("output")
+            required_output = contract.get("required_output")
+            if not isinstance(output, dict) or not isinstance(required_output, dict):
+                return False
+            if any(
+                key not in output or not values_equal(output[key], value)
+                for key, value in required_output.items()
+            ):
+                return False
+    except (RecursionError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _materialize_tests_only_repair_artifact(
+    llm_response: str,
+    *,
+    expected_path: Path,
+    expected_test_path: Path,
+    workspace_root: Path | None,
+    artifact_root: Path | None,
+    materialized_paths: set[Path] | None,
+    repair_candidate: ValidationRetryCandidate,
+    required_test_case_contracts: Sequence[Mapping[str, object]],
+) -> bool:
+    """Materialize only a non-weakening test expansion over an immutable RuleSpec."""
+
+    if repair_candidate.tests is None:
+        return False
+    test_content: str | None = None
+    if workspace_root is not None:
+        workspace_main = workspace_root / expected_path.name
+        workspace_test = workspace_root / expected_test_path.name
+        if workspace_main.exists():
+            return False
+        if workspace_test.exists():
+            test_content = workspace_test.read_text()
+    bundle = _extract_generated_file_bundle(llm_response)
+    if bundle:
+        if set(bundle) != {expected_test_path.name}:
+            return False
+        candidate_files = {Path(name).name: content for name, content in bundle.items()}
+        bundled_test = candidate_files.get(expected_test_path.name)
+        if bundled_test is not None:
+            test_content = bundled_test
+    if test_content is None or not _preserves_companion_test_cases(
+        repair_candidate.tests, test_content, required_test_case_contracts
+    ):
+        return False
+    if hashlib.sha256(repair_candidate.rulespec.encode("utf-8")).hexdigest() != (
+        repair_candidate.rulespec_sha256
+    ):
+        return False
+    _write_eval_artifact_text(expected_path, repair_candidate.rulespec, artifact_root)
+    _write_eval_artifact_text(expected_test_path, test_content, artifact_root)
+    if materialized_paths is not None:
+        materialized_paths.update((expected_path, expected_test_path))
     return True
 
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1676"
+ENCODER_VERSION = "0.2.1677"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,10 @@ from axiom_encode import __version__ as AXIOM_ENCODE_TEST_VERSION
 from axiom_encode.cli import (
     _APPLY_TRANSACTION_SCHEMA,
     _APPLY_VALIDATION_SNAPSHOT_ATTR,
+    _IMMUTABLE_RULESPEC_SHA256_ATTR,
+    _PRESERVED_COMPANION_TESTS_ATTR,
     _REPLACEMENT_OVERLAY_SCOPE_ATTR,
+    _REQUIRED_TEST_CASE_CONTRACTS_ATTR,
     APPLIED_ENCODING_MANIFEST_SCHEMA,
     APPLIED_ENCODING_MODEL_TOOL,
     APPLIED_ENCODING_OFFICIAL_REPOSITORY,
@@ -86,6 +89,7 @@ from axiom_encode.cli import (
     _grounded_formula_literal_for_scalar_expression,
     _has_zero_output_test,
     _hoist_nested_test_tables,
+    _immutable_planned_rulespec_digest_issue,
     _import_base_to_repo_file,
     _infer_missing_input_default,
     _inline_medicaid_magi_income_helpers,
@@ -198,6 +202,7 @@ from axiom_encode.cli import (
     _stamp_generated_source_attestation_for_apply,
     _stamp_matching_supplemental_source_attestations,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
+    _tests_only_companion_preservation_issue,
     _translate_rulespec_engine_envelope_error,
     _try_repair_generated_aca_36b_b_premium_assistance_compat_for_apply,
     _try_repair_generated_admin_agency_aggregate_entities_for_apply,
@@ -919,6 +924,65 @@ def _rebind_test_eval_suite_report_payload(payload: dict, tmp_path: Path) -> Non
     unsigned_evidence = dict(payload["evidence"])
     unsigned_evidence.pop("sha256", None)
     payload["evidence"]["sha256"] = _eval_suite_json_sha256(unsigned_evidence)
+
+
+def test_planned_apply_preserves_tests_only_rulespec_digest():
+    original = b"format: rulespec/v1\nrules: []\n"
+    relative = Path("regulation/7/273/4.yaml")
+    result = SimpleNamespace()
+    setattr(
+        result,
+        _IMMUTABLE_RULESPEC_SHA256_ATTR,
+        hashlib.sha256(original).hexdigest(),
+    )
+
+    assert (
+        _immutable_planned_rulespec_digest_issue(
+            result,
+            {relative: original},
+            relative,
+        )
+        is None
+    )
+    assert "planned hash-bound RuleSpec" in str(
+        _immutable_planned_rulespec_digest_issue(
+            result,
+            {relative: b"format: rulespec/v1\nrules: [changed]\n"},
+            relative,
+        )
+    )
+
+
+def test_final_apply_rechecks_tests_only_companion_contract(tmp_path):
+    original = (
+        "- name: existing\n  period: 2025-06\n  input: {}\n"
+        "  output:\n    result: holds\n"
+    )
+    contract = {
+        "name": "required",
+        "period": "2025-06",
+        "input": {"fact": True},
+        "required_output": {"required_result": "holds"},
+    }
+    result = SimpleNamespace()
+    setattr(result, _PRESERVED_COMPANION_TESTS_ATTR, original)
+    setattr(result, _REQUIRED_TEST_CASE_CONTRACTS_ATTR, (contract,))
+    test_file = tmp_path / "4.test.yaml"
+    test_file.write_text(
+        original + "- name: required\n  period: 2025-06\n"
+        "  input:\n    fact: true\n"
+        "  output:\n    required_result: holds\n"
+    )
+
+    assert _tests_only_companion_preservation_issue(result, test_file) is None
+
+    test_file.write_text(
+        test_file.read_text() + "- name: unsigned\n  period: 2025-06\n  input: {}\n"
+        "  output:\n    result: holds\n"
+    )
+    assert "outside the bound contract" in str(
+        _tests_only_companion_preservation_issue(result, test_file)
+    )
 
 
 @pytest.mark.parametrize("oracle", ["none", "policyengine"])
@@ -13026,6 +13090,9 @@ class TestCmdEncode:
         args.repair_candidate_tests_sha256 = overrides.get(
             "repair_candidate_tests_sha256", None
         )
+        args.repair_candidate_tests_only = overrides.get(
+            "repair_candidate_tests_only", False
+        )
         args.policyengine_rule_hint = overrides.get("policyengine_rule_hint", None)
         args.db = overrides.get("db", tmp_path / "encodings.db")
         args.sync = overrides.get("sync", True)
@@ -14409,6 +14476,92 @@ rules:
         assert "preserved-rule" in candidate.rulespec
         assert candidate.tests is not None
         assert "preserved-companion" in candidate.tests
+
+    def test_encode_tests_only_repair_requires_bound_apply_contract(self, tmp_path):
+        import axiom_encode.cli as cli_module
+
+        candidate = cli_module.ValidationRetryCandidate(
+            rulespec="format: rulespec/v1\nrules: []\n",
+            tests="[]\n",
+        )
+        test_case = cli_module._RequiredTestCaseContract(
+            name="required",
+            period={
+                "period_kind": "custom",
+                "name": "month",
+                "start": "2025-06-01",
+                "end": "2025-06-30",
+            },
+            input={"fact": True},
+            required_output={"result": "holds"},
+        )
+        contract = cli_module._DeferredOutputReviewContract(
+            citation="us/regulation/7/273/4",
+            rulespec_path="us/regulations/7/273/4.yaml",
+            required_deferred_outputs=(),
+            required_test_cases=(test_case,),
+        )
+        args = SimpleNamespace(
+            repair_candidate_tests_only=True,
+            review_contract_json=contract,
+            repair_candidate_path=Path("regulations/7/273/4.yaml"),
+            replace_rulespec_path=Path("us/regulations/7/273/4.yaml"),
+            citation="us/regulation/7/273/4",
+            apply=True,
+        )
+
+        cli_module._validate_tests_only_repair_contract(args, candidate)
+
+        args.repair_candidate_path = Path("us/regulations/7/273/4.yaml")
+        cli_module._validate_tests_only_repair_contract(args, candidate)
+
+        args.repair_candidate_path = Path("us-ny/regulations/7/273/4.yaml")
+        with pytest.raises(ValueError, match="replacement path mismatch"):
+            cli_module._validate_tests_only_repair_contract(args, candidate)
+        args.repair_candidate_path = Path("regulations/7/273/4.yaml")
+
+        args.replace_legacy_rulespec_path = Path("us/regulations/7/273/4-old.yaml")
+        with pytest.raises(ValueError, match="cannot perform a legacy migration"):
+            cli_module._validate_tests_only_repair_contract(args, candidate)
+        args.replace_legacy_rulespec_path = None
+
+        args.legacy_exact_dependent_rulespec_path = [
+            Path("us/regulations/7/273/4-dependent.yaml")
+        ]
+        with pytest.raises(ValueError, match="cannot perform a legacy migration"):
+            cli_module._validate_tests_only_repair_contract(args, candidate)
+        args.legacy_exact_dependent_rulespec_path = []
+
+        args.apply = False
+        with pytest.raises(ValueError, match="requires encode --apply"):
+            cli_module._validate_tests_only_repair_contract(args, candidate)
+
+    def test_encode_tests_only_retry_keeps_cross_run_candidate(self):
+        import axiom_encode.cli as cli_module
+
+        initial = cli_module.ValidationRetryCandidate(
+            rulespec="format: rulespec/v1\n# immutable\nrules: []\n",
+            tests="[]\n",
+        )
+        rejected = cli_module.ValidationRetryCandidate(
+            rulespec="format: rulespec/v1\n# rewritten\nrules: []\n",
+            tests="[]\n",
+        )
+        failed_attempt = cli_module._FailedEncodeAttempt(
+            result=SimpleNamespace(metrics=SimpleNamespace()),
+            error="missing required witness",
+            candidate=rejected,
+            validation_issues=("missing required witness",),
+        )
+
+        feedback, candidate = cli_module._encode_validation_retry_context(
+            [failed_attempt],
+            initial_retry_candidate=initial,
+            preserve_initial_candidate=True,
+        )
+
+        assert feedback == ("missing required witness",)
+        assert candidate is initial
 
     def test_encode_replaces_cross_run_candidate_after_in_run_rejection(self, tmp_path):
         candidate_root = tmp_path / "preserved-candidate"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -718,6 +718,7 @@ def _workspace_prompt_for_source_unit(
     *,
     required_import_targets: tuple[str, ...] = (),
     validation_retry_candidate: ValidationRetryCandidate | None = None,
+    repair_candidate_tests_only: bool = False,
 ):
     workspace = prepare_eval_workspace(
         citation=source_unit.requested,
@@ -741,6 +742,7 @@ def _workspace_prompt_for_source_unit(
         runner_backend="openai",
         required_import_targets=required_import_targets,
         validation_retry_candidate=validation_retry_candidate,
+        repair_candidate_tests_only=repair_candidate_tests_only,
     )
     return workspace, prompt
 
@@ -789,6 +791,35 @@ def test_workspace_prompt_embeds_latest_retry_candidate_as_untrusted_edit_contex
     assert str(tmp_path) not in prompt
 
 
+def test_tests_only_prompt_preserves_cases_wrapper(tmp_path):
+    release = _write_test_corpus_release(
+        tmp_path,
+        [
+            {
+                "citation_path": "dk/statute/benefit/section-1",
+                "body": "The benefit is ten percent of the qualifying amount.",
+            }
+        ],
+    )
+    source_unit = resolve_corpus_source_unit("dk/statute/benefit/section-1", release)
+    candidate = ValidationRetryCandidate(
+        rulespec="format: rulespec/v1\nrules: []\n",
+        tests="cases:\n  - name: existing\n    period: 2026-01\n"
+        "    input: {}\n    output:\n      result: holds\n",
+    )
+
+    _workspace, prompt = _workspace_prompt_for_source_unit(
+        tmp_path,
+        source_unit,
+        validation_retry_candidate=candidate,
+        repair_candidate_tests_only=True,
+    )
+
+    assert "mapping with exactly one `cases` test-case list" in prompt
+    assert "must preserve its top-level `cases:` mapping" in prompt
+    assert "must be a YAML list beginning" not in prompt
+
+
 def test_retry_candidate_formatter_requires_fresh_content_digest():
     candidate = ValidationRetryCandidate(
         rulespec="format: rulespec/v1\nrules: []\n",
@@ -816,14 +847,15 @@ def test_retry_candidate_formatter_explicitly_handles_missing_tests():
     assert "complete replacement RuleSpec and companion test files" in section
 
 
-def test_run_model_eval_appends_retry_candidate_after_existing_public_parameters():
+def test_run_model_eval_appends_repair_parameters_after_existing_public_parameters():
     parameters = list(inspect.signature(run_model_eval).parameters)
 
-    assert parameters[-4:] == [
+    assert parameters[-5:] == [
         "required_import_targets",
         "legacy_replacement",
         "replacement_overlay_scope",
         "validation_retry_candidate",
+        "repair_candidate_tests_only",
     ]
 
 
@@ -2140,6 +2172,40 @@ def test_model_eval_passes_single_target_output_override(tmp_path):
     assert mock_run.call_args.kwargs["target_relative_output"] == target
     assert mock_run.call_args.kwargs["legacy_replacement"] is legacy_replacement
     assert mock_run.call_args.kwargs["replacement_overlay_scope"] is True
+
+
+def test_model_eval_tests_only_repair_forces_companion_test_prompting(tmp_path):
+    corpus_release, source_unit = _write_test_source_unit(
+        tmp_path,
+        "authoritative source",
+        citation_path="us/regulation/7/273/4",
+    )
+    candidate = ValidationRetryCandidate(
+        "format: rulespec/v1\nrules: []\n",
+        "- name: existing\n  period: 2025-06\n  input: {}\n  output: {}\n",
+    )
+    with (
+        patch(
+            "axiom_encode.harness.evals.resolve_corpus_source_unit",
+            return_value=source_unit,
+        ),
+        patch(
+            "axiom_encode.harness.evals._run_single_eval",
+            return_value=Mock(name="result"),
+        ) as mock_run,
+    ):
+        run_model_eval(
+            citations=["us/regulation/7/273/4"],
+            runner_specs=["openai:model-a"],
+            output_root=tmp_path / "out",
+            policy_path=tmp_path / "rulespec-us" / "us",
+            runtime_axiom_rules_path=tmp_path / "engine",
+            corpus_release=corpus_release,
+            validation_retry_candidate=candidate,
+            repair_candidate_tests_only=True,
+        )
+
+    assert mock_run.call_args.kwargs["include_tests"] is True
 
 
 def test_model_eval_rejects_replacement_scope_without_target_override(tmp_path):
@@ -8195,6 +8261,30 @@ rules: []
             for call in mock_repair.call_args_list
         )
 
+    def test_generated_eval_can_disable_post_materialization_repairs(self, tmp_path):
+        metrics = SimpleNamespace(ci_issues=["repairable"])
+        with (
+            patch(
+                "axiom_encode.harness.evals.evaluate_artifact",
+                return_value=metrics,
+            ) as mock_evaluate,
+            patch(
+                "axiom_encode.harness.evals._apply_generated_eval_repairs"
+            ) as mock_repair,
+        ):
+            result = _evaluate_generated_artifact_with_repairs(
+                rulespec_file=tmp_path / "artifact.yaml",
+                policy_repo_root=tmp_path / "rulespec-us",
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                source_text="Source body",
+                local_corpus_release=object(),
+                allow_artifact_repairs=False,
+            )
+
+        assert result is metrics
+        mock_evaluate.assert_called_once()
+        mock_repair.assert_not_called()
+
     def test_generated_eval_reanchors_same_and_amendment_document_proofs(
         self, capsys, tmp_path
     ):
@@ -11548,6 +11638,223 @@ class TestGeneratedBundleCleaning:
 
         assert wrote is False
         assert not output_file.exists()
+
+    def test_materialize_tests_only_repair_preserves_rulespec_and_expands_tests(
+        self, tmp_path
+    ):
+        output_file = tmp_path / "regulation/7/273/4.yaml"
+        rulespec = "format: rulespec/v1\nrules: []\n"
+        original_tests = (
+            "- name: existing\n"
+            "  period: 2025-06\n"
+            "  input:\n    fact: true\n"
+            "  output:\n    result: holds\n"
+        )
+        candidate = ValidationRetryCandidate(rulespec, original_tests)
+        required_contract = {
+            "name": "required-witness",
+            "period": "2025-06",
+            "input": {"other_fact": True},
+            "required_output": {"other_result": "holds"},
+        }
+        response = (
+            "=== FILE: 4.test.yaml ===\n"
+            + original_tests
+            + "- name: required-witness\n"
+            "  period: 2025-06\n"
+            "  input:\n    other_fact: true\n"
+            "  output:\n    other_result: holds\n"
+        )
+        materialized: set[Path] = set()
+
+        wrote = _materialize_eval_artifact(
+            response,
+            output_file,
+            artifact_root=tmp_path,
+            materialized_paths=materialized,
+            repair_candidate=candidate,
+            required_test_case_contracts=(required_contract,),
+        )
+
+        assert wrote is True
+        assert output_file.read_text() == rulespec
+        assert "required-witness" in output_file.with_suffix(".test.yaml").read_text()
+        assert materialized == {output_file, output_file.with_suffix(".test.yaml")}
+
+    def test_materialize_tests_only_repair_preserves_cases_wrapper(self, tmp_path):
+        output_file = tmp_path / "regulation/7/273/4.yaml"
+        rulespec = "format: rulespec/v1\nrules: []\n"
+        original_tests = (
+            "cases:\n"
+            "  - name: existing\n"
+            "    period: 2025-06\n"
+            "    input: {}\n"
+            "    output:\n      result: holds\n"
+        )
+        candidate = ValidationRetryCandidate(rulespec, original_tests)
+        contract = {
+            "name": "required",
+            "period": "2025-06",
+            "input": {},
+            "required_output": {"other_result": "holds"},
+        }
+        response = (
+            "=== FILE: 4.test.yaml ===\n" + original_tests + "  - name: required\n"
+            "    period: 2025-06\n"
+            "    input: {}\n"
+            "    output:\n      other_result: holds\n"
+        )
+
+        wrote = _materialize_eval_artifact(
+            response,
+            output_file,
+            artifact_root=tmp_path,
+            repair_candidate=candidate,
+            required_test_case_contracts=(contract,),
+        )
+
+        assert wrote is True
+        assert yaml.safe_load(output_file.with_suffix(".test.yaml").read_text()) == {
+            "cases": [
+                {
+                    "name": "existing",
+                    "period": "2025-06",
+                    "input": {},
+                    "output": {"result": "holds"},
+                },
+                {
+                    "name": "required",
+                    "period": "2025-06",
+                    "input": {},
+                    "output": {"other_result": "holds"},
+                },
+            ]
+        }
+
+    def test_materialize_tests_only_repair_allows_helper_output_assertions(
+        self, tmp_path
+    ):
+        output_file = tmp_path / "regulation/7/273/4.yaml"
+        candidate = ValidationRetryCandidate(
+            "format: rulespec/v1\nrules: []\n",
+            "- name: existing\n  period: 2025-06\n  input: {}\n"
+            "  output:\n    result: holds\n",
+        )
+        contract = {
+            "name": "required",
+            "period": "2025-06",
+            "input": {"fact": True},
+            "required_output": {"required_result": "holds"},
+        }
+        response = (
+            "=== FILE: 4.test.yaml ===\n"
+            + candidate.tests
+            + "- name: required\n  period: 2025-06\n"
+            "  input:\n    fact: true\n"
+            "  output:\n    required_result: holds\n    reached_helper: true\n"
+        )
+
+        assert _materialize_eval_artifact(
+            response,
+            output_file,
+            artifact_root=tmp_path,
+            repair_candidate=candidate,
+            required_test_case_contracts=(contract,),
+        )
+
+    @pytest.mark.parametrize(
+        "proposed_tests",
+        [
+            "- name: replacement\n  period: 2025-06\n  input: {}\n  output: {}\n",
+            "- name: existing\n  period: 2025-07\n  input:\n    fact: true\n  output:\n    result: holds\n",
+            "- name: existing\n  period: 2025-06\n  input:\n    fact: false\n  output:\n    result: holds\n",
+            "- name: existing\n  period: 2025-06\n  input:\n    fact: true\n  output:\n    result: not_holds\n",
+        ],
+    )
+    def test_materialize_tests_only_repair_rejects_test_weakening(
+        self, tmp_path, proposed_tests
+    ):
+        output_file = tmp_path / "regulation/7/273/4.yaml"
+        candidate = ValidationRetryCandidate(
+            "format: rulespec/v1\nrules: []\n",
+            "- name: existing\n"
+            "  period: 2025-06\n"
+            "  input:\n    fact: true\n"
+            "  output:\n    result: holds\n",
+        )
+
+        wrote = _materialize_eval_artifact(
+            f"=== FILE: 4.test.yaml ===\n{proposed_tests}",
+            output_file,
+            artifact_root=tmp_path,
+            repair_candidate=candidate,
+        )
+
+        assert wrote is False
+        assert not output_file.exists()
+
+    def test_materialize_tests_only_repair_rejects_emitted_rulespec(self, tmp_path):
+        output_file = tmp_path / "regulation/7/273/4.yaml"
+        candidate = ValidationRetryCandidate(
+            "format: rulespec/v1\nrules: []\n",
+            "- name: existing\n  period: 2025-06\n  input: {}\n  output: {}\n",
+        )
+        response = (
+            "=== FILE: 4.yaml ===\nformat: rulespec/v1\nrules: []\n"
+            "=== FILE: 4.test.yaml ===\n" + candidate.tests
+        )
+
+        wrote = _materialize_eval_artifact(
+            response,
+            output_file,
+            artifact_root=tmp_path,
+            repair_candidate=candidate,
+        )
+
+        assert wrote is False
+        assert not output_file.exists()
+
+    def test_materialize_tests_only_repair_rejects_type_changes_and_unsigned_cases(
+        self, tmp_path
+    ):
+        output_file = tmp_path / "regulation/7/273/4.yaml"
+        candidate = ValidationRetryCandidate(
+            "format: rulespec/v1\nrules: []\n",
+            "- name: existing\n"
+            "  period: 2025-06\n"
+            "  input:\n    fact: true\n"
+            "  output:\n    result: holds\n",
+        )
+        contract = {
+            "name": "required",
+            "period": "2025-06",
+            "input": {"required_fact": True},
+            "required_output": {"required_result": "holds"},
+        }
+        type_changed = (
+            "=== FILE: 4.test.yaml ===\n"
+            "- name: existing\n  period: 2025-06\n"
+            "  input:\n    fact: 1\n  output:\n    result: holds\n"
+        )
+        unsigned_case = (
+            "=== FILE: 4.test.yaml ===\n"
+            + candidate.tests
+            + "- name: unsigned\n  period: 2025-06\n"
+            "  input: {}\n  output:\n    result: holds\n"
+        )
+
+        for response in (type_changed, unsigned_case):
+            assert (
+                _materialize_eval_artifact(
+                    response,
+                    output_file,
+                    artifact_root=tmp_path,
+                    repair_candidate=candidate,
+                    required_test_case_contracts=(contract,),
+                )
+                is False
+            )
+            assert not output_file.exists()
 
     def test_materialize_eval_artifact_repairs_single_file_conjoined_excerpts(
         self, tmp_path

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1676"
+ENCODER_VERSION = "0.2.1677"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1676"
+ENCODER_VERSION = "0.2.1677"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_live_run_telemetry.py
+++ b/tests/test_live_run_telemetry.py
@@ -95,7 +95,7 @@ class TestLiveRunTelemetry:
                 citation="us/statute/26/32",
                 backend="codex",
                 model="gpt-5.5",
-                encoder_version="0.2.1676",
+                encoder_version="0.2.1677",
             ) as live:
                 live.set_attempt(2, "gpt-5.5-max")
                 live.finish("completed", run_id="abc12345")

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1676"
+ENCODER_VERSION = "0.2.1677"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1676"
+ENCODER_VERSION = "0.2.1677"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1676"
+ENCODER_VERSION = "0.2.1677"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1676"
+ENCODER_VERSION = "0.2.1677"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1676"')
+        .startswith('__version__ = "0.2.1677"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1676"
+    assert encoder_package["version"] == "0.2.1677"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1676"
+    assert project["project"]["version"] == "0.2.1677"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1676"')
+        .startswith('__version__ = "0.2.1677"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1676"
+    assert encoder_package["version"] == "0.2.1677"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1676"
+    assert project["project"]["version"] == "0.2.1677"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1676"')
+        .startswith('__version__ = "0.2.1677"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1676"
+ENCODER_VERSION = "0.2.1677"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shlex
 import shutil
 import socket
@@ -2101,7 +2102,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert concurrency_suffix("manual-user", "", "queue-generation", "run-3") == "run-3"
     assert concurrency_suffix("github-actions[bot]", "snap", "", "run-4") == "run-4"
     inputs = trigger["workflow_dispatch"]["inputs"]
-    assert len(inputs) == 25
+    assert len(inputs) == 26
     assert "allowlisted reviewed SHA" in inputs["rulespec_ref"]["description"]
     assert "artifact-only" in inputs["rulespec_ref"]["description"]
     assert inputs["country"] == {
@@ -2315,6 +2316,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert repair_step["if"] == "${{ inputs.repair_run_id != '' }}"
     assert repair_step["env"]["GH_TOKEN"] == "${{ github.token }}"
     assert repair_step["env"]["RULESPEC_CHECKOUT"] == ("rulespec-${{ inputs.country }}")
+    assert repair_step["env"]["REPAIR_TESTS_ONLY"] == (
+        "${{ inputs.repair_candidate_tests_only }}"
+    )
     repair_command = repair_step["run"]
     assert '.conclusion == "failure"' in repair_command
     assert '.event == "workflow_dispatch"' in repair_command
@@ -2324,6 +2328,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "merge-base --is-ancestor" in repair_command
     assert '"$repair_encoder_commit" "$GITHUB_SHA"' in repair_command
     assert "repair replay is limited to one non-legacy target" in repair_command
+    assert "tests-only repair requires primary required test cases" in repair_command
+    assert "repair test cases require tests-only repair mode" in repair_command
     assert 'test -n "$REPLACE_RULESPEC_PATH"' not in repair_command
     assert "targeted-reencode-failure-${REPAIR_RUN_ID}-1" in repair_command
     assert "extract_repair_candidate.py" in repair_command
@@ -2454,6 +2460,17 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '"$REPAIR_CANDIDATE_RULESPEC_SHA256"' in command
     assert "--repair-candidate-tests-sha256" in command
     assert '"$REPAIR_CANDIDATE_TESTS_SHA256"' in command
+    assert "args+=(--repair-candidate-tests-only)" in command
+    assert (
+        len(
+            re.findall(
+                r'"\$required_imports_enabled" "\[\]" \\\n[ \t]+'
+                r'"\$primary_required_test_cases_json"',
+                command,
+            )
+        )
+        == 2
+    )
     assert apply_step["env"]["REPAIR_CANDIDATE_ROOT"] == (
         "${{ steps.repair_candidate.outputs.root }}"
     )
@@ -2465,6 +2482,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert apply_step["env"]["REPAIR_CANDIDATE_TESTS_SHA256"] == (
         "${{ steps.repair_candidate.outputs.tests_sha256 }}"
+    )
+    assert apply_step["env"]["REPAIR_TESTS_ONLY"] == (
+        "${{ inputs.repair_candidate_tests_only }}"
     )
     assert "args+=(--apply-target-only)" in command
     assert 'args+=(--replace-rulespec-path "$replacement_path")' in command

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1676"
+version = "0.2.1677"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- add an apply-only `--repair-candidate-tests-only` mode bound to a prior complete candidate and a structured required-test-case contract
- keep the candidate RuleSpec byte-immutable through materialization, validation, repair, canonicalization, and final apply
- permit only contract-named companion-test additions while preserving all existing cases and typed values
- expose the constrained mode through the protected targeted signed re-encode workflow

This is the encoder prerequisite for repairing the missing positive witnesses in the SNAP immigration RuleSpec candidate without allowing the model to rewrite the already-generated rule.

## Safety properties

- requires `--apply`, an exact replacement path/citation, a complete prior run, and a nonempty v2 required-test contract
- rejects deferred outputs, unexpected bundle paths, RuleSpec mutations, renamed/removed/modified existing test cases, uncontracted cases, recursive YAML aliases, and boolean/integer type substitution
- rechecks RuleSpec and companion-test preservation after deterministic repairs and canonical concept registry normalization, immediately before signing/install
- retry attempts remain bound to the initial candidate

## Review cycle

Independent `codex review --uncommitted` cycle completed with no actionable findings after fixing each reported issue and rerunning focused checks. The final reviewer reported no actionable correctness issues.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests` — passed
- `python -m compileall -q src/axiom_encode scripts` — passed
- affected-file suite (`tests/test_evals.py tests/test_cli.py tests/test_signing_supervisor.py`) — passed in the independent review environment
- focused constrained-repair regressions — 13 passed
- full `uv run pytest` — reached 668 passed / 10 skipped without failures, then a read-only Git subprocess stalled in the long-lived macOS test process; the exact interrupted apply test passed independently in 8.06s. CI is required to pass before merge.
