### PR TITLE
Infer embedded scalar repair types safely

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1678"
+version = "0.2.1679"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1677"
+version = "0.2.1678"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1678"
+__version__ = "0.2.1679"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1677"
+__version__ = "0.2.1678"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -33488,9 +33488,7 @@ def _proof_source_citation_paths(
         if isinstance(atom, dict)
         and (path is None or atom.get("path") == path)
         and isinstance(atom.get("source"), dict)
-        and isinstance(
-            citation_path := atom["source"].get("corpus_citation_path"), str
-        )
+        and isinstance(citation_path := atom["source"].get("corpus_citation_path"), str)
         and citation_path.strip()
     }
 
@@ -33540,7 +33538,9 @@ def _replace_exact_stripped_formula_line(
         return formula
     lines = formula.splitlines(keepends=True)
     matching_indices = [
-        index for index, line in enumerate(lines) if line.strip() == normalized_expression
+        index
+        for index, line in enumerate(lines)
+        if line.strip() == normalized_expression
     ]
     if len(matching_indices) != 1:
         return formula
@@ -33578,11 +33578,7 @@ def _embedded_scalar_parameter_rule(
         "kind": "parameter",
         "dtype": dtype,
         "source": source_rule.get("source"),
-        "metadata": {
-            "proof": {
-                "atoms": [source_atom]
-            }
-        },
+        "metadata": {"proof": {"atoms": [source_atom]}},
         "versions": [parameter_version],
     }
     if not parameter_rule["source"]:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -33200,24 +33200,11 @@ def _extract_embedded_scalar_literal_record(
             _grounded_formula_literal_for_scalar_expression(rule, expression) or literal
         )
         replace_expression = parameter_formula != literal
-        existing_parameter_name = _existing_embedded_scalar_parameter_name(
-            rules,
-            base_name=parameter_name,
-            literal=parameter_formula,
-        )
-        insert_parameter = existing_parameter_name is None
-        if existing_parameter_name is not None:
-            parameter_name = existing_parameter_name
-        else:
-            parameter_name = _unique_generated_rule_name(
-                parameter_name,
-                existing_names,
-            )
         versions = rule.get("versions")
         if not isinstance(versions, list) or not versions:
             return None
-        changed = False
-        for version in versions:
+        matching_versions: list[tuple[int, dict[str, Any], str]] = []
+        for version_index, version in enumerate(versions):
             if not isinstance(version, dict):
                 continue
             formula = version.get("formula")
@@ -33237,20 +33224,89 @@ def _extract_embedded_scalar_literal_record(
                     parameter_name=parameter_name,
                 )
             if replacement != formula:
-                version["formula"] = replacement
-                changed = True
-        if not changed:
+                matching_versions.append((version_index, version, replacement))
+        if len(matching_versions) != 1:
             return None
+        target_version_index, target_version, replacement = matching_versions[0]
+        target_formula = str(target_version.get("formula") or "")
+        parameter_dtype = _embedded_scalar_parameter_dtype(
+            rule,
+            literal=literal,
+            expression=expression,
+            target_formula=target_formula,
+        )
+        if parameter_dtype is None:
+            return None
+        parameter_unit = _embedded_scalar_parameter_unit(
+            rule,
+            dtype=parameter_dtype,
+        )
+        existing_parameter_name = _existing_embedded_scalar_parameter_name(
+            rules,
+            base_name=parameter_name,
+            literal=parameter_formula,
+            dtype=parameter_dtype,
+            unit=parameter_unit,
+            target_version=target_version,
+            target_rule=rule,
+            target_version_index=target_version_index,
+            expected_target=f"{target_anchor}#{parameter_name}",
+            target_corpus_citation_path=corpus_citation_path,
+        )
+        insert_parameter = existing_parameter_name is None
+        if existing_parameter_name is not None:
+            parameter_name = existing_parameter_name
+        else:
+            if parameter_name in existing_names and _rule_has_formula_import(
+                rule,
+                path=f"versions[{target_version_index}].formula",
+                target=f"{target_anchor}#{parameter_name}",
+                output=parameter_name,
+            ):
+                return None
+            parameter_name = _unique_generated_rule_name(
+                parameter_name,
+                existing_names,
+            )
+        parameter_source_atom: dict[str, Any] | None = None
+        if insert_parameter:
+            parameter_source_atom = _source_atom_for_embedded_scalar_parameter(
+                rule,
+                literal=parameter_formula,
+                source_version_index=target_version_index,
+                corpus_citation_path=corpus_citation_path,
+            )
+            if parameter_source_atom is None:
+                return None
+            if replace_expression:
+                replacement = _replace_embedded_scalar_expression(
+                    target_formula,
+                    expression=expression,
+                    parameter_name=parameter_name,
+                )
+            else:
+                replacement = _replace_embedded_scalar_literal(
+                    target_formula,
+                    literal=literal,
+                    expression=expression,
+                    parameter_name=parameter_name,
+                )
+        target_version["formula"] = replacement
         _add_formula_proof_import(
             rule,
             target=f"{target_anchor}#{parameter_name}",
             output=parameter_name,
+            path=f"versions[{target_version_index}].formula",
         )
         if insert_parameter:
             parameter_rule = _embedded_scalar_parameter_rule(
                 rule,
                 name=parameter_name,
                 literal=parameter_formula,
+                dtype=parameter_dtype,
+                unit=parameter_unit,
+                source_version=target_version,
+                source_atom=parameter_source_atom,
                 corpus_citation_path=corpus_citation_path,
             )
             rules.insert(index, parameter_rule)
@@ -33335,6 +33391,13 @@ def _existing_embedded_scalar_parameter_name(
     *,
     base_name: str,
     literal: str,
+    dtype: str,
+    unit: str | None,
+    target_version: dict[str, Any],
+    target_rule: dict[str, Any],
+    target_version_index: int,
+    expected_target: str,
+    target_corpus_citation_path: str | None,
 ) -> str | None:
     for rule in rules:
         if not isinstance(rule, dict):
@@ -33343,16 +33406,93 @@ def _existing_embedded_scalar_parameter_name(
             continue
         if str(rule.get("kind") or "").strip().lower() != "parameter":
             return None
+        if str(rule.get("dtype") or "").strip() != dtype:
+            return None
+        existing_unit = str(rule.get("unit") or "").strip() or None
+        if existing_unit != unit:
+            return None
+        target_path = f"versions[{target_version_index}].formula"
+        if not _rule_has_formula_import(
+            target_rule,
+            path=target_path,
+            target=expected_target,
+            output=base_name,
+        ):
+            return None
         versions = rule.get("versions")
         if not isinstance(versions, list):
             return None
-        for version in versions:
-            if not isinstance(version, dict):
-                continue
-            formula = version.get("formula")
-            if str(formula).strip() == literal:
-                return base_name
+        matching_version_indices = [
+            version_index
+            for version_index, version in enumerate(versions)
+            if isinstance(version, dict)
+            and str(version.get("formula")).strip() == literal
+            and _normalized_rulespec_date(version.get("effective_from"))
+            == _normalized_rulespec_date(target_version.get("effective_from"))
+            and _normalized_rulespec_date(version.get("effective_to"))
+            == _normalized_rulespec_date(target_version.get("effective_to"))
+        ]
+        if len(matching_version_indices) != 1:
+            return None
+        parameter_source_paths = _proof_source_citation_paths(
+            rule,
+            path=f"versions[{matching_version_indices[0]}].formula",
+        )
+        if not parameter_source_paths:
+            return None
+        target_source_paths = _proof_source_citation_paths(
+            target_rule,
+            path=target_path,
+        )
+        if not target_source_paths:
+            if not target_corpus_citation_path:
+                return None
+            target_source_paths = {target_corpus_citation_path.strip()}
+        if parameter_source_paths.isdisjoint(target_source_paths):
+            return None
+        return base_name
     return None
+
+
+def _rule_has_formula_import(
+    rule: dict[str, Any],
+    *,
+    path: str,
+    target: str,
+    output: str,
+) -> bool:
+    proof = rule.get("metadata", {}).get("proof")
+    atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    return isinstance(atoms, list) and any(
+        isinstance(atom, dict)
+        and atom.get("path") == path
+        and isinstance(atom.get("import"), dict)
+        and atom["import"].get("target") == target
+        and atom["import"].get("output") == output
+        for atom in atoms
+    )
+
+
+def _proof_source_citation_paths(
+    rule: dict[str, Any],
+    *,
+    path: str | None = None,
+) -> set[str]:
+    proof = rule.get("metadata", {}).get("proof")
+    atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    if not isinstance(atoms, list):
+        return set()
+    return {
+        citation_path.strip()
+        for atom in atoms
+        if isinstance(atom, dict)
+        and (path is None or atom.get("path") == path)
+        and isinstance(atom.get("source"), dict)
+        and isinstance(
+            citation_path := atom["source"].get("corpus_citation_path"), str
+        )
+        and citation_path.strip()
+    }
 
 
 def _replace_embedded_scalar_literal(
@@ -33367,16 +33507,12 @@ def _replace_embedded_scalar_literal(
         parameter_name,
         expression,
     )
-    if (
-        expression.strip() != literal
-        and expression_replacement != expression
-        and expression in formula
-    ):
-        formula = formula.replace(expression, expression_replacement, 1)
-    return re.sub(
-        rf"(?<![A-Za-z0-9_.]){re.escape(literal)}(?![A-Za-z0-9_.])",
-        parameter_name,
+    if expression_replacement == expression:
+        return formula
+    return _replace_exact_stripped_formula_line(
         formula,
+        expression=expression,
+        replacement=expression_replacement,
     )
 
 
@@ -33386,9 +33522,34 @@ def _replace_embedded_scalar_expression(
     expression: str,
     parameter_name: str,
 ) -> str:
-    if expression.strip() and expression in formula:
-        return formula.replace(expression, parameter_name)
-    return formula
+    return _replace_exact_stripped_formula_line(
+        formula,
+        expression=expression,
+        replacement=parameter_name,
+    )
+
+
+def _replace_exact_stripped_formula_line(
+    formula: str,
+    *,
+    expression: str,
+    replacement: str,
+) -> str:
+    normalized_expression = expression.strip()
+    if not normalized_expression:
+        return formula
+    lines = formula.splitlines(keepends=True)
+    matching_indices = [
+        index for index, line in enumerate(lines) if line.strip() == normalized_expression
+    ]
+    if len(matching_indices) != 1:
+        return formula
+    index = matching_indices[0]
+    line = lines[index]
+    leading = len(line) - len(line.lstrip())
+    trailing = len(line.rstrip())
+    lines[index] = f"{line[:leading]}{replacement}{line[trailing:]}"
+    return "".join(lines)
 
 
 def _embedded_scalar_parameter_rule(
@@ -33396,58 +33557,162 @@ def _embedded_scalar_parameter_rule(
     *,
     name: str,
     literal: str,
+    dtype: str,
+    unit: str | None,
+    source_version: dict[str, Any],
+    source_atom: dict[str, Any],
     corpus_citation_path: str | None = None,
 ) -> dict[str, Any]:
-    first_effective_from = "0001-01-01"
-    versions = source_rule.get("versions")
-    if isinstance(versions, list):
-        for version in versions:
-            if not isinstance(version, dict):
-                continue
-            effective_from = version.get("effective_from")
-            if isinstance(effective_from, str) and effective_from.strip():
-                first_effective_from = effective_from.strip()
-                break
+    effective_from = (
+        _normalized_rulespec_date(source_version.get("effective_from")) or "0001-01-01"
+    )
+    parameter_version: dict[str, Any] = {
+        "effective_from": effective_from,
+        "formula": literal,
+    }
+    effective_to = _normalized_rulespec_date(source_version.get("effective_to"))
+    if effective_to is not None:
+        parameter_version["effective_to"] = effective_to
     parameter_rule: dict[str, Any] = {
         "name": name,
         "kind": "parameter",
-        "dtype": "Count",
+        "dtype": dtype,
         "source": source_rule.get("source"),
         "metadata": {
             "proof": {
-                "atoms": [
-                    _source_atom_for_embedded_scalar_parameter(
-                        source_rule,
-                        literal=literal,
-                        corpus_citation_path=corpus_citation_path,
-                    )
-                ]
+                "atoms": [source_atom]
             }
         },
-        "versions": [
-            {
-                "effective_from": first_effective_from,
-                "formula": literal,
-            }
-        ],
+        "versions": [parameter_version],
     }
     if not parameter_rule["source"]:
         parameter_rule.pop("source", None)
+    if unit is not None:
+        parameter_rule["unit"] = unit
     return parameter_rule
+
+
+def _normalized_rulespec_date(value: Any) -> str | None:
+    if isinstance(value, datetime):
+        return None
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _embedded_scalar_parameter_dtype(
+    source_rule: dict[str, Any],
+    *,
+    literal: str,
+    expression: str,
+    target_formula: str,
+) -> str | None:
+    """Infer only scalar types that the formula shape determines safely."""
+    normalized_expression = expression.strip()
+    source_dtype = str(source_rule.get("dtype") or "").strip()
+    numeric_dtypes = {"Count", "Decimal", "Integer", "Money", "Rate"}
+
+    if source_dtype not in numeric_dtypes:
+        return None
+
+    literal_pattern = rf"(?<![A-Za-z0-9_.]){re.escape(literal)}(?![A-Za-z0-9_.])"
+    occurrences = [match.span() for match in re.finditer(literal_pattern, expression)]
+    if not occurrences:
+        return None
+
+    count_patterns = (
+        rf"\[\s*(?P<literal>{literal_pattern})\s*\]",
+        rf"\b[A-Za-z_][A-Za-z0-9_]*(?:count|number|size)\b\s*"
+        rf"(?:<=|<|>=|>|\+|-)\s*(?P<literal>{literal_pattern})",
+        rf"(?P<literal>{literal_pattern})\s*(?:<=|<|>=|>|\+|-)\s*"
+        rf"[A-Za-z_][A-Za-z0-9_]*(?:count|number|size)\b",
+        rf"\b(?:min|max)\s*\([^,]*(?:count|number|size)\b\s*,\s*"
+        rf"(?P<literal>{literal_pattern})\s*\)",
+    )
+    count_spans = {
+        match.span("literal")
+        for pattern in count_patterns
+        for match in re.finditer(pattern, expression, flags=re.IGNORECASE)
+    }
+    output_pattern = (
+        rf"(?:^|:|\belse\b)\s*(?P<literal>{literal_pattern})"
+        rf"(?=\s*(?:\belse\b|$))"
+    )
+    output_spans = {
+        match.span("literal")
+        for match in re.finditer(output_pattern, expression, flags=re.IGNORECASE)
+    }
+    if (
+        normalized_expression == literal
+        and target_formula.strip() != normalized_expression
+        and not _standalone_conditional_leaf_line(target_formula, literal)
+    ):
+        output_spans = set()
+
+    inferred: set[str] = set()
+    for span in occurrences:
+        occurrence_types: set[str] = set()
+        if span in count_spans:
+            occurrence_types.add("Count")
+        if span in output_spans:
+            occurrence_types.add(source_dtype)
+        if (
+            normalized_expression == literal
+            and target_formula.strip() == normalized_expression
+        ) or (
+            _simple_fraction_expression_value(normalized_expression) is not None
+            and target_formula.strip() == normalized_expression
+        ):
+            occurrence_types.add(source_dtype)
+        if len(occurrence_types) != 1:
+            return None
+        inferred.update(occurrence_types)
+    return next(iter(inferred)) if len(inferred) == 1 else None
+
+
+def _standalone_conditional_leaf_line(formula: str, literal: str) -> bool:
+    stripped_lines = [line.strip() for line in formula.splitlines() if line.strip()]
+    matching_indices = [
+        index for index, line in enumerate(stripped_lines) if line == literal
+    ]
+    return (
+        len(matching_indices) == 1
+        and matching_indices[0] > 0
+        and stripped_lines[matching_indices[0] - 1].endswith(":")
+    )
+
+
+def _embedded_scalar_parameter_unit(
+    source_rule: dict[str, Any],
+    *,
+    dtype: str,
+) -> str | None:
+    if dtype != str(source_rule.get("dtype") or "").strip():
+        return None
+    unit = source_rule.get("unit")
+    if isinstance(unit, str) and unit.strip():
+        return unit.strip()
+    return None
 
 
 def _source_atom_for_embedded_scalar_parameter(
     source_rule: dict[str, Any],
     *,
     literal: str,
+    source_version_index: int,
     corpus_citation_path: str | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     proof = source_rule.get("metadata", {}).get("proof")
     atoms = proof.get("atoms") if isinstance(proof, dict) else None
     fallback_source: dict[str, Any] | None = None
+    source_path = f"versions[{source_version_index}].formula"
     if isinstance(atoms, list):
         for atom in atoms:
             if not isinstance(atom, dict):
+                continue
+            if atom.get("path") != source_path:
                 continue
             source = atom.get("source")
             if not isinstance(source, dict):
@@ -33477,10 +33742,7 @@ def _source_atom_for_embedded_scalar_parameter(
             "kind": "parameter",
             "source": source,
         }
-    return {
-        "path": "versions[0].formula",
-        "kind": "parameter",
-    }
+    return None
 
 
 def _add_formula_proof_import(
@@ -33488,6 +33750,7 @@ def _add_formula_proof_import(
     *,
     target: str,
     output: str,
+    path: str = "versions[0].formula",
 ) -> None:
     metadata = rule.setdefault("metadata", {})
     if not isinstance(metadata, dict):
@@ -33505,12 +33768,13 @@ def _add_formula_proof_import(
         isinstance(atom, dict)
         and isinstance(atom.get("import"), dict)
         and atom["import"].get("target") == target
+        and atom.get("path") == path
         for atom in atoms
     ):
         return
     atoms.append(
         {
-            "path": "versions[0].formula",
+            "path": path,
             "kind": "import",
             "import": {
                 "target": target,

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1678"
+ENCODER_VERSION = "0.2.1679"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1677"
+ENCODER_VERSION = "0.2.1678"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21363,14 +21363,11 @@ rules:
         )
         assert any(
             atom.get("path") == "versions[1].formula"
-            and atom.get("import", {}).get("output")
-            == "household_credit_scalar_limit"
+            and atom.get("import", {}).get("output") == "household_credit_scalar_limit"
             for atom in derived["metadata"]["proof"]["atoms"]
         )
 
-    def test_embedded_scalar_literal_repair_rejects_incompatible_reuse(
-        self, tmp_path
-    ):
+    def test_embedded_scalar_literal_repair_rejects_incompatible_reuse(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "runner" / "policies" / "credit.yaml"
         rules_file.parent.mkdir(parents=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7684,6 +7684,9 @@ rules:
         rules_file.parent.mkdir(parents=True)
         rules_file.write_text(
             """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-fl/manual/example
 rules:
   - name: benefit
     kind: derived
@@ -20829,6 +20832,7 @@ rules:
         parameter = payload["rules"][1]
         assert parameter["name"] == "snap_standard_deduction_max_household_size"
         assert parameter["kind"] == "parameter"
+        assert parameter["dtype"] == "Count"
         assert parameter["versions"][0]["formula"] == "6"
         derived = payload["rules"][2]
         assert (
@@ -20850,6 +20854,7 @@ rules:
   kind: derived
   entity: Household
   dtype: Money
+  unit: USD
   period: Month
   source: Appendix A-1, Maximum Benefit Effective October 1, 2025
   metadata:
@@ -20873,8 +20878,10 @@ rules:
             policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-fl"),
             issues=[
                 "Embedded scalar literal: maximum_food_assistance_benefit line 10 "
-                "embeds 10 in `assistance_group_size <= 10`; extract the value "
-                "to its own named numeric concept or indexed table/grid value"
+                "embeds 10 in `if assistance_group_size <= 10: "
+                "maximum_food_assistance_benefit_table[assistance_group_size] else: "
+                "maximum_food_assistance_benefit_table[10]`; extract the value to "
+                "its own named numeric concept or indexed table/grid value"
             ],
         )
 
@@ -20882,6 +20889,8 @@ rules:
         payload = yaml.safe_load(rules_file.read_text())
         parameter = payload["rules"][0]
         assert parameter["name"] == "maximum_food_assistance_benefit_scalar_limit"
+        assert parameter["dtype"] == "Count"
+        assert "unit" not in parameter
         atom = parameter["metadata"]["proof"]["atoms"][0]
         assert atom["source"]["corpus_citation_path"] == "us-fl/manual/example"
         assert "Maximum Benefit Effective" in atom["source"]["excerpt"]
@@ -20901,6 +20910,8 @@ rules:
             f"""format: rulespec/v1
 module:
   summary: Tennessee SNAP standards.
+  source_verification:
+    corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
 rules:
 - name: snap_gross_income_standard_for_household
   kind: derived
@@ -20950,6 +20961,8 @@ rules:
             f"""format: rulespec/v1
 module:
   summary: Arizona CCAP income chart.
+  source_verification:
+    corpus_citation_path: us-az/policies/des/ccap/chart
 rules:
 - name: child_care_assistance_fee_level
   kind: derived
@@ -20970,7 +20983,7 @@ rules:
             policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-az"),
             issues=[
                 "Embedded scalar literal: child_care_assistance_fee_level "
-                "line 10 embeds 4 in `4`; extract the value to its own named "
+                f"line 10 embeds 4 in `{formula}`; extract the value to its own named "
                 "numeric concept or indexed table/grid value"
             ],
         )
@@ -21031,6 +21044,7 @@ rules:
         payload = yaml.safe_load(rules_file.read_text())
         parameter = payload["rules"][0]
         assert parameter["name"] == "applicable_income_limitation_rate_scalar_limit"
+        assert parameter["dtype"] == "Rate"
         assert parameter["versions"][0]["formula"] == "1.333333"
         assert (
             parameter["metadata"]["proof"]["atoms"][0]["source"]["excerpt"]
@@ -21088,10 +21102,21 @@ rules:
         )
         rules_file.write_text(
             f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
 rules:
 - name: snap_gross_income_standard_for_household_scalar_limit
   kind: parameter
   dtype: Count
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: Household size 10
   versions:
   - effective_from: '0001-01-01'
     formula: '10'
@@ -21123,7 +21148,7 @@ rules:
             policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-tn"),
             issues=[
                 "Embedded scalar literal: snap_gross_income_standard_for_household "
-                "line 10 embeds 10 in `snap_gross_income_standard[10]`; "
+                f"line 10 embeds 10 in `{formula}`; "
                 "extract the value to its own named numeric concept or indexed "
                 "table/grid value"
             ],
@@ -21147,6 +21172,386 @@ rules:
             == 3
         )
         assert len(derived["metadata"]["proof"]["atoms"]) == 1
+
+    def test_embedded_scalar_literal_repair_infers_money_for_output_leaf(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "credit.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: taxpayer_senior_additional_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  source: KRS 141.020(3)(a)4
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if taxpayer_is_senior: 40 else: 0'
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+        from axiom_encode.harness.validator_pipeline import ValidatorPipeline
+
+        pipeline = ValidatorPipeline(
+            tmp_path,
+            tmp_path,
+            local_corpus_release=None,
+            enable_oracles=False,
+        )
+        issues = pipeline._check_embedded_scalar_literals(rules_file)
+        assert any(
+            "embeds 40 in `if taxpayer_is_senior: 40 else: 0`" in issue
+            for issue in issues
+        )
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=issues,
+        )
+
+        assert repaired == ["taxpayer_senior_additional_credit_scalar_limit"]
+        payload = yaml.safe_load(rules_file.read_text())
+        parameter = payload["rules"][0]
+        assert parameter["dtype"] == "Money"
+        assert parameter["unit"] == "USD"
+        assert parameter["versions"][0]["formula"] == "40"
+
+    def test_embedded_scalar_literal_repair_declines_ambiguous_multiplier(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "tax.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+rules:
+- name: income_tax
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  versions:
+  - effective_from: '2026-01-01'
+    formula: taxable_income * 0.01
+"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: income_tax line 9 embeds 0.01 in "
+                "`taxable_income * 0.01`; extract the value to its own named "
+                "numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_embedded_scalar_literal_repair_declines_mixed_roles(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "credit.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+rules:
+- name: household_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if household_size <= 40: 40 else: 0'
+"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: household_credit line 9 embeds 40 in "
+                "`if household_size <= 40: 40 else: 0`; extract the value to its "
+                "own named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_embedded_scalar_literal_repair_scopes_later_version(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "credit.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: household_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ky/statute/krs/141.020/document-1
+          excerpt: 2025 multiplier 40
+      - path: versions[1].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ky/statute/krs/141.020/document-1
+          excerpt: 2026 credit 40 dollars
+  versions:
+  - effective_from: 2025-01-01
+    effective_to: 2025-12-31
+    formula: taxable_income * 40
+  - effective_from: 2026-01-01
+    effective_to: 2026-12-31
+    formula: 'if eligible: 40 else: 0'
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: household_credit line 13 embeds 40 in "
+                "`if eligible: 40 else: 0`; extract the value to its own named "
+                "numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["household_credit_scalar_limit"]
+        payload = yaml.safe_load(rules_file.read_text())
+        parameter, derived = payload["rules"]
+        assert parameter["dtype"] == "Money"
+        assert parameter["unit"] == "USD"
+        assert parameter["versions"] == [
+            {
+                "effective_from": "2026-01-01",
+                "effective_to": "2026-12-31",
+                "formula": "40",
+            }
+        ]
+        assert (
+            parameter["metadata"]["proof"]["atoms"][0]["source"]["excerpt"]
+            == "2026 credit 40 dollars"
+        )
+        assert derived["versions"][0]["formula"] == "taxable_income * 40"
+        assert (
+            derived["versions"][1]["formula"]
+            == "if eligible: household_credit_scalar_limit else: 0"
+        )
+        assert any(
+            atom.get("path") == "versions[1].formula"
+            and atom.get("import", {}).get("output")
+            == "household_credit_scalar_limit"
+            for atom in derived["metadata"]["proof"]["atoms"]
+        )
+
+    def test_embedded_scalar_literal_repair_rejects_incompatible_reuse(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "credit.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: household_credit_scalar_limit
+  kind: parameter
+  dtype: Count
+  versions:
+  - effective_from: '2025-01-01'
+    effective_to: '2025-12-31'
+    formula: '40'
+  - effective_from: '2026-01-01'
+    formula: '50'
+- name: household_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if eligible: 40 else: 0'
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: household_credit line 19 embeds 40 in "
+                "`if eligible: 40 else: 0`; extract the value to its own named "
+                "numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["household_credit_scalar_limit_2"]
+        payload = yaml.safe_load(rules_file.read_text())
+        old_parameter, new_parameter, derived = payload["rules"]
+        assert old_parameter["dtype"] == "Count"
+        assert new_parameter["dtype"] == "Money"
+        assert new_parameter["unit"] == "USD"
+        assert new_parameter["versions"] == [
+            {"effective_from": "2026-01-01", "formula": "40"}
+        ]
+        assert (
+            derived["versions"][0]["formula"]
+            == "if eligible: household_credit_scalar_limit_2 else: 0"
+        )
+
+    def test_embedded_scalar_literal_repair_replaces_exact_multiline_leaf(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "credit.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: fee_level_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  versions:
+  - effective_from: '2026-01-01'
+    formula: |-
+      if fee_level_40_applies:
+        40
+      else:
+        0
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+        from axiom_encode.harness.validator_pipeline import ValidatorPipeline
+
+        pipeline = ValidatorPipeline(
+            tmp_path,
+            tmp_path,
+            local_corpus_release=None,
+            enable_oracles=False,
+        )
+        issues = pipeline._check_embedded_scalar_literals(rules_file)
+        assert any("embeds 40 in `40`" in issue for issue in issues)
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=issues,
+        )
+
+        assert repaired == ["fee_level_credit_scalar_limit"]
+        payload = yaml.safe_load(rules_file.read_text())
+        parameter, derived = payload["rules"]
+        assert parameter["dtype"] == "Money"
+        formula = derived["versions"][0]["formula"]
+        assert "fee_level_40_applies" in formula
+        assert "fee_level_credit_scalar_limit_applies" not in formula
+        assert "\n  fee_level_credit_scalar_limit\n" in formula
+
+    def test_embedded_scalar_literal_repair_rejects_unrelated_provenance_reuse(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "credit.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: household_credit_scalar_limit
+  kind: parameter
+  dtype: Money
+  unit: USD
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ky/statute/krs/141.020/document-1
+          excerpt: Kentucky 30 dollars in 2025
+      - path: versions[1].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-xx/statute/unrelated
+          excerpt: unrelated 40 dollars
+  versions:
+  - effective_from: '2025-01-01'
+    effective_to: '2025-12-31'
+    formula: '30'
+  - effective_from: '2026-01-01'
+    formula: '40'
+- name: household_credit
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ky/statute/krs/141.020/document-1
+          excerpt: Kentucky credit 40 dollars
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ky:policies/credit#household_credit_scalar_limit
+          output: household_credit_scalar_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if eligible: 40 else: 0'
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        original = rules_file.read_text()
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: household_credit line 32 embeds 40 in "
+                "`if eligible: 40 else: 0`; extract the value to its own named "
+                "numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
 
     def test_bare_snapunit_entity_repair_scopes_assistance_group_to_household(
         self, tmp_path

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1677"
+ENCODER_VERSION = "0.2.1678"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1678"
+ENCODER_VERSION = "0.2.1679"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1677"
+ENCODER_VERSION = "0.2.1678"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1678"
+ENCODER_VERSION = "0.2.1679"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1677"
+ENCODER_VERSION = "0.2.1678"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1678"
+ENCODER_VERSION = "0.2.1679"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1678"
+ENCODER_VERSION = "0.2.1679"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1677"
+ENCODER_VERSION = "0.2.1678"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1678"
+ENCODER_VERSION = "0.2.1679"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1677"
+ENCODER_VERSION = "0.2.1678"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1677"
+ENCODER_VERSION = "0.2.1678"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1678"
+ENCODER_VERSION = "0.2.1679"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1677"')
+        .startswith('__version__ = "0.2.1678"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1677"
+    assert encoder_package["version"] == "0.2.1678"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1677"
+    assert project["project"]["version"] == "0.2.1678"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1677"')
+        .startswith('__version__ = "0.2.1678"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1677"
+    assert encoder_package["version"] == "0.2.1678"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1677"
+    assert project["project"]["version"] == "0.2.1678"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1677"')
+        .startswith('__version__ = "0.2.1678"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1678"')
+        .startswith('__version__ = "0.2.1679"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1678"
+    assert encoder_package["version"] == "0.2.1679"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1678"
+    assert project["project"]["version"] == "0.2.1679"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1678"')
+        .startswith('__version__ = "0.2.1679"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1678"
+    assert encoder_package["version"] == "0.2.1679"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1678"
+    assert project["project"]["version"] == "0.2.1679"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1678"')
+        .startswith('__version__ = "0.2.1679"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1678"
+ENCODER_VERSION = "0.2.1679"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1677"
+ENCODER_VERSION = "0.2.1678"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1678"
+version = "0.2.1679"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1677"
+version = "0.2.1678"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- infer safe numeric types and units for embedded scalar repairs instead of hardcoding Count
- scope replacements, temporal bounds, and proof atoms to the exact validator-reported version and line
- fail closed on ambiguous roles or incompatible parameter provenance

## Validation

- independent review-fix cycle: clean after three rounds
- focused embedded-scalar tests: 13 passed
- full tests/test_cli.py: 1,251 passed, 10 skipped
- Ruff, compileall, and diff checks passed

This does not change dispatching or oracle ownership.