### PR TITLE
Allow identity-safe repair replay after RuleSpec reroot

### DIFF
--- a/changelog.d/repair-base-reroot-identity.fixed.md
+++ b/changelog.d/repair-base-reroot-identity.fixed.md
@@ -1,0 +1,1 @@
+Permit protected repair-candidate replay across a RuleSpec history re-root only when the target RuleSpec, companion tests, and uniquely resolved ownership manifest retain exact blob identities, including the canonical manifest-path relocation.

--- a/scripts/verify_repair_base_advance.py
+++ b/scripts/verify_repair_base_advance.py
@@ -19,11 +19,59 @@ def _git(
     repository: Path, *arguments: str, check: bool = True
 ) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ["git", "-C", str(repository), *arguments],
+        ["git", "--no-replace-objects", "-C", str(repository), *arguments],
         check=check,
         capture_output=True,
         text=True,
     )
+
+
+def _blob_identity(repository: Path, commit: str, path: PurePosixPath) -> str | None:
+    """Return one tracked blob identity without reading checkout-controlled bytes."""
+
+    result = _git(
+        repository,
+        "rev-parse",
+        "--verify",
+        f"{commit}:{path.as_posix()}",
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    identity = result.stdout.strip()
+    if re.fullmatch(r"[0-9a-f]{40,64}", identity) is None:
+        raise RuntimeError("repair replay target returned an invalid blob identity")
+    object_type = _git(repository, "cat-file", "-t", identity).stdout.strip()
+    if object_type != "blob":
+        raise ValueError("repair replay target identity is not a tracked blob")
+    return identity
+
+
+def _unique_manifest_identity(
+    repository: Path,
+    commit: str,
+    manifest_paths: tuple[PurePosixPath, ...],
+    *,
+    label: str,
+) -> str:
+    """Resolve one legacy or canonical manifest path, rejecting ambiguity."""
+
+    identities = tuple(
+        identity
+        for path in manifest_paths
+        if (identity := _blob_identity(repository, commit, path)) is not None
+    )
+    if not identities:
+        raise ValueError(
+            f"repair replay target identity is missing at its {label} RuleSpec base: "
+            "ownership manifest"
+        )
+    if len(identities) != 1:
+        raise ValueError(
+            f"repair replay target identity is ambiguous at its {label} RuleSpec "
+            "base: ownership manifest"
+        )
+    return identities[0]
 
 
 def verify_base_advance(
@@ -63,17 +111,6 @@ def verify_base_advance(
     ).stdout.strip()
     if source_commit != source_ref:
         raise ValueError("repair source RuleSpec ref does not identify its commit")
-    ancestor = _git(
-        repository,
-        "merge-base",
-        "--is-ancestor",
-        source_ref,
-        current_ref,
-        check=False,
-    )
-    if ancestor.returncode != 0:
-        raise ValueError("repair source RuleSpec ref is not an ancestor of current")
-
     repository_path = (
         PurePosixPath(rulespec_path)
         if rulespec_path is not None
@@ -94,43 +131,53 @@ def verify_base_advance(
     ):
         raise ValueError("repair repository RuleSpec path is not canonical")
     test_path = path.with_suffix(".test.yaml")
-    manifest_path = (
+    legacy_manifest_path = (
         PurePosixPath(".axiom", "encoding-manifests") / repository_path
+    ).with_suffix(".json")
+    canonical_manifest_path = (
+        PurePosixPath(".axiom", "encoding-manifests") / path
     ).with_suffix(".json")
     tracked_paths = (
         repository_path.as_posix(),
         PurePosixPath(repository_path.parts[0], test_path).as_posix(),
-        manifest_path.as_posix(),
     )
     for tracked_path in tracked_paths:
-        exists_at_source = _git(
-            repository,
-            "cat-file",
-            "-e",
-            f"{source_ref}:{tracked_path}",
-            check=False,
-        )
-        if exists_at_source.returncode != 0:
+        path_identity = PurePosixPath(tracked_path)
+        source_identity = _blob_identity(repository, source_ref, path_identity)
+        if source_identity is None:
             raise ValueError(
                 "repair replay target identity is missing at its source RuleSpec "
                 f"base: {tracked_path}"
             )
-    unchanged = _git(
-        repository,
-        "diff",
-        "--quiet",
-        source_ref,
-        current_ref,
-        "--",
-        *tracked_paths,
-        check=False,
+        current_identity = _blob_identity(repository, current_ref, path_identity)
+        if current_identity is None:
+            raise ValueError(
+                "repair replay target identity is missing at its current RuleSpec "
+                f"base: {tracked_path}"
+            )
+        if source_identity != current_identity:
+            raise ValueError(
+                "repair replay target identity changed after its source RuleSpec base"
+            )
+    manifest_paths = tuple(
+        dict.fromkeys((legacy_manifest_path, canonical_manifest_path))
     )
-    if unchanged.returncode == 1:
+    source_manifest_identity = _unique_manifest_identity(
+        repository,
+        source_ref,
+        manifest_paths,
+        label="source",
+    )
+    current_manifest_identity = _unique_manifest_identity(
+        repository,
+        current_ref,
+        manifest_paths,
+        label="current",
+    )
+    if source_manifest_identity != current_manifest_identity:
         raise ValueError(
             "repair replay target identity changed after its source RuleSpec base"
         )
-    if unchanged.returncode != 0:
-        raise RuntimeError("could not compare repair replay target identity")
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/tests/test_verify_repair_base_advance.py
+++ b/tests/test_verify_repair_base_advance.py
@@ -216,7 +216,9 @@ def test_rejects_dotted_section_manifest_change_at_real_manifest_path(
         )
 
 
-def test_rejects_source_ref_that_is_not_an_ancestor(tmp_path: Path) -> None:
+def test_accepts_rerooted_base_when_repair_target_identity_is_unchanged(
+    tmp_path: Path,
+) -> None:
     repository, source_ref = _repository(tmp_path)
     (repository / "source-only.txt").write_text("source\n", encoding="utf-8")
     source_ref = _commit(repository, "source branch")
@@ -227,7 +229,146 @@ def test_rejects_source_ref_that_is_not_an_ancestor(tmp_path: Path) -> None:
     (repository / "other.txt").write_text("other\n", encoding="utf-8")
     current_ref = _commit(repository, "other history")
 
-    with pytest.raises(ValueError, match="not an ancestor"):
+    verify_base_advance(
+        repository,
+        country="us",
+        source_ref=source_ref,
+        current_ref=current_ref,
+        candidate_path="statutes/42/1437c-1.yaml",
+    )
+
+
+def test_accepts_rerooted_base_with_exact_canonical_manifest_relocation(
+    tmp_path: Path,
+) -> None:
+    repository, source_ref = _repository(tmp_path)
+    (repository / "source-only.txt").write_text("source\n", encoding="utf-8")
+    source_ref = _commit(repository, "source branch")
+    subprocess.run(
+        ["git", "-C", str(repository), "switch", "-qc", "other", f"{source_ref}^"],
+        check=True,
+    )
+    legacy_manifest = Path(".axiom/encoding-manifests/us/statutes/42/1437c-1.json")
+    canonical_manifest = Path(".axiom/encoding-manifests/statutes/42/1437c-1.json")
+    (repository / canonical_manifest).parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "mv",
+            legacy_manifest.as_posix(),
+            canonical_manifest.as_posix(),
+        ],
+        check=True,
+    )
+    current_ref = _commit(repository, "canonical manifest relocation")
+
+    verify_base_advance(
+        repository,
+        country="us",
+        source_ref=source_ref,
+        current_ref=current_ref,
+        candidate_path="statutes/42/1437c-1.yaml",
+    )
+
+
+def test_rejects_ambiguous_legacy_and_canonical_manifests(tmp_path: Path) -> None:
+    repository, source_ref = _repository(tmp_path)
+    canonical_manifest = (
+        repository / ".axiom/encoding-manifests/statutes/42/1437c-1.json"
+    )
+    canonical_manifest.parent.mkdir(parents=True, exist_ok=True)
+    canonical_manifest.write_text("{}\n", encoding="utf-8")
+    current_ref = _commit(repository, "duplicate canonical manifest")
+
+    with pytest.raises(ValueError, match="ambiguous at its current RuleSpec base"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=current_ref,
+            candidate_path="statutes/42/1437c-1.yaml",
+        )
+
+
+def test_rejects_tree_instead_of_tracked_blob(tmp_path: Path) -> None:
+    repository, _ = _repository(tmp_path)
+    candidate = repository / "us/statutes/42/1437c-1.yaml"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "rm",
+            "-q",
+            "--",
+            candidate.relative_to(repository),
+        ],
+        check=True,
+    )
+    candidate.mkdir()
+    (candidate / "child").write_text("not a rulespec blob\n", encoding="utf-8")
+    source_ref = _commit(repository, "tree at candidate path")
+
+    with pytest.raises(ValueError, match="not a tracked blob"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=source_ref,
+            candidate_path="statutes/42/1437c-1.yaml",
+        )
+
+
+def test_rejects_rerooted_base_when_repair_target_identity_changes(
+    tmp_path: Path,
+) -> None:
+    repository, source_ref = _repository(tmp_path)
+    (repository / "source-only.txt").write_text("source\n", encoding="utf-8")
+    source_ref = _commit(repository, "source branch")
+    subprocess.run(
+        ["git", "-C", str(repository), "switch", "-qc", "other", f"{source_ref}^"],
+        check=True,
+    )
+    (repository / "us/statutes/42/1437c-1.yaml").write_text(
+        "changed\n", encoding="utf-8"
+    )
+    current_ref = _commit(repository, "changed target on other history")
+
+    with pytest.raises(ValueError, match="target identity changed"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=current_ref,
+            candidate_path="statutes/42/1437c-1.yaml",
+        )
+
+
+def test_ignores_local_git_blob_replacement(tmp_path: Path) -> None:
+    repository, source_ref = _repository(tmp_path)
+    candidate = repository / "us/statutes/42/1437c-1.yaml"
+    candidate.write_text("replacement content\n", encoding="utf-8")
+    current_ref = _commit(repository, "changed candidate")
+    source_blob = _git(
+        repository,
+        "--no-replace-objects",
+        "rev-parse",
+        f"{source_ref}:us/statutes/42/1437c-1.yaml",
+    )
+    current_blob = _git(
+        repository,
+        "--no-replace-objects",
+        "rev-parse",
+        f"{current_ref}:us/statutes/42/1437c-1.yaml",
+    )
+    subprocess.run(
+        ["git", "-C", str(repository), "replace", source_blob, current_blob],
+        check=True,
+    )
+
+    with pytest.raises(ValueError, match="target identity changed"):
         verify_base_advance(
             repository,
             country="us",


### PR DESCRIPTION
## Summary

- permit protected repair replay across re-rooted RuleSpec history only when the primary RuleSpec, companion tests, and ownership manifest retain exact Git blob identities
- allow the known legacy-to-canonical ownership-manifest path relocation while rejecting missing or ambiguous manifests
- ignore local Git replacement objects and reject non-blob identities

This unblocks the SNAP immigration repair sourced from run 31510054931. The prior retry, run 31531852842, failed safely in preflight because rulespec-us history was re-rooted. The target group was independently verified byte-identical across source and current refs before this change.

## Safety

The verifier remains fail-closed for changed, missing, ambiguous, noncanonical, or non-blob targets. A re-root alone is accepted only after exact Git object identity checks for all three protected artifacts.

## Review cycle

Independent security review found one high-severity issue: Git replacement refs could alter object resolution. Fixed by using --no-replace-objects for every verifier Git call and adding a blob-replacement regression test. A follow-up test-quality finding was fixed. Final independent re-review: No actionable findings.

## Checks

- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- uv run pytest -q tests/test_verify_repair_base_advance.py — 34 passed
- uv run pytest -q tests/test_signing_supervisor.py::test_targeted_signed_reencode_workflow_is_main_dispatch_only tests/test_extract_repair_candidate.py — 55 passed
- full suite — 13,248 passed, 126 skipped; five macOS AppleDouble artifact-set failures
- COPYFILE_DISABLE=1 focused rerun of those five signing tests — 5 passed