### PR TITLE
Isolate all partition audit discrepancies

### DIFF
--- a/changelog.d/partition-audit-isolation.fixed.md
+++ b/changelog.d/partition-audit-isolation.fixed.md
@@ -1,0 +1,1 @@
+Isolate every discrepancy in bounded validation-waiver audit partitions so transient batch-state differences can be rechecked without weakening unpartitioned systemic-failure limits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1682"
+version = "0.2.1683"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1682"
+__version__ = "0.2.1683"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4455,7 +4455,16 @@ def _cmd_validation_waivers_audit(args) -> int:
     # also blow the hosted-runner window, so fail with one explicit
     # systemic error instead of per-row accusations that isolation never
     # confirmed.
-    recheck_budget = max(16, -(-len(executed_by_path) // 100))
+    # A matrix partition is already a bounded slice of the full ledger, so
+    # isolating every discrepancy cannot recreate the multi-thousand-module
+    # serial timeout this cutoff protects against. Preserve the strict budget
+    # for unpartitioned audits, but require exact isolated evidence for every
+    # accusation in a partitioned audit.
+    recheck_budget = (
+        len(executed_by_path)
+        if partition is not None
+        else max(16, -(-len(executed_by_path) // 100))
+    )
     systemic_discrepancy = len(discrepant) > recheck_budget
     if discrepant and not systemic_discrepancy:
         rechecked = _fingerprint_validation_waiver_modules(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1682"
+ENCODER_VERSION = "0.2.1683"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1682"
+ENCODER_VERSION = "0.2.1683"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1682"
+ENCODER_VERSION = "0.2.1683"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1682"
+ENCODER_VERSION = "0.2.1683"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1682"
+ENCODER_VERSION = "0.2.1683"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1682"
+ENCODER_VERSION = "0.2.1683"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1682"
+ENCODER_VERSION = "0.2.1683"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1682"')
+        .startswith('__version__ = "0.2.1683"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1682"
+    assert encoder_package["version"] == "0.2.1683"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1682"
+    assert project["project"]["version"] == "0.2.1683"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1682"')
+        .startswith('__version__ = "0.2.1683"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1682"
+    assert encoder_package["version"] == "0.2.1683"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1682"
+    assert project["project"]["version"] == "0.2.1683"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1682"')
+        .startswith('__version__ = "0.2.1683"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1682"
+ENCODER_VERSION = "0.2.1683"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_validation_waiver_audit_parallel.py
+++ b/tests/test_validation_waiver_audit_parallel.py
@@ -707,3 +707,57 @@ def test_systemic_discrepancy_fails_without_per_row_accusations(
     assert "systemic audit discrepancy" in report["errors"][0]
     assert all(r.get("unverified_discrepancy") for r in report["results"])
     assert not any("error" in r for r in report["results"])
+
+
+def test_partition_rechecks_all_discrepancies_in_isolation(
+    monkeypatch, capsys, tmp_path
+):
+    import json as _json
+
+    monkeypatch.setenv(cli._WAIVER_AUDIT_WORKERS_ENV, "1")
+    fp_good = "sha256:" + "a" * 64
+    fp_bad = "sha256:" + "b" * 64
+    count = 40
+    root = tmp_path / "rulespec-us"
+    (root / "us/statutes").mkdir(parents=True)
+    states = {}
+    for index in range(count):
+        rel = f"us/statutes/m{index:03d}.yaml"
+        (root / rel).write_text("format: rulespec/v1\n")
+        states[rel] = {"active": fp_good}
+    (root / "known-validation-gaps.yaml").write_text(_ledger_for(states, tmp_path))
+    base = tmp_path / "base.yaml"
+    base.write_text(_ledger_for(states, tmp_path))
+    changed = tmp_path / "changed.txt"
+    changed.write_text("")
+
+    def fake_parallel(modules, **kwargs):
+        return [
+            {"path": str(m), "passed": False, "fingerprint": fp_bad, "outcome": {}}
+            for m in modules
+        ]
+
+    serial_calls = []
+
+    def fake_serial(modules, **kwargs):
+        serial_calls.append([str(module) for module in modules])
+        return [
+            {"path": str(m), "passed": False, "fingerprint": fp_good, "outcome": {}}
+            for m in modules
+        ]
+
+    args = _audit_args(tmp_path, root, tmp_path / "c", tmp_path / "e", base, changed)
+    args.json = True
+    args.partition_key = "us"
+    args.partition_keys_json = '["us"]'
+    with (
+        patch.object(
+            cli, "_fingerprint_validation_waiver_modules_parallel", fake_parallel
+        ),
+        patch.object(cli, "_fingerprint_validation_waiver_modules", fake_serial),
+    ):
+        code = cli._cmd_validation_waivers_audit(args)
+    report = _json.loads(capsys.readouterr().out)
+    assert code == 0 and report["success"] is True
+    assert serial_calls == [[f"us/statutes/m{index:03d}.yaml" for index in range(count)]]
+    assert all(row.get("isolated_recheck") for row in report["results"])

--- a/tests/test_validation_waiver_audit_parallel.py
+++ b/tests/test_validation_waiver_audit_parallel.py
@@ -759,5 +759,7 @@ def test_partition_rechecks_all_discrepancies_in_isolation(
         code = cli._cmd_validation_waivers_audit(args)
     report = _json.loads(capsys.readouterr().out)
     assert code == 0 and report["success"] is True
-    assert serial_calls == [[f"us/statutes/m{index:03d}.yaml" for index in range(count)]]
+    assert serial_calls == [
+        [f"us/statutes/m{index:03d}.yaml" for index in range(count)]
+    ]
     assert all(row.get("isolated_recheck") for row in report["results"])

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1682"
+version = "0.2.1683"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

Makes the waiver audit produce exact isolated evidence for bounded matrix partitions. The old systemic cutoff was designed for a 3,000-module monolithic audit and incorrectly suppressed isolation when 17+ of a 60–70 module partition disagreed.

- unpartitioned audits retain the strict systemic cutoff
- partitioned audits may isolate every module in their bounded slice
- partition coverage, transition validation, fingerprints, and verdict rules are unchanged
- adds a regression test proving 40 partition discrepancies are isolated and stable results pass

## Review cycle

Independent review completed after the substantive change and again after the
version-bump correction. No actionable findings remain.

## Checks

- focused waiver-audit suite — 30 passed
- focused post-version suite — 34 passed
- Ruff full source/test check and format check — passed
- compileall — passed
- `git diff --check` — passed

The first full CI run executed 13,415 tests and found only the required version
provenance bump missing (13,340 passed, 74 skipped). This is corrected in
`0.2.1683`; final full CI is rerunning.

Local Python 3.14 dependency bootstrap hit the existing macOS `pyroaring` toolchain build issue; focused checks ran in the repository Python 3.13 environment. CI covers the supported Linux matrix.
