### PR TITLE
Infer embedded comparison scalar types

### DIFF
--- a/changelog.d/embedded-scalar-comparison-type.fixed.md
+++ b/changelog.d/embedded-scalar-comparison-type.fixed.md
@@ -1,0 +1,1 @@
+Infer generated embedded comparison-scalar types and units from uniquely declared local numeric operands while refusing ambiguous, unresolved, arithmetic, or mixed-role cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1679"
+version = "0.2.1680"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1679"
+__version__ = "0.2.1680"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -32179,6 +32179,7 @@ def _try_repair_generated_embedded_scalar_literals_for_apply(
     rules = payload.get("rules")
     if not isinstance(rules, list):
         return []
+    symbol_signatures = _local_numeric_symbol_signatures(payload)
     source_path = _rulespec_module_source_path(payload)
 
     target_anchor = _relative_output_to_anchor(
@@ -32196,6 +32197,7 @@ def _try_repair_generated_embedded_scalar_literals_for_apply(
             target_anchor=target_anchor,
             existing_names=existing_names,
             corpus_citation_path=source_path,
+            symbol_signatures=symbol_signatures,
         )
         if changed:
             repaired.append(changed)
@@ -33184,6 +33186,7 @@ def _extract_embedded_scalar_literal_record(
     target_anchor: str,
     existing_names: set[str],
     corpus_citation_path: str | None = None,
+    symbol_signatures: dict[str, tuple[str, str | None] | None] | None = None,
 ) -> str | None:
     rule_name = record["rule"]
     literal = record["literal"]
@@ -33193,7 +33196,12 @@ def _extract_embedded_scalar_literal_record(
             continue
         if str(rule.get("name") or "").strip() != rule_name:
             continue
-        parameter_name = _embedded_scalar_parameter_name(rule_name, expression)
+        parameter_name = _embedded_scalar_parameter_name(
+            rule_name,
+            expression,
+            literal=literal,
+            symbol_signatures=symbol_signatures or {},
+        )
         if not parameter_name:
             return None
         parameter_formula = (
@@ -33229,18 +33237,16 @@ def _extract_embedded_scalar_literal_record(
             return None
         target_version_index, target_version, replacement = matching_versions[0]
         target_formula = str(target_version.get("formula") or "")
-        parameter_dtype = _embedded_scalar_parameter_dtype(
+        parameter_signature = _embedded_scalar_parameter_signature(
             rule,
             literal=literal,
             expression=expression,
             target_formula=target_formula,
+            symbol_signatures=symbol_signatures or {},
         )
-        if parameter_dtype is None:
+        if parameter_signature is None:
             return None
-        parameter_unit = _embedded_scalar_parameter_unit(
-            rule,
-            dtype=parameter_dtype,
-        )
+        parameter_dtype, parameter_unit = parameter_signature
         existing_parameter_name = _existing_embedded_scalar_parameter_name(
             rules,
             base_name=parameter_name,
@@ -33378,12 +33384,67 @@ def _format_grounded_scalar_formula_literal(value: float) -> str:
     return f"{value:.6f}".rstrip("0").rstrip(".")
 
 
-def _embedded_scalar_parameter_name(rule_name: str, expression: str) -> str | None:
+def _embedded_scalar_parameter_name(
+    rule_name: str,
+    expression: str,
+    *,
+    literal: str | None = None,
+    symbol_signatures: dict[str, tuple[str, str | None] | None] | None = None,
+) -> str | None:
+    if literal is not None and symbol_signatures:
+        comparison_records = _embedded_scalar_comparison_records(
+            expression,
+            literal=literal,
+        )
+        comparison_name = _embedded_scalar_comparison_parameter_name(
+            expression,
+            literal=literal,
+            symbol_signatures=symbol_signatures,
+        )
+        if any(
+            identifier in symbol_signatures
+            for _, identifier, _, _ in comparison_records
+        ):
+            return comparison_name
     if re.search(r"\bmin\s*\(", expression) and rule_name.endswith("_size_category"):
         return f"{rule_name.removesuffix('_size_category')}_max_household_size"
     if re.search(r"\bmax\s*\(", expression):
         return f"{rule_name}_floor"
     return f"{rule_name}_scalar_limit"
+
+
+def _embedded_scalar_comparison_parameter_name(
+    expression: str,
+    *,
+    literal: str,
+    symbol_signatures: dict[str, tuple[str, str | None] | None],
+) -> str | None:
+    records = _embedded_scalar_comparison_records(expression, literal=literal)
+    if not records:
+        return None
+    names: set[str] = set()
+    right_suffix = {
+        ">=": "floor",
+        ">": "lower_threshold",
+        "<=": "ceiling",
+        "<": "upper_threshold",
+        "==": "threshold",
+    }
+    left_suffix = {
+        "<=": "floor",
+        "<": "lower_threshold",
+        ">=": "ceiling",
+        ">": "upper_threshold",
+        "==": "threshold",
+    }
+    for _, identifier, operator, literal_is_left in records:
+        if symbol_signatures.get(identifier) is None:
+            return None
+        suffix = (left_suffix if literal_is_left else right_suffix).get(operator)
+        if suffix is None:
+            return None
+        names.add(f"{identifier}_{suffix}")
+    return next(iter(names)) if len(names) == 1 else None
 
 
 def _existing_embedded_scalar_parameter_name(
@@ -33598,33 +33659,109 @@ def _normalized_rulespec_date(value: Any) -> str | None:
     return None
 
 
-def _embedded_scalar_parameter_dtype(
+_RULESPEC_NUMERIC_DTYPES = {"Count", "Decimal", "Integer", "Money", "Rate"}
+
+
+def _local_numeric_symbol_signatures(
+    payload: dict[str, Any],
+) -> dict[str, tuple[str, str | None] | None]:
+    """Return numeric signatures only for uniquely declared local symbols."""
+    declaration_counts: dict[str, int] = {}
+    numeric_declarations: dict[str, tuple[str, str | None]] = {}
+    for section in ("inputs", "rules"):
+        items = payload.get(section)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name") or "").strip()
+            dtype = str(item.get("dtype") or "").strip()
+            if not name:
+                continue
+            declaration_counts[name] = declaration_counts.get(name, 0) + 1
+            if dtype not in _RULESPEC_NUMERIC_DTYPES:
+                continue
+            unit = str(item.get("unit") or "").strip() or None
+            numeric_declarations[name] = (dtype, unit)
+    return {
+        name: numeric_declarations.get(name) if count == 1 else None
+        for name, count in declaration_counts.items()
+    }
+
+
+def _embedded_scalar_comparison_records(
+    expression: str,
+    *,
+    literal: str,
+) -> list[tuple[tuple[int, int], str, str, bool]]:
+    literal_pattern = rf"(?<![A-Za-z0-9_.]){re.escape(literal)}(?![A-Za-z0-9_.])"
+    identifier_pattern = r"[A-Za-z_][A-Za-z0-9_]*"
+    comparison_boundary = r"(?=\s*(?::|$|\band\b|\bor\b|\)))"
+    patterns = (
+        (
+            rf"(?:^|\b(?:if|and|or)\s+|\(\s*)"
+            rf"(?P<identifier>{identifier_pattern})\s*"
+            rf"(?P<operator><=|>=|==|!=|<|>)\s*"
+            rf"(?P<literal>{literal_pattern}){comparison_boundary}",
+            False,
+        ),
+        (
+            rf"(?:^|\b(?:if|and|or)\s+|\(\s*)"
+            rf"(?P<literal>{literal_pattern})\s*"
+            rf"(?P<operator><=|>=|==|!=|<|>)\s*"
+            rf"(?P<identifier>{identifier_pattern}){comparison_boundary}",
+            True,
+        ),
+    )
+    records: list[tuple[tuple[int, int], str, str, bool]] = []
+    for pattern, literal_is_left in patterns:
+        records.extend(
+            (
+                match.span("literal"),
+                match.group("identifier"),
+                match.group("operator"),
+                literal_is_left,
+            )
+            for match in re.finditer(pattern, expression, flags=re.IGNORECASE)
+        )
+    return records
+
+
+def _embedded_scalar_parameter_signature(
     source_rule: dict[str, Any],
     *,
     literal: str,
     expression: str,
     target_formula: str,
-) -> str | None:
+    symbol_signatures: dict[str, tuple[str, str | None] | None],
+) -> tuple[str, str | None] | None:
     """Infer only scalar types that the formula shape determines safely."""
     normalized_expression = expression.strip()
     source_dtype = str(source_rule.get("dtype") or "").strip()
-    numeric_dtypes = {"Count", "Decimal", "Integer", "Money", "Rate"}
-
-    if source_dtype not in numeric_dtypes:
-        return None
+    source_unit = str(source_rule.get("unit") or "").strip() or None
+    source_signature = (
+        (source_dtype, source_unit)
+        if source_dtype in _RULESPEC_NUMERIC_DTYPES
+        else None
+    )
 
     literal_pattern = rf"(?<![A-Za-z0-9_.]){re.escape(literal)}(?![A-Za-z0-9_.])"
     occurrences = [match.span() for match in re.finditer(literal_pattern, expression)]
     if not occurrences:
         return None
 
+    count_identifier_pattern = (
+        r"(?<![A-Za-z0-9_])"
+        r"(?:[A-Za-z_][A-Za-z0-9_]*_)?(?:count|number|size)\b"
+    )
     count_patterns = (
         rf"\[\s*(?P<literal>{literal_pattern})\s*\]",
-        rf"\b[A-Za-z_][A-Za-z0-9_]*(?:count|number|size)\b\s*"
+        rf"{count_identifier_pattern}\s*"
         rf"(?:<=|<|>=|>|\+|-)\s*(?P<literal>{literal_pattern})",
         rf"(?P<literal>{literal_pattern})\s*(?:<=|<|>=|>|\+|-)\s*"
-        rf"[A-Za-z_][A-Za-z0-9_]*(?:count|number|size)\b",
-        rf"\b(?:min|max)\s*\([^,]*(?:count|number|size)\b\s*,\s*"
+        rf"{count_identifier_pattern}",
+        rf"\b(?:min|max)\s*\([^,]*{count_identifier_pattern}\s*,\s*"
         rf"(?P<literal>{literal_pattern})\s*\)",
     )
     count_spans = {
@@ -33632,6 +33769,16 @@ def _embedded_scalar_parameter_dtype(
         for pattern in count_patterns
         for match in re.finditer(pattern, expression, flags=re.IGNORECASE)
     }
+    comparison_signatures: dict[tuple[int, int], set[tuple[str, str | None]]] = {}
+    comparison_records = _embedded_scalar_comparison_records(
+        expression,
+        literal=literal,
+    )
+    comparison_spans = {span for span, _, _, _ in comparison_records}
+    for span, identifier, _, _ in comparison_records:
+        signature = symbol_signatures.get(identifier)
+        if signature is not None:
+            comparison_signatures.setdefault(span, set()).add(signature)
     output_pattern = (
         rf"(?:^|:|\belse\b)\s*(?P<literal>{literal_pattern})"
         rf"(?=\s*(?:\belse\b|$))"
@@ -33647,25 +33794,48 @@ def _embedded_scalar_parameter_dtype(
     ):
         output_spans = set()
 
-    inferred: set[str] = set()
+    inferred: set[tuple[str, str | None]] = set()
+    inferred_roles: set[str] = set()
+    whole_formula_role = (
+        normalized_expression == literal
+        and target_formula.strip() == normalized_expression
+    ) or (
+        _simple_fraction_expression_value(normalized_expression) is not None
+        and target_formula.strip() == normalized_expression
+    )
     for span in occurrences:
-        occurrence_types: set[str] = set()
-        if span in count_spans:
-            occurrence_types.add("Count")
-        if span in output_spans:
-            occurrence_types.add(source_dtype)
+        occurrence_signatures: set[tuple[str, str | None]] = set()
+        comparison_signature_set = comparison_signatures.get(span, set())
         if (
-            normalized_expression == literal
-            and target_formula.strip() == normalized_expression
-        ) or (
-            _simple_fraction_expression_value(normalized_expression) is not None
-            and target_formula.strip() == normalized_expression
+            span in comparison_spans
+            and not comparison_signature_set
+            and source_signature is None
         ):
-            occurrence_types.add(source_dtype)
-        if len(occurrence_types) != 1:
             return None
-        inferred.update(occurrence_types)
-    return next(iter(inferred)) if len(inferred) == 1 else None
+        if span in count_spans:
+            occurrence_signatures.add(("Count", None))
+            inferred_roles.add("comparison" if comparison_signature_set else "count")
+        if span in output_spans and not whole_formula_role:
+            if source_signature is None:
+                return None
+            occurrence_signatures.add(source_signature)
+            inferred_roles.add("output")
+        if comparison_signature_set:
+            occurrence_signatures.update(comparison_signature_set)
+            inferred_roles.add("comparison")
+        if whole_formula_role:
+            if source_signature is None:
+                return None
+            occurrence_signatures.add(source_signature)
+            inferred_roles.add("whole_formula")
+        if len(occurrence_signatures) != 1:
+            return None
+        inferred.update(occurrence_signatures)
+    return (
+        next(iter(inferred))
+        if len(inferred) == 1 and len(inferred_roles) == 1
+        else None
+    )
 
 
 def _standalone_conditional_leaf_line(formula: str, literal: str) -> bool:
@@ -33678,19 +33848,6 @@ def _standalone_conditional_leaf_line(formula: str, literal: str) -> bool:
         and matching_indices[0] > 0
         and stripped_lines[matching_indices[0] - 1].endswith(":")
     )
-
-
-def _embedded_scalar_parameter_unit(
-    source_rule: dict[str, Any],
-    *,
-    dtype: str,
-) -> str | None:
-    if dtype != str(source_rule.get("dtype") or "").strip():
-        return None
-    unit = source_rule.get("unit")
-    if isinstance(unit, str) and unit.strip():
-        return unit.strip()
-    return None
 
 
 def _source_atom_for_embedded_scalar_parameter(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1679"
+ENCODER_VERSION = "0.2.1680"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21258,6 +21258,541 @@ rules:
         assert repaired == []
         assert rules_file.read_text() == original
 
+    @pytest.mark.parametrize(
+        ("input_dtype", "input_unit", "literal", "expected_dtype", "expected_unit"),
+        [
+            ("Rate", None, "0.80", "Rate", None),
+            ("Money", "USD", "500", "Money", "USD"),
+        ],
+    )
+    def test_embedded_scalar_literal_repair_infers_simple_comparison_operand_type(
+        self,
+        tmp_path,
+        input_dtype,
+        input_unit,
+        literal,
+        expected_dtype,
+        expected_unit,
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        unit = f"\n  unit: {input_unit}" if input_unit else ""
+        rules_file.write_text(
+            f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: threshold_is_met
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  source: KRS 141.020
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if comparison_value >= {literal}: holds else: not_holds'
+inputs:
+- name: comparison_value
+  entity: TaxUnit
+  dtype: {input_dtype}{unit}
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+        expression = f"if comparison_value >= {literal}: holds else: not_holds"
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: threshold_is_met line 10 "
+                f"embeds {literal} in `{expression}`; extract the value to its "
+                "own named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["comparison_value_floor"]
+        payload = yaml.safe_load(rules_file.read_text())
+        parameter, derived = payload["rules"]
+        assert parameter["dtype"] == expected_dtype
+        assert parameter.get("unit") == expected_unit
+        assert parameter["versions"][0]["formula"] == literal
+        assert derived["dtype"] == "Judgment"
+        assert (
+            derived["versions"][0]["formula"]
+            == "if comparison_value >= comparison_value_floor: holds else: not_holds"
+        )
+
+    def test_embedded_scalar_literal_repair_infers_local_rule_comparison_type(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: local_rate
+  kind: parameter
+  dtype: Rate
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '0.75'
+- name: higher_band_applies
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if 0.80 <= local_rate: holds else: not_holds'
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: higher_band_applies line 14 embeds 0.80 "
+                "in `if 0.80 <= local_rate: holds else: not_holds`; extract the "
+                "value to its own named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["local_rate_floor"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["rules"][1]["dtype"] == "Rate"
+
+    @pytest.mark.parametrize(
+        ("rule_name", "rule_dtype", "expression", "extra_inputs"),
+        [
+            (
+                "discount_amount",
+                "Money",
+                "if discount_rate >= 0.80: max(discount_amount, 0) else: 0",
+                """- name: discount_amount
+  dtype: Money
+  unit: USD
+""",
+            ),
+            (
+                "discount_size_category",
+                "Count",
+                "if discount_rate >= 0.80: min(household_size, 8) else: 0",
+                """- name: household_size
+  dtype: Count
+""",
+            ),
+        ],
+    )
+    def test_embedded_scalar_literal_repair_comparison_name_precedes_unrelated_bounds(
+        self,
+        tmp_path,
+        rule_name,
+        rule_dtype,
+        expression,
+        extra_inputs,
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: {rule_name}
+  kind: derived
+  entity: TaxUnit
+  dtype: {rule_dtype}
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '{expression}'
+inputs:
+- name: discount_rate
+  dtype: Rate
+{extra_inputs}"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                f"Embedded scalar literal: {rule_name} line 10 embeds 0.80 in "
+                f"`{expression}`; extract the value to its own named numeric "
+                "concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["discount_rate_floor"]
+        payload = yaml.safe_load(rules_file.read_text())
+        parameter, derived = payload["rules"]
+        assert parameter["name"] == "discount_rate_floor"
+        assert parameter["dtype"] == "Rate"
+        assert derived["versions"][0]["formula"] == expression.replace(
+            "0.80", "discount_rate_floor"
+        )
+
+    def test_embedded_scalar_literal_repair_replaces_repeated_same_type_comparisons(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: either_rate_is_high
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if rate_value >= 0.80 or rate_value >= 0.80: holds else: not_holds'
+inputs:
+- name: rate_value
+  dtype: Rate
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+        expression = (
+            "if rate_value >= 0.80 or rate_value >= 0.80: holds else: not_holds"
+        )
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: either_rate_is_high line 10 embeds 0.80 "
+                f"in `{expression}`; extract the value to its own named numeric "
+                "concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["rate_value_floor"]
+        payload = yaml.safe_load(rules_file.read_text())
+        parameter, derived = payload["rules"]
+        assert parameter["dtype"] == "Rate"
+        assert derived["versions"][0]["formula"].count("rate_value_floor") == 2
+
+    def test_embedded_scalar_literal_repair_extracts_comparison_band(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        expression = (
+            "if later_margin_share_value >= 0.80 "
+            "and later_margin_share_value <= 0.99: holds else: not_holds"
+        )
+        rules_file.write_text(
+            f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: later_band_applies
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  source: KRS 141.020(2)(c)5.b
+  versions:
+  - effective_from: '2027-07-01'
+    formula: '{expression}'
+inputs:
+- name: later_margin_share_value
+  entity: TaxUnit
+  dtype: Rate
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: later_band_applies line 10 embeds 0.80 "
+                f"in `{expression}`; extract the value to its own named numeric "
+                "concept or indexed table/grid value"
+            ],
+        )
+        repaired_expression = expression.replace(
+            "0.80",
+            "later_margin_share_value_floor",
+        )
+        repaired += _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: later_band_applies line 10 embeds 0.99 "
+                f"in `{repaired_expression}`; extract the value to its own named "
+                "numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == [
+            "later_margin_share_value_floor",
+            "later_margin_share_value_ceiling",
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        by_name = {rule["name"]: rule for rule in payload["rules"]}
+        assert by_name["later_margin_share_value_floor"]["dtype"] == "Rate"
+        assert by_name["later_margin_share_value_ceiling"]["dtype"] == "Rate"
+        assert by_name["later_band_applies"]["versions"][0]["formula"] == (
+            "if later_margin_share_value >= later_margin_share_value_floor "
+            "and later_margin_share_value <= later_margin_share_value_ceiling: "
+            "holds else: not_holds"
+        )
+
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            "",
+            """inputs:
+- name: comparison_value
+  dtype: Rate
+- name: comparison_value
+  dtype: Rate
+""",
+            """inputs:
+- name: comparison_value
+  dtype: Rate
+- name: comparison_value
+  dtype: Count
+""",
+        ],
+    )
+    def test_embedded_scalar_literal_repair_declines_nonunique_comparison_operand(
+        self, tmp_path, declaration
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: threshold_is_met
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if comparison_value >= 0.80: holds else: not_holds'
+{declaration}"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: threshold_is_met line 10 embeds 0.80 "
+                "in `if comparison_value >= 0.80: holds else: not_holds`; extract "
+                "the value to its own named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_embedded_scalar_literal_repair_declines_mixed_comparison_signatures(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: threshold_is_met
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if rate_value >= 5 and count_value >= 5: holds else: not_holds'
+inputs:
+- name: rate_value
+  dtype: Rate
+- name: count_value
+  dtype: Count
+"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: threshold_is_met line 10 embeds 5 in "
+                "`if rate_value >= 5 and count_value >= 5: holds else: not_holds`; "
+                "extract the value to its own named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    @pytest.mark.parametrize("operand_name", ["discount", "rate_count"])
+    def test_embedded_scalar_literal_repair_declines_count_heuristic_conflict(
+        self, tmp_path, operand_name
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        expression = f"if {operand_name} >= 0.80: holds else: not_holds"
+        original = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: threshold_is_met
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '{expression}'
+inputs:
+- name: {operand_name}
+  dtype: Rate
+"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: threshold_is_met line 10 embeds 0.80 "
+                f"in `{expression}`; extract the value to its own named numeric "
+                "concept or indexed table/grid value"
+            ],
+        )
+
+        if operand_name == "discount":
+            assert repaired == ["discount_floor"]
+            payload = yaml.safe_load(rules_file.read_text())
+            assert payload["rules"][0]["dtype"] == "Rate"
+        else:
+            assert repaired == []
+            assert rules_file.read_text() == original
+
+    @pytest.mark.parametrize(
+        ("expression", "declaration"),
+        [
+            (
+                "if annual_income + adjustment >= 500: holds else: not_holds",
+                """inputs:
+- name: annual_income
+  dtype: Money
+  unit: USD
+- name: adjustment
+  dtype: Money
+  unit: USD
+""",
+            ),
+            (
+                "if imported_rate >= 0.80: holds else: not_holds",
+                "imports:\n- us-xx:policies/rates\n",
+            ),
+        ],
+    )
+    def test_embedded_scalar_literal_repair_declines_unresolved_comparison_operand(
+        self, tmp_path, expression, declaration
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        literal = "500" if "500" in expression else "0.80"
+        original = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: threshold_is_met
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '{expression}'
+{declaration}"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: threshold_is_met line 10 "
+                f"embeds {literal} in `{expression}`; extract the value to its "
+                "own named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_embedded_scalar_literal_repair_declines_comparison_and_output_roles(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "threshold.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
+rules:
+- name: selected_rate
+  kind: derived
+  entity: TaxUnit
+  dtype: Rate
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if comparison_rate >= 0.80: 0.80 else: 0'
+inputs:
+- name: comparison_rate
+  dtype: Rate
+"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=_canonical_rulespec_content_root(tmp_path, "us-ky"),
+            issues=[
+                "Embedded scalar literal: selected_rate line 10 embeds 0.80 in "
+                "`if comparison_rate >= 0.80: 0.80 else: 0`; extract the value "
+                "to its own named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
     def test_embedded_scalar_literal_repair_declines_mixed_roles(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "runner" / "policies" / "credit.yaml"

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1679"
+ENCODER_VERSION = "0.2.1680"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1679"
+ENCODER_VERSION = "0.2.1680"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1679"
+ENCODER_VERSION = "0.2.1680"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1679"
+ENCODER_VERSION = "0.2.1680"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1679"
+ENCODER_VERSION = "0.2.1680"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1679"
+ENCODER_VERSION = "0.2.1680"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1679"')
+        .startswith('__version__ = "0.2.1680"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1679"
+    assert encoder_package["version"] == "0.2.1680"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1679"
+    assert project["project"]["version"] == "0.2.1680"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1679"')
+        .startswith('__version__ = "0.2.1680"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1679"
+    assert encoder_package["version"] == "0.2.1680"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1679"
+    assert project["project"]["version"] == "0.2.1680"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1679"')
+        .startswith('__version__ = "0.2.1680"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1679"
+ENCODER_VERSION = "0.2.1680"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1679"
+version = "0.2.1680"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- infer an embedded comparison literal dtype and unit from its unique, locally declared numeric operand
- derive durable threshold names from the operand and comparison direction while preserving existing min/max and count repair lanes
- fail closed for unresolved, ambiguous, conflicting, mixed-role, or unsupported comparisons
- bump axiom-encode to 0.2.1680 and add release notes

This is a generic encoder repair. It does not change dispatching, workflows, oracle mappings, or state-specific behavior.

## Validation

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` — 13,283 passed, 123 skipped
- focused embedded-scalar suite — 29 passed

## Review cycle

Three independent reviewers examined semantic safety, adversarial tests, naming-contract compliance, and production scope. Two earlier rounds found and closed count-signature conflict and naming-precedence issues. Round 3 is clean from all three reviewers with no actionable findings.