### PR TITLE
Fix targeted workflow dispatch input limit

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -38,11 +38,6 @@ on:
         description: Prior failed protected run whose final candidate is replayed as untrusted repair context
         required: false
         type: string
-      repair_candidate_tests_only:
-        description: Preserve the repair candidate RuleSpec byte-for-byte and expand only its companion tests under a v2 contract
-        required: false
-        default: false
-        type: boolean
       source_bundle_json:
         description: JSON citation array, canonical_refresh_bundle object, or atomic-source-transaction/v2 envelope for an independent refresh transaction
         required: false
@@ -369,7 +364,6 @@ jobs:
           LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           QUEUE_ID: ${{ inputs.queue_id }}
           REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
-          REPAIR_TESTS_ONLY: ${{ inputs.repair_candidate_tests_only }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
@@ -379,7 +373,7 @@ jobs:
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
         run: |
           set -euo pipefail
-          : "${REPAIR_TESTS_ONLY:=false}"
+          REPAIR_TESTS_ONLY=false
           atomic_source_payload="$(
             python \
               axiom-encode/scripts/prepare_signed_backfill.py \
@@ -391,18 +385,9 @@ jobs:
             <<< "$atomic_source_payload")"
           primary_required_test_cases_json="$(jq -cer \
             '.primary_required_test_cases' <<< "$atomic_source_payload")"
-          if [ "$REPAIR_TESTS_ONLY" = "true" ]; then
-            jq -e 'type == "array" and length > 0' \
-              <<< "$primary_required_test_cases_json" > /dev/null || {
-                echo "tests-only repair requires primary required test cases" >&2
-                exit 1
-              }
-          else
-            jq -e 'type == "array" and length == 0' \
-              <<< "$primary_required_test_cases_json" > /dev/null || {
-                echo "repair test cases require tests-only repair mode" >&2
-                exit 1
-              }
+          if jq -e 'type == "array" and length > 0' \
+            <<< "$primary_required_test_cases_json" > /dev/null; then
+            REPAIR_TESTS_ONLY=true
           fi
           if [[ ! "$REPAIR_RUN_ID" =~ ^[0-9]+$ ]] || \
              [ "$REPAIR_RUN_ID" = "$GITHUB_RUN_ID" ]; then
@@ -571,7 +556,6 @@ jobs:
           LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           QUEUE_ID: ${{ inputs.queue_id }}
           REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
-          REPAIR_TESTS_ONLY: ${{ inputs.repair_candidate_tests_only }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
@@ -579,7 +563,7 @@ jobs:
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
         run: |
           set -euo pipefail
-          : "${REPAIR_TESTS_ONLY:=false}"
+          REPAIR_TESTS_ONLY=false
           atomic_source_payload="$(
             axiom-encode/.venv/bin/python \
               axiom-encode/scripts/prepare_signed_backfill.py \
@@ -591,6 +575,10 @@ jobs:
             <<< "$atomic_source_payload")"
           primary_required_test_cases_json="$(jq -cer \
             '.primary_required_test_cases' <<< "$atomic_source_payload")"
+          if jq -e 'type == "array" and length > 0' \
+            <<< "$primary_required_test_cases_json" > /dev/null; then
+            REPAIR_TESTS_ONLY=true
+          fi
           if [ "$REPAIR_TESTS_ONLY" = "true" ] && [ -z "$REPAIR_RUN_ID" ]; then
             echo "tests-only repair requires repair_run_id" >&2
             exit 1
@@ -1048,7 +1036,6 @@ jobs:
           REPAIR_CANDIDATE_ROOT: ${{ steps.repair_candidate.outputs.root }}
           REPAIR_CANDIDATE_RULESPEC_SHA256: ${{ steps.repair_candidate.outputs.rulespec_sha256 }}
           REPAIR_CANDIDATE_TESTS_SHA256: ${{ steps.repair_candidate.outputs.tests_sha256 }}
-          REPAIR_TESTS_ONLY: ${{ inputs.repair_candidate_tests_only }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
@@ -1064,7 +1051,7 @@ jobs:
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
           set -euo pipefail
-          : "${REPAIR_TESTS_ONLY:=false}"
+          REPAIR_TESTS_ONLY=false
           : "${QUEUE_ID:=}"
           : "${REPLACE_RULESPEC_PATH:=}"
           : "${REPLACE_LEGACY_RULESPEC_PATH:=}"
@@ -1353,6 +1340,10 @@ jobs:
             <<< "$atomic_source_payload")"
           primary_required_test_cases_json="$(jq -cer \
             '.primary_required_test_cases' <<< "$atomic_source_payload")"
