### PR TITLE
Fix repair witness routing

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -579,6 +579,10 @@ jobs:
             <<< "$atomic_source_payload")"
           primary_required_test_cases_json="$(jq -cer \
             '.primary_required_test_cases' <<< "$atomic_source_payload")"
+          canonical_refresh_primary_required_test_cases_json="$primary_required_test_cases_json"
+          if [ -n "${REPAIR_RUN_ID:-}" ]; then
+            canonical_refresh_primary_required_test_cases_json="[]"
+          fi
           source_bundle_args=(
             axiom-encode/.venv/bin/python
             axiom-encode/scripts/prepare_signed_backfill.py
@@ -607,7 +611,7 @@ jobs:
               --primary-citation "$CITATION" \
               --primary-rulespec-path "$REPLACE_RULESPEC_PATH" \
               --primary-required-test-cases-json \
-                "$primary_required_test_cases_json"
+                "$canonical_refresh_primary_required_test_cases_json"
           )"
           existing_import_args=(
             axiom-encode/.venv/bin/python
@@ -889,6 +893,7 @@ jobs:
           LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
+          REPAIR_TESTS_ONLY: ${{ steps.repair_candidate.outputs.tests_only }}
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
@@ -907,6 +912,10 @@ jobs:
             <<< "$atomic_source_payload")"
           primary_required_test_cases_json="$(jq -cer \
             '.primary_required_test_cases' <<< "$atomic_source_payload")"
+          canonical_refresh_primary_required_test_cases_json="$primary_required_test_cases_json"
+          if [ "${REPAIR_TESTS_ONLY:-false}" = "true" ]; then
+            canonical_refresh_primary_required_test_cases_json="[]"
+          fi
           source_bundle_args=(
             "$workflow_python" -I "$backfill_helper" parse-source-bundle
             "$source_bundle_json" --primary-citation "$CITATION"
@@ -927,7 +936,7 @@ jobs:
               --primary-citation "$CITATION" \
               --primary-rulespec-path "$REPLACE_RULESPEC_PATH" \
               --primary-required-test-cases-json \
-                "$primary_required_test_cases_json"
+                "$canonical_refresh_primary_required_test_cases_json"
           )"
           printf '%s\n' "$normalized_canonical_refresh_bundle" \
             > "$RUNNER_TEMP/canonical-refresh-bundle.json"
@@ -1337,6 +1346,10 @@ jobs:
             <<< "$atomic_source_payload")"
           primary_required_test_cases_json="$(jq -cer \
             '.primary_required_test_cases' <<< "$atomic_source_payload")"
+          canonical_refresh_primary_required_test_cases_json="$primary_required_test_cases_json"
+          if [ "$REPAIR_TESTS_ONLY" = "true" ]; then
+            canonical_refresh_primary_required_test_cases_json="[]"
+          fi
           source_bundle_args=(
             "$workflow_python" "$backfill_helper" parse-source-bundle
             "$source_bundle_json" --primary-citation "$CITATION"
@@ -1355,7 +1368,7 @@ jobs:
               --primary-citation "$CITATION" \
               --primary-rulespec-path "$REPLACE_RULESPEC_PATH" \
               --primary-required-test-cases-json \
-                "$primary_required_test_cases_json"
+                "$canonical_refresh_primary_required_test_cases_json"
           )"
           verified_canonical_refresh_bundle="$(tr -d '\n' \
             < "$RUNNER_TEMP/canonical-refresh-bundle.json")"

