### PR TITLE
Partition validation waiver audits across CI jobs

### DIFF
--- a/changelog.d/partition-validation-waiver-audit.changed.md
+++ b/changelog.d/partition-validation-waiver-audit.changed.md
@@ -1,0 +1,1 @@
+Allow protected workflows to distribute a validation-waiver audit across a declared job-key manifest while preserving deterministic, exhaustive coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1681"
+version = "0.2.1682"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1680"
+version = "0.2.1681"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1681"
+__version__ = "0.2.1682"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1680"
+__version__ = "0.2.1681"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1693,6 +1693,17 @@ def main():
         help="File containing one repository-relative changed path per line",
     )
     validation_waivers_audit_parser.add_argument(
+        "--partition-key",
+        help="This audit job's key in --partition-keys-json",
+    )
+    validation_waivers_audit_parser.add_argument(
+        "--partition-keys-json",
+        help=(
+            "JSON array of every audit job key; the sorted waiver set is "
+            "distributed exactly once across these keys"
+        ),
+    )
+    validation_waivers_audit_parser.add_argument(
         "--axiom-rules-engine-path",
         dest="axiom_rules_path",
         type=Path,
@@ -4285,6 +4296,41 @@ def _cmd_validation_waivers_active_paths(args) -> int:
     return 0
 
 
+def _validation_waiver_audit_partition(
+    classified: Sequence[tuple[str, str]],
+    *,
+    partition_key: str,
+    partition_keys_json: str,
+) -> tuple[list[tuple[str, str]], int, int]:
+    """Select one deterministic, exhaustive partition of waiver paths."""
+    try:
+        raw_partition_keys = json.loads(partition_keys_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError("--partition-keys-json must be valid JSON") from exc
+    if (
+        not isinstance(raw_partition_keys, list)
+        or not raw_partition_keys
+        or any(not isinstance(key, str) or not key for key in raw_partition_keys)
+    ):
+        raise ValueError(
+            "--partition-keys-json must be a non-empty JSON array of strings"
+        )
+    partition_keys = sorted(raw_partition_keys)
+    if len(set(partition_keys)) != len(partition_keys):
+        raise ValueError("--partition-keys-json must not contain duplicate keys")
+    if partition_key not in partition_keys:
+        raise ValueError(
+            "--partition-key must occur exactly once in --partition-keys-json"
+        )
+    partition_index = partition_keys.index(partition_key)
+    selected = [
+        item
+        for index, item in enumerate(classified)
+        if index % len(partition_keys) == partition_index
+    ]
+    return selected, partition_index, len(partition_keys)
+
+
 def _cmd_validation_waivers_audit(args) -> int:
     root = Path(args.root).resolve()
     if not root.is_dir():
@@ -4335,6 +4381,30 @@ def _cmd_validation_waivers_audit(args) -> int:
     for path in removed_active_paths:
         classified.setdefault(path, "removed")
     classified = dict(sorted(classified.items()))
+
+    partition_key = getattr(args, "partition_key", None)
+    partition_keys_json = getattr(args, "partition_keys_json", None)
+    if (partition_key is None) != (partition_keys_json is None):
+        raise ValueError(
+            "--partition-key and --partition-keys-json must be provided together"
+        )
+    partition: dict[str, Any] | None = None
+    if partition_key is not None:
+        all_classified = list(classified.items())
+        selected, partition_index, partition_count = (
+            _validation_waiver_audit_partition(
+                all_classified,
+                partition_key=partition_key,
+                partition_keys_json=partition_keys_json,
+            )
+        )
+        classified = dict(selected)
+        partition = {
+            "key": partition_key,
+            "index": partition_index,
+            "count": partition_count,
+            "total_paths": len(all_classified),
+        }
 
     deleted_removed: set[str] = set()
     missing_required: set[str] = set()
@@ -4484,6 +4554,8 @@ def _cmd_validation_waivers_audit(args) -> int:
         "results": results,
         "errors": errors,
     }
+    if partition is not None:
+        report["partition"] = partition
     _print_validation_waiver_audit_report(report, as_json=args.json)
     return 0 if report["success"] else 1
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4391,12 +4391,10 @@ def _cmd_validation_waivers_audit(args) -> int:
     partition: dict[str, Any] | None = None
     if partition_key is not None:
         all_classified = list(classified.items())
-        selected, partition_index, partition_count = (
-            _validation_waiver_audit_partition(
-                all_classified,
-                partition_key=partition_key,
-                partition_keys_json=partition_keys_json,
-            )
+        selected, partition_index, partition_count = _validation_waiver_audit_partition(
+            all_classified,
+            partition_key=partition_key,
+            partition_keys_json=partition_keys_json,
         )
         classified = dict(selected)
         partition = {

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1680"
+ENCODER_VERSION = "0.2.1681"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1681"
+ENCODER_VERSION = "0.2.1682"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1681"
+ENCODER_VERSION = "0.2.1682"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1680"
+ENCODER_VERSION = "0.2.1681"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1681"
+ENCODER_VERSION = "0.2.1682"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1680"
+ENCODER_VERSION = "0.2.1681"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1680"
+ENCODER_VERSION = "0.2.1681"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1681"
+ENCODER_VERSION = "0.2.1682"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1681"
+ENCODER_VERSION = "0.2.1682"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1680"
+ENCODER_VERSION = "0.2.1681"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1680"
+ENCODER_VERSION = "0.2.1681"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1681"
+ENCODER_VERSION = "0.2.1682"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1680"
+ENCODER_VERSION = "0.2.1681"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1681"
+ENCODER_VERSION = "0.2.1682"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1680"')
+        .startswith('__version__ = "0.2.1681"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1680"
+    assert encoder_package["version"] == "0.2.1681"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1680"
+    assert project["project"]["version"] == "0.2.1681"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1680"')
+        .startswith('__version__ = "0.2.1681"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1680"
+    assert encoder_package["version"] == "0.2.1681"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1680"
+    assert project["project"]["version"] == "0.2.1681"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1680"')
+        .startswith('__version__ = "0.2.1681"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1681"')
+        .startswith('__version__ = "0.2.1682"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1681"
+    assert encoder_package["version"] == "0.2.1682"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1681"
+    assert project["project"]["version"] == "0.2.1682"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1681"')
+        .startswith('__version__ = "0.2.1682"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1681"
+    assert encoder_package["version"] == "0.2.1682"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1681"
+    assert project["project"]["version"] == "0.2.1682"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1681"')
+        .startswith('__version__ = "0.2.1682"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1680"
+ENCODER_VERSION = "0.2.1681"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1681"
+ENCODER_VERSION = "0.2.1682"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_validation_waiver_audit_cli.py
+++ b/tests/test_validation_waiver_audit_cli.py
@@ -862,6 +862,39 @@ def test_audit_requires_protected_base_and_changed_paths(tmp_path: Path):
         cli._cmd_validation_waivers_audit(args)
 
 
+def test_audit_cli_registers_partition_pair(tmp_path: Path):
+    with (
+        patch(
+            "sys.argv",
+            [
+                "axiom-encode",
+                "validation-waivers",
+                "audit",
+                "--root",
+                str(tmp_path),
+                "--corpus-path",
+                str(tmp_path),
+                "--protected-base",
+                str(tmp_path / "base.yaml"),
+                "--changed-paths",
+                str(tmp_path / "changed.txt"),
+                "--axiom-rules-engine-path",
+                str(tmp_path),
+                "--partition-key",
+                "us-ak",
+                "--partition-keys-json",
+                '["us", "us-ak"]',
+            ],
+        ),
+        patch.object(cli, "cmd_validation_waivers") as command,
+    ):
+        cli.main()
+
+    args = command.call_args.args[0]
+    assert args.partition_key == "us-ak"
+    assert args.partition_keys_json == '["us", "us-ak"]'
+
+
 @pytest.mark.parametrize(
     "argv",
     [

--- a/tests/test_validation_waiver_audit_parallel.py
+++ b/tests/test_validation_waiver_audit_parallel.py
@@ -100,11 +100,14 @@ def test_audit_partitions_are_exhaustive_disjoint_and_order_independent():
     flattened = [item for partition in partitions for item in partition]
     assert sorted(flattened) == classified
     assert len(flattened) == len(set(flattened))
-    assert cli._validation_waiver_audit_partition(
-        classified,
-        partition_key="us-ak",
-        partition_keys_json='["us", "us-ca", "us-ak"]',
-    )[0] == partitions[1]
+    assert (
+        cli._validation_waiver_audit_partition(
+            classified,
+            partition_key="us-ak",
+            partition_keys_json='["us", "us-ca", "us-ak"]',
+        )[0]
+        == partitions[1]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_validation_waiver_audit_parallel.py
+++ b/tests/test_validation_waiver_audit_parallel.py
@@ -86,6 +86,70 @@ def test_worker_count_rejects_invalid_env(monkeypatch, raw):
         cli._waiver_audit_worker_count(100)
 
 
+def test_audit_partitions_are_exhaustive_disjoint_and_order_independent():
+    classified = [(f"us/{index:03d}.yaml", "active") for index in range(17)]
+    keys = '["us-ca", "us-ak", "us"]'
+    partitions = [
+        cli._validation_waiver_audit_partition(
+            classified,
+            partition_key=key,
+            partition_keys_json=keys,
+        )[0]
+        for key in ("us", "us-ak", "us-ca")
+    ]
+    flattened = [item for partition in partitions for item in partition]
+    assert sorted(flattened) == classified
+    assert len(flattened) == len(set(flattened))
+    assert cli._validation_waiver_audit_partition(
+        classified,
+        partition_key="us-ak",
+        partition_keys_json='["us", "us-ca", "us-ak"]',
+    )[0] == partitions[1]
+
+
+@pytest.mark.parametrize(
+    ("key", "keys", "message"),
+    [
+        ("us", "not-json", "valid JSON"),
+        ("us", "[]", "non-empty JSON array"),
+        ("us", '["us", "us"]', "duplicate"),
+        ("us", '["us-ak"]', "occur exactly once"),
+    ],
+)
+def test_audit_partition_rejects_ambiguous_manifests(key, keys, message):
+    with pytest.raises(ValueError, match=message):
+        cli._validation_waiver_audit_partition(
+            [("us/a.yaml", "active")],
+            partition_key=key,
+            partition_keys_json=keys,
+        )
+
+
+@pytest.mark.parametrize(
+    ("partition_key", "partition_keys_json"),
+    [("us", None), (None, '["us"]')],
+)
+def test_audit_rejects_incomplete_partition_arguments(
+    monkeypatch, tmp_path, partition_key, partition_keys_json
+):
+    import yaml as _yaml
+
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    ledger = {"validate_failures": {}}
+    (root / "known-validation-gaps.yaml").write_text(_yaml.safe_dump(ledger))
+    base = tmp_path / "base.yaml"
+    base.write_text(_yaml.safe_dump(ledger))
+    changed = tmp_path / "changed.txt"
+    changed.write_text("")
+    args = _audit_args(tmp_path, root, tmp_path / "c", tmp_path / "e", base, changed)
+    args.partition_key = partition_key
+    args.partition_keys_json = partition_keys_json
+
+    with pytest.raises(ValueError, match="must be provided together"):
+        cli._cmd_validation_waivers_audit(args)
+
+
 def test_single_worker_delegates_to_serial(monkeypatch):
     monkeypatch.setenv(cli._WAIVER_AUDIT_WORKERS_ENV, "1")
     sentinel = [{"path": "us/a.yaml", "passed": False, "fingerprint": "f"}]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1680"
+version = "0.2.1681"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1681"
+version = "0.2.1682"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- adds an optional fail-closed partition manifest to `validation-waivers audit`
- deterministically assigns every sorted waiver path to exactly one declared CI job key
- preserves full transition validation in every job and preserves the existing full audit when partition arguments are absent
- rejects missing, invalid, empty, duplicate, or non-member partition manifests

This lets the shared RuleSpec validation matrix execute the complete signed waiver census across its existing jobs instead of spending six hours in the first shard.

## Security properties

- every declared waiver path is assigned exactly once across the declared key set
- each job loads and validates the complete signed head/base ledgers before selecting its execution subset
- malformed or ambiguous manifests fail closed
- worker result integrity and isolated discrepancy rechecks are unchanged
- single-job and unpartitioned workflows retain full-census behavior

## Review cycle

Independent `codex review --commit 1fee4fbb` found no actionable correctness issues.

## Checks

- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests` — passed
- `uv run --python 3.13 python -m compileall -q src/axiom_encode scripts` — passed
- focused waiver audit and version provenance tests — 63 passed
- broad affected suite — 2,549 passed, 31 skipped; its sole pre-commit failure was the version-provenance check, which passes after commit
- `git diff --check` — passed