+          if jq -e 'type == "array" and length > 0' \
+            <<< "$primary_required_test_cases_json" > /dev/null; then
+            REPAIR_TESTS_ONLY=true
+          fi
           source_bundle_args=(
             "$workflow_python" "$backfill_helper" parse-source-bundle
             "$source_bundle_json" --primary-citation "$CITATION"

--- a/changelog.d/targeted-dispatch-input-limit.fixed.md
+++ b/changelog.d/targeted-dispatch-input-limit.fixed.md
@@ -1,0 +1,1 @@
+Keep the targeted signed re-encode workflow within GitHub's 25-input dispatch limit by deriving constrained companion-test repair mode from its bound v2 test-case contract.

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2102,7 +2102,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert concurrency_suffix("manual-user", "", "queue-generation", "run-3") == "run-3"
     assert concurrency_suffix("github-actions[bot]", "snap", "", "run-4") == "run-4"
     inputs = trigger["workflow_dispatch"]["inputs"]
-    assert len(inputs) == 26
+    assert len(inputs) <= 25
     assert "allowlisted reviewed SHA" in inputs["rulespec_ref"]["description"]
     assert "artifact-only" in inputs["rulespec_ref"]["description"]
     assert inputs["country"] == {
@@ -2121,6 +2121,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "required": False,
         "type": "string",
     }
+    assert "repair_candidate_tests_only" not in inputs
     assert inputs["pr_base_branch"]["type"] == "string"
     assert inputs["pr_base_branch"]["default"] == "main"
     assert inputs["source_bundle_json"] == {
@@ -2316,9 +2317,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert repair_step["if"] == "${{ inputs.repair_run_id != '' }}"
     assert repair_step["env"]["GH_TOKEN"] == "${{ github.token }}"
     assert repair_step["env"]["RULESPEC_CHECKOUT"] == ("rulespec-${{ inputs.country }}")
-    assert repair_step["env"]["REPAIR_TESTS_ONLY"] == (
-        "${{ inputs.repair_candidate_tests_only }}"
-    )
+    assert "REPAIR_TESTS_ONLY" not in repair_step["env"]
     repair_command = repair_step["run"]
     assert '.conclusion == "failure"' in repair_command
     assert '.event == "workflow_dispatch"' in repair_command
@@ -2328,8 +2327,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "merge-base --is-ancestor" in repair_command
     assert '"$repair_encoder_commit" "$GITHUB_SHA"' in repair_command
     assert "repair replay is limited to one non-legacy target" in repair_command
-    assert "tests-only repair requires primary required test cases" in repair_command
-    assert "repair test cases require tests-only repair mode" in repair_command
+    assert "REPAIR_TESTS_ONLY=false" in repair_command
+    assert "REPAIR_TESTS_ONLY=true" in repair_command
     assert 'test -n "$REPLACE_RULESPEC_PATH"' not in repair_command
     assert "targeted-reencode-failure-${REPAIR_RUN_ID}-1" in repair_command
     assert "extract_repair_candidate.py" in repair_command
@@ -2483,9 +2482,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert apply_step["env"]["REPAIR_CANDIDATE_TESTS_SHA256"] == (
         "${{ steps.repair_candidate.outputs.tests_sha256 }}"
     )
-    assert apply_step["env"]["REPAIR_TESTS_ONLY"] == (
-        "${{ inputs.repair_candidate_tests_only }}"
-    )
+    assert "REPAIR_TESTS_ONLY" not in apply_step["env"]
+    assert "REPAIR_TESTS_ONLY=false" in command
+    assert "REPAIR_TESTS_ONLY=true" in command
     assert "args+=(--apply-target-only)" in command
     assert 'args+=(--replace-rulespec-path "$replacement_path")' in command
     assert 'local require_direct_imports="$7"' in command


### PR DESCRIPTION
## Summary

- remove the redundant constrained-repair boolean from workflow_dispatch so the workflow stays within GitHub’s 25-input limit
- derive tests-only repair mode from nonempty v2 primary required-test cases
- retain fail-closed repair-run validation and command forwarding

## Review cycle

Independent review: no actionable findings.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- targeted workflow contract and shell-syntax tests: 2 passed
- broader targeted-signing subset: 33 passed; 5 existing macOS archive/resource-fork failures unrelated to this diff