--- a/changelog.d/repair-witness-routing.fixed.md
+++ b/changelog.d/repair-witness-routing.fixed.md
@@ -1,0 +1,1 @@
+Keep required companion-test witnesses in the constrained repair lane instead of misclassifying them as a canonical refresh.

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -3029,6 +3029,104 @@ def test_fresh_v2_required_test_cases_do_not_require_a_repair_run(
     assert completed.returncode == 0, completed.stderr
 
 
+def test_repair_required_test_cases_do_not_enable_canonical_refresh(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = (
+        next(
+            step["run"]
+            for step in workflow["jobs"]["encode"]["steps"]
+            if step.get("name") == "Validate atomic source inputs"
+        )
+        .replace("axiom-encode/.venv/bin/python", sys.executable)
+        .replace(
+            "axiom-encode/scripts/prepare_signed_backfill.py",
+            str(ROOT / "scripts/prepare_signed_backfill.py"),
+        )
+    )
+    checkout, primary_citation, primary_path, _additions = (
+        _prepare_canonical_refresh_inputs(tmp_path)
+    )
+    manifest = (
+        checkout / ".axiom/encoding-manifests" / Path(primary_path).with_suffix(".json")
+    )
+    manifest.write_text('{"schema_version":"legacy"}\n', encoding="utf-8")
+    required_cases_payload = json.dumps(
+        {
+            "schema": "axiom-encode/atomic-source-transaction/v2",
+            "source_bundle": [],
+            "canonical_refresh_bundle": [],
+            "primary_required_test_cases": [
+                {
+                    "name": "required repair control",
+                    "period": {
+                        "period_kind": "tax_year",
+                        "start": "2026-01-01",
+                        "end": "2026-12-31",
+                    },
+                    "input": {"example_input": 1},
+                    "required_output": {"example_output": 1},
+                }
+            ],
+        }
+    )
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        cwd=ROOT.parent,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "ATOMIC_SOURCE_JSON": required_cases_payload,
+            "CITATION": primary_citation,
+            "DEPENDENT_CITATION": "",
+            "EXISTING_SIGNED_IMPORTS_JSON": "[]",
+            "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
+            "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON": "[]",
+            "QUEUE_ID": "",
+            "REPAIR_RUN_ID": "100",
+            "REPLACE_LEGACY_RULESPEC_PATH": "",
+            "REPLACE_RULESPEC_PATH": primary_path,
+            "RULESPEC_CHECKOUT": str(checkout),
+            "SECOND_DEPENDENT_CITATION": "",
+            "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
+        },
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_repair_witness_routing_is_rechecked_in_protected_steps() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    steps = workflow["jobs"]["encode"]["steps"]
+    validate = next(
+        step for step in steps if step.get("name") == "Validate atomic source inputs"
+    )
+    verify = next(
+        step for step in steps if step.get("name") == "Verify existing signed imports"
+    )
+    encode = next(
+        step
+        for step in steps
+        if step.get("name") == "Encode, review, validate, and apply"
+    )
+
+    assert 'if [ -n "${REPAIR_RUN_ID:-}" ]; then' in validate["run"]
+    assert verify["env"]["REPAIR_TESTS_ONLY"] == (
+        "${{ steps.repair_candidate.outputs.tests_only }}"
+    )
+    assert 'if [ "${REPAIR_TESTS_ONLY:-false}" = "true" ]; then' in verify["run"]
+    assert 'if [ "$REPAIR_TESTS_ONLY" = "true" ]; then' in encode["run"]
+    for step in (validate, verify, encode):
+        assert '"$canonical_refresh_primary_required_test_cases_json"' in step["run"]
+
+
 @pytest.mark.parametrize(
     ("provision_conclusion", "protected_runtime_state"),
     [


### PR DESCRIPTION
## Summary

- keep v2 required companion-test witnesses in constrained repair mode instead of enabling canonical refresh
- apply the same routing decision in input validation, protected import verification, and signed apply
- add execution and protected-stage regression coverage

This unblocks the bounded SNAP immigration repair replay for `us/regulation/7/273/4`.

## Review cycle

- independent security/correctness review: no actionable findings
- post-fix independent re-review: no actionable findings
- exact immigration atomic-source payload replayed through `Validate atomic source inputs` against rulespec-us `436fad35d2724375ba2831082a2ef00bf166f781`: passed

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `COPYFILE_DISABLE=1 uv run pytest -q tests/test_signing_supervisor.py` — 99 passed, 58 skipped
- `COPYFILE_DISABLE=1 uv run pytest -q` — 13,257 passed, 126 skipped