### PR TITLE
Cost controls: failed-attempt budget + per-run spend summary for targeted re-encode CI

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -120,11 +120,57 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  encode:
-    name: Queue protected signed RuleSpec re-encode
+  # Cost damper (axiom-encode#1495): blocks ad hoc re-dispatches of a
+  # citation that keeps failing, before the protected environment consumes
+  # an approval and before any model call. Ad hoc dispatches only — queue
+  # runs skip it entirely so the guard can never stall a tranche, and the
+  # queue machinery owns its own retry policy. Runs unprotected on purpose:
+  # it reads public run history with the read-scoped token and signs
+  # nothing. Tunables are repository variables, not inputs — the dispatch
+  # input list sits at GitHub's hard cap of 25 (pinned by
+  # tests/test_signing_supervisor.py).
+  attempt_budget:
+    name: Enforce failed-attempt budget
     if: >-
       ${{
         github.event_name == 'workflow_dispatch'
+        && github.ref == 'refs/heads/main'
+        && inputs.queue_id == ''
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout axiom-encode
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: axiom-encode
+          persist-credentials: false
+
+      - name: Enforce failed-attempt budget
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CITATION: ${{ inputs.citation }}
+          QUEUE_ID: ${{ inputs.queue_id }}
+          ATTEMPT_BUDGET: ${{ vars.ATTEMPT_BUDGET }}
+          ATTEMPT_BUDGET_OVERRIDE: ${{ vars.ATTEMPT_BUDGET_OVERRIDE }}
+        run: |
+          python3 "$GITHUB_WORKSPACE/axiom-encode/scripts/enforce_attempt_budget.py"
+
+  encode:
+    name: Queue protected signed RuleSpec re-encode
+    needs: attempt_budget
+    # !cancelled() disables the implicit success() gate so a skipped
+    # attempt_budget (queue dispatch) still admits encode; an explicit
+    # failure (budget exhausted) or infrastructure failure of the guard
+    # job blocks only ad hoc runs, which can always be re-dispatched.
+    if: >-
+      ${{
+        !cancelled()
+        && (
+          needs.attempt_budget.result == 'success'
+          || needs.attempt_budget.result == 'skipped'
+        )
+        && github.event_name == 'workflow_dispatch'
         && github.ref == 'refs/heads/main'
         && (
           inputs.queue_id == ''
@@ -1641,6 +1687,19 @@ jobs:
                 "Compose signed source bundle for ${CITATION}"
             fi
           fi
+
+      - name: Summarize model spend
+        id: run_cost_summary
+        # Telemetry only (axiom-encode#1495): prices this run's recorded
+        # usage so spend is visible per run instead of only on the invoice.
+        # Runs on failure too — failed attempts are the expensive case.
+        if: ${{ !cancelled() && steps.encode_apply.outcome != 'skipped' }}
+        env:
+          TRACES_ROOT: ${{ runner.temp }}/generated
+        run: |
+          python3 "$GITHUB_WORKSPACE/axiom-encode/scripts/summarize_run_cost.py" \
+            --traces-root "$TRACES_ROOT" \
+            --pricing "$GITHUB_WORKSPACE/axiom-encode/src/axiom_encode/harness/pricing_rates.toml"
 
       - name: Verify generated provenance
         id: verify_generated_provenance

--- a/changelog.d/1495-attempt-budget-run-cost-telemetry.added.md
+++ b/changelog.d/1495-attempt-budget-run-cost-telemetry.added.md
@@ -1,0 +1,1 @@
+Block ad hoc CI re-dispatches of a citation after repeated encode failures (failed-attempt budget with repository-variable tunables, skipped entirely for queue dispatches), and summarize each targeted re-encode run's model token spend into the workflow step summary, failures included.

--- a/scripts/enforce_attempt_budget.py
+++ b/scripts/enforce_attempt_budget.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Fail-fast budget for repeated failed re-encode dispatches of one citation.
+
+Motivation (axiom-encode#1495): individual citations burned 20-31 targeted
+re-encode runs in a single week at API prices, all of them ad hoc
+dispatches retrying a persistently failing gate. This guard runs as a
+cheap unprotected job before the production-signing environment gate and
+before any model call. When the same citation has already failed
+``attempt_budget`` consecutive times (no intervening success) inside the
+lookback window, an ad hoc dispatch is blocked with triage instructions.
+
+Queue-driven dispatches never reach this script in CI — the
+attempt_budget job's own condition skips them so the guard can never
+stall a tranche. The ``queue_id`` report-only branch below survives as
+defense in depth for odd dispatch paths and local use.
+
+The guard is a cost damper, not a security gate: if the GitHub API cannot
+be reached it fails open with a loud warning. Stdlib-only because it runs
+on a bare runner before any toolchain setup.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+DEFAULT_BUDGET = 3
+DEFAULT_LOOKBACK_DAYS = 7
+# Conclusions that consumed model spend and count against the budget.
+FAILURE_CONCLUSIONS = {"failure", "timed_out"}
+# Conclusions that neither consume budget nor reset the streak.
+NEUTRAL_CONCLUSIONS = {
+    "cancelled",
+    "skipped",
+    "neutral",
+    "action_required",
+    "startup_failure",
+    "stale",
+}
+MAX_RUN_PAGES = 5
+RUNS_PER_PAGE = 100
+# Job name of the protected encode job; a counted failure must have reached
+# it (not skipped) to prove the run actually spent model tokens. Runs this
+# guard itself blocked conclude "failure" with the encode job skipped and
+# must not feed back into the streak.
+ENCODE_JOB_NAME = "Queue protected signed RuleSpec re-encode"
+# At most this many per-run jobs lookups per evaluation; beyond the cap a
+# failure is counted without verification (conservative toward blocking).
+MAX_JOB_LOOKUPS = 10
+
+
+@dataclass
+class Decision:
+    """Outcome of evaluating the failed-attempt streak for a citation."""
+
+    streak: int
+    budget: int
+    counted_runs: list[dict] = field(default_factory=list)
+
+    @property
+    def exhausted(self) -> bool:
+        return self.streak >= self.budget
+
+
+def run_citation(run_name: object) -> str | None:
+    """Extract the citation from a targeted re-encode run name.
+
+    Run names look like ``Targeted signed RuleSpec re-encode
+    [<queue>:<item>:<sha>] <citation>``; citations are corpus paths and
+    never contain ``"] "``, so the segment after the last ``"] "`` is the
+    citation.
+    """
+    if not isinstance(run_name, str) or "] " not in run_name:
+        return None
+    return run_name.rsplit("] ", 1)[-1]
+
+
+def evaluate_attempt_budget(
+    runs: list[dict],
+    *,
+    citation: str,
+    budget: int,
+    current_run_id: int,
+    spent_model_tokens: Callable[[dict], bool] | None = None,
+) -> Decision:
+    """Count consecutive completed failures for ``citation``.
+
+    ``runs`` may arrive in any order; they are sorted newest-first here.
+    The streak counts failure conclusions from the most recent completed
+    run backwards and stops at the first success. Neutral conclusions
+    (cancelled and friends) are skipped without resetting the streak.
+
+    ``spent_model_tokens`` classifies whether a run actually reached the
+    encode job. It filters both directions: failure runs that never
+    reached a model call — above all, runs this guard itself blocked — do
+    not extend the streak, and phantom successes that never ran encode
+    (e.g. a queue run re-run where encode requires attempt 1, leaving
+    only successful/skipped jobs) do not reset it. Both are neutral.
+    """
+    decision = Decision(streak=0, budget=budget)
+    matching = [
+        run
+        for run in runs
+        if run_citation(run.get("name")) == citation
+        and run.get("id") != current_run_id
+        and run.get("status") == "completed"
+    ]
+    matching.sort(key=lambda run: str(run.get("created_at") or ""), reverse=True)
+    for run in matching:
+        conclusion = run.get("conclusion")
+        if conclusion == "success":
+            if spent_model_tokens is not None and not spent_model_tokens(run):
+                continue
+            break
+        if conclusion in NEUTRAL_CONCLUSIONS:
+            continue
+        if conclusion in FAILURE_CONCLUSIONS:
+            if spent_model_tokens is not None and not spent_model_tokens(run):
+                continue
+            decision.streak += 1
+            decision.counted_runs.append(
+                {
+                    "id": run.get("id"),
+                    "created_at": run.get("created_at"),
+                    "conclusion": conclusion,
+                    "html_url": run.get("html_url"),
+                }
+            )
+            continue
+        # Unknown conclusion values are treated as neutral so that new
+        # GitHub statuses cannot spuriously block encodes.
+    return decision
+
+
+def make_encode_job_checker(
+    fetch_jobs: Callable[[int], list[dict]],
+    *,
+    max_lookups: int = MAX_JOB_LOOKUPS,
+    encode_job_name: str = ENCODE_JOB_NAME,
+) -> Callable[[dict], bool]:
+    """Build a ``spent_model_tokens`` classifier backed by the jobs API.
+
+    A run counts as model-spending only when its encode job exists with a
+    non-skipped conclusion. Past ``max_lookups`` (or on lookup errors)
+    the classification is conservative toward blocking in both
+    directions: unverified failures count against the budget and
+    unverified successes stay neutral rather than resetting the streak.
+    Bounded so a long history cannot stall the guard.
+    """
+    lookups = 0
+
+    def _unverified(run: dict) -> bool:
+        return run.get("conclusion") != "success"
+
+    def spent_model_tokens(run: dict) -> bool:
+        nonlocal lookups
+        run_id = run.get("id")
+        if not isinstance(run_id, int) or lookups >= max_lookups:
+            return _unverified(run)
+        lookups += 1
+        try:
+            jobs = fetch_jobs(run_id)
+        except Exception:
+            return _unverified(run)
+        encode_jobs = [
+            job
+            for job in jobs
+            if isinstance(job, dict) and job.get("name") == encode_job_name
+        ]
+        if not encode_jobs:
+            return False
+        return any(job.get("conclusion") != "skipped" for job in encode_jobs)
+
+    return spent_model_tokens
+
+
+def _fetch_completed_runs(
+    *,
+    repo: str,
+    workflow_file: str,
+    token: str,
+    lookback_days: int,
+) -> list[dict]:
+    since = (datetime.now(timezone.utc) - timedelta(days=lookback_days)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    runs: list[dict] = []
+    for page in range(1, MAX_RUN_PAGES + 1):
+        query = urllib.parse.urlencode(
+            {
+                "status": "completed",
+                "created": f">={since}",
+                "per_page": str(RUNS_PER_PAGE),
+                "page": str(page),
+            }
+        )
+        url = (
+            f"https://api.github.com/repos/{repo}/actions/workflows/"
+            f"{workflow_file}/runs?{query}"
+        )
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "axiom-encode-attempt-budget",
+            },
+        )
+        payload = None
+        for attempt in range(2):
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    payload = json.load(response)
+                break
+            except (urllib.error.URLError, TimeoutError, ValueError):
+                if attempt == 0:
+                    time.sleep(2)
+                else:
+                    raise
+        page_runs = (payload or {}).get("workflow_runs") or []
+        runs.extend(run for run in page_runs if isinstance(run, dict))
+        if len(page_runs) < RUNS_PER_PAGE:
+            break
+    return runs
+
+
+def _fetch_run_jobs(*, repo: str, token: str, run_id: int) -> list[dict]:
+    url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=30"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "axiom-encode-attempt-budget",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    jobs = (payload or {}).get("jobs") or []
+    return [job for job in jobs if isinstance(job, dict)]
+
+
+def _append_summary(lines: list[str]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def _render_summary(
+    decision: Decision, *, citation: str, enforced: bool, blocked: bool
+) -> list[str]:
+    lines = ["### Failed-attempt budget", ""]
+    lines.append(
+        f"- Citation: `{citation}` — {decision.streak} consecutive failed "
+        f"run(s) in the lookback window (budget {decision.budget})."
+    )
+    for run in decision.counted_runs:
+        lines.append(
+            f"  - {run.get('created_at')} — {run.get('conclusion')} — "
+            f"{run.get('html_url')}"
+        )
+    if blocked:
+        lines.append(
+            "- **Blocked before the signing environment and any model call.** "
+            "Triage the failing gate first (see axiom-encode#1494 for why "
+            "regeneration alone rarely fixes these). To proceed anyway, set "
+            "the repository variable `ATTEMPT_BUDGET_OVERRIDE` to `true` (or "
+            "raise `ATTEMPT_BUDGET`), re-dispatch, and unset it after triage."
+        )
+    elif not enforced:
+        lines.append(
+            "- Report-only: queue-driven dispatch, or override was set; not blocking."
+        )
+    return lines
+
+
+def main() -> int:
+    citation = os.environ.get("CITATION", "").strip()
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GH_TOKEN", "")
+    workflow_file = os.environ.get("WORKFLOW_FILE", "targeted-signed-reencode.yml")
+    queue_id = os.environ.get("QUEUE_ID", "").strip()
+    override = os.environ.get("ATTEMPT_BUDGET_OVERRIDE", "").strip().lower()
+    try:
+        budget = int(os.environ.get("ATTEMPT_BUDGET", str(DEFAULT_BUDGET)))
+    except ValueError:
+        budget = DEFAULT_BUDGET
+    if budget < 1:
+        budget = DEFAULT_BUDGET
+    try:
+        lookback_days = int(os.environ.get("LOOKBACK_DAYS", str(DEFAULT_LOOKBACK_DAYS)))
+    except ValueError:
+        lookback_days = DEFAULT_LOOKBACK_DAYS
+    try:
+        current_run_id = int(os.environ.get("GITHUB_RUN_ID", "0"))
+    except ValueError:
+        current_run_id = 0
+
+    if not citation or not repo or not token:
+        print(
+            "attempt-budget: missing CITATION/GITHUB_REPOSITORY/GH_TOKEN; "
+            "failing open.",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        runs = _fetch_completed_runs(
+            repo=repo,
+            workflow_file=workflow_file,
+            token=token,
+            lookback_days=lookback_days,
+        )
+    except Exception as error:  # noqa: BLE001 - fail open on API trouble
+        print(
+            f"attempt-budget: could not list workflow runs ({error}); failing open.",
+            file=sys.stderr,
+        )
+        return 0
+
+    decision = evaluate_attempt_budget(
+        runs,
+        citation=citation,
+        budget=budget,
+        current_run_id=current_run_id,
+        spent_model_tokens=make_encode_job_checker(
+            lambda run_id: _fetch_run_jobs(repo=repo, token=token, run_id=run_id)
+        ),
+    )
+    enforced = queue_id == "" and override != "true"
+    blocked = enforced and decision.exhausted
+    print(
+        f"attempt-budget: citation={citation} streak={decision.streak} "
+        f"budget={budget} enforced={enforced} blocked={blocked}"
+    )
+    if decision.counted_runs or blocked or override == "true":
+        _append_summary(
+            _render_summary(
+                decision, citation=citation, enforced=enforced, blocked=blocked
+            )
+        )
+    if override == "true":
+        print("attempt-budget: override set by dispatcher; not blocking.")
+    return 1 if blocked else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/summarize_run_cost.py
+++ b/scripts/summarize_run_cost.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Append a model token/cost summary for one CI encode run to the step summary.
+
+Motivation (axiom-encode#1495): CI encode spend was only attributable
+through billing-email forensics. This script makes every targeted
+re-encode run print what it consumed.
+
+It reads the per-attempt traces the harness writes under
+``<output-root>/**/traces/<runner>/*.json`` — for the OpenAI Responses
+backend the trace carries ``model`` plus the raw response payload under
+``json_result`` (usage keys: ``input_tokens``, ``output_tokens``,
+``input_tokens_details.cached_tokens``,
+``output_tokens_details.reasoning_tokens``) — and prices them with
+``pricing_rates.toml`` from this checkout.
+
+The math intentionally mirrors
+``axiom_encode.harness.pricing.estimate_usage_cost_breakdown``;
+``tests/test_run_cost_summary.py`` pins parity. It is reimplemented here
+stdlib-only because in CI the encode binary is the provisioned
+``/opt/axiom-verification`` runtime, whose pinned checkout may not carry
+current rates, and because this script must run even when the encode step
+failed before the encoder was importable.
+
+Telemetry must never break an encode run: ``main`` always exits 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_PRICING_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "axiom_encode"
+    / "harness"
+    / "pricing_rates.toml"
+)
+
+
+@dataclass(frozen=True)
+class Attempt:
+    """Token usage recorded for one model invocation trace."""
+
+    trace_path: str
+    model: str
+    input_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    output_tokens: int
+    reasoning_tokens: int
+    error: str | None = None
+
+    @property
+    def has_usage(self) -> bool:
+        return any(
+            (
+                self.input_tokens,
+                self.cache_read_tokens,
+                self.cache_creation_tokens,
+                self.output_tokens,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class Rates:
+    """Per-million-token USD rates for one model prefix."""
+
+    input_per_million: float
+    output_per_million: float
+    cache_read_per_million: float
+    cache_create_per_million: float
+
+
+def load_rates(path: Path) -> tuple[dict[str, Rates], dict]:
+    """Load ``pricing_rates.toml`` into prefix-matchable rate entries."""
+    with path.open("rb") as fh:
+        data = tomllib.load(fh)
+    models: dict[str, Rates] = {}
+    for name, raw in (data.get("models") or {}).items():
+        models[name] = Rates(
+            input_per_million=float(raw.get("input_per_million", 0.0)),
+            output_per_million=float(raw.get("output_per_million", 0.0)),
+            cache_read_per_million=float(raw.get("cache_read_per_million", 0.0)),
+            cache_create_per_million=float(raw.get("cache_create_per_million", 0.0)),
+        )
+    meta = {
+        "version": data.get("version"),
+        "effective_date": data.get("effective_date"),
+    }
+    return models, meta
+
+
+def rates_for_model(models: dict[str, Rates], model: str) -> Rates | None:
+    """Exact-then-variant-prefix matching, mirroring ``get_model_pricing``.
+
+    Prefix matches require a ``-`` variant boundary so lexical siblings
+    (e.g. a hypothetical gpt-5.6-solstice) cannot inherit gpt-5.6-sol
+    rates — same rule PR #1492 adopts in the harness, including its fold
+    of the unsuffixed ``gpt-5.6`` API alias onto the Sol model.
+    """
+    normalized = (model or "").strip()
+    if not normalized:
+        return None
+    if normalized == "gpt-5.6":
+        normalized = "gpt-5.6-sol"
+    if normalized in models:
+        return models[normalized]
+    for prefix, rates in models.items():
+        if normalized.startswith(f"{prefix}-"):
+            return rates
+    return None
+
+
+def parse_trace(trace_path: Path) -> Attempt | None:
+    """Parse one trace file into an :class:`Attempt`, or None if unreadable."""
+    try:
+        payload = json.loads(trace_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    model = str(payload.get("model") or "")
+    json_result = payload.get("json_result")
+    usage: dict = {}
+    if isinstance(json_result, dict) and isinstance(json_result.get("usage"), dict):
+        usage = json_result["usage"]
+    elif isinstance(payload.get("usage"), dict):
+        usage = payload["usage"]
+
+    def _int(value: object) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    input_details = usage.get("input_tokens_details")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    output_details = usage.get("output_tokens_details")
+    if not isinstance(output_details, dict):
+        output_details = {}
+    error = None
+    if isinstance(json_result, dict) and isinstance(json_result.get("error"), dict):
+        error = str(json_result["error"].get("message") or "error")
+    return Attempt(
+        trace_path=str(trace_path),
+        model=model,
+        input_tokens=_int(usage.get("input_tokens")),
+        cache_read_tokens=_int(
+            input_details.get("cached_tokens") or usage.get("cache_read_input_tokens")
+        ),
+        cache_creation_tokens=_int(
+            usage.get("cache_creation_input_tokens")
+            or usage.get("cache_write_tokens")
+            or input_details.get("cache_write_tokens")
+        ),
+        output_tokens=_int(usage.get("output_tokens")),
+        reasoning_tokens=_int(output_details.get("reasoning_tokens")),
+        error=error,
+    )
+
+
+def attempt_cost_usd(attempt: Attempt, rates: Rates | None) -> float | None:
+    """Total cost mirroring ``estimate_usage_cost_breakdown``'s total."""
+    if rates is None:
+        return None
+    non_cached_input = max(
+        attempt.input_tokens
+        - attempt.cache_read_tokens
+        - attempt.cache_creation_tokens,
+        0,
+    )
+    return (
+        non_cached_input * rates.input_per_million
+        + attempt.cache_read_tokens * rates.cache_read_per_million
+        + attempt.cache_creation_tokens * rates.cache_create_per_million
+        + attempt.output_tokens * rates.output_per_million
+    ) / 1_000_000
+
+
+def collect_attempts(roots: list[Path]) -> list[Attempt]:
+    attempts: list[Attempt] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for trace_path in sorted(root.rglob("traces/*/*.json")):
+            attempt = parse_trace(trace_path)
+            if attempt is not None:
+                attempts.append(attempt)
+    return attempts
+
+
+def render_markdown(
+    attempts: list[Attempt], models: dict[str, Rates], meta: dict
+) -> tuple[str, float]:
+    """Render the summary table; return (markdown, priced total USD)."""
+    lines = ["### Model spend for this run", ""]
+    if not attempts:
+        lines.append("No model traces found (encode never reached a model call).")
+        return "\n".join(lines) + "\n", 0.0
+    lines.append("| Trace | Model | Input | Cached | Output | Reasoning | Est. USD |")
+    lines.append("|---|---|---:|---:|---:|---:|---:|")
+    total = 0.0
+    unpriced: set[str] = set()
+    for attempt in attempts:
+        cost = attempt_cost_usd(attempt, rates_for_model(models, attempt.model))
+        if cost is None:
+            if attempt.model and attempt.has_usage:
+                unpriced.add(attempt.model)
+            cost_cell = "unpriced"
+        else:
+            total += cost
+            cost_cell = f"{cost:.4f}"
+        label = Path(attempt.trace_path).name
+        if attempt.error:
+            label += " (error)"
+        lines.append(
+            f"| {label} | {attempt.model or '?'} | {attempt.input_tokens:,} "
+            f"| {attempt.cache_read_tokens:,} | {attempt.output_tokens:,} "
+            f"| {attempt.reasoning_tokens:,} | {cost_cell} |"
+        )
+    lines.append("")
+    lines.append(f"**Priced total: ${total:.4f}**")
+    if unpriced:
+        lines.append(
+            "⚠️ Unpriced model(s): "
+            + ", ".join(sorted(unpriced))
+            + " — add rates to `pricing_rates.toml`."
+        )
+    lines.append(
+        f"_Rates v{meta.get('version')} effective {meta.get('effective_date')}; "
+        "estimates from recorded usage, not the provider invoice._"
+    )
+    return "\n".join(lines) + "\n", total
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--traces-root",
+        action="append",
+        default=[],
+        help="Directory tree containing traces/<runner>/*.json (repeatable)",
+    )
+    parser.add_argument(
+        "--pricing",
+        default=str(DEFAULT_PRICING_PATH),
+        help="Path to pricing_rates.toml",
+    )
+    args = parser.parse_args(argv)
+    try:
+        models, meta = load_rates(Path(args.pricing))
+        attempts = collect_attempts([Path(root) for root in args.traces_root])
+        markdown, total = render_markdown(attempts, models, meta)
+        print(markdown)
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(markdown)
+        output_path = os.environ.get("GITHUB_OUTPUT")
+        if output_path:
+            with open(output_path, "a", encoding="utf-8") as fh:
+                fh.write(f"run_cost_usd={total:.4f}\n")
+    except Exception as error:  # noqa: BLE001 - telemetry must not fail runs
+        print(f"run-cost-summary: skipped ({error})", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_attempt_budget.py
+++ b/tests/test_attempt_budget.py
@@ -1,0 +1,436 @@
+"""Tests for the failed-attempt budget guard (axiom-encode#1495)."""
+
+from __future__ import annotations
+
+import pytest
+
+import scripts.enforce_attempt_budget as budget_mod
+from scripts.enforce_attempt_budget import (
+    ENCODE_JOB_NAME,
+    evaluate_attempt_budget,
+    make_encode_job_checker,
+    run_citation,
+)
+
+CITATION = "us-ky/statute/krs/141.020/document-1"
+
+
+def _run(
+    run_id: int,
+    created_at: str,
+    conclusion: str,
+    *,
+    citation: str = CITATION,
+    queue: str = "adhoc:adhoc:adhoc",
+    status: str = "completed",
+) -> dict:
+    return {
+        "id": run_id,
+        "name": f"Targeted signed RuleSpec re-encode [{queue}] {citation}",
+        "created_at": created_at,
+        "status": status,
+        "conclusion": conclusion,
+        "html_url": f"https://github.com/org/repo/actions/runs/{run_id}",
+    }
+
+
+class TestRunCitation:
+    def test_adhoc_run_name(self) -> None:
+        name = f"Targeted signed RuleSpec re-encode [adhoc:adhoc:adhoc] {CITATION}"
+        assert run_citation(name) == CITATION
+
+    def test_queue_run_name(self) -> None:
+        name = f"Targeted signed RuleSpec re-encode [q1:item2:abc123] {CITATION}"
+        assert run_citation(name) == CITATION
+
+    def test_name_without_bracket_separator(self) -> None:
+        assert run_citation("some unrelated run") is None
+
+    def test_non_string_name(self) -> None:
+        assert run_citation(None) is None
+
+
+class TestEvaluateAttemptBudget:
+    def test_consecutive_failures_reach_budget(self) -> None:
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "failure"),
+            _run(3, "2026-08-12T03:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs, citation=CITATION, budget=3, current_run_id=99
+        )
+        assert decision.streak == 3
+        assert decision.exhausted
+        assert [run["id"] for run in decision.counted_runs] == [3, 2, 1]
+
+    def test_success_resets_streak(self) -> None:
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "success"),
+            _run(3, "2026-08-12T03:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs, citation=CITATION, budget=3, current_run_id=99
+        )
+        assert decision.streak == 1
+        assert not decision.exhausted
+
+    def test_cancelled_runs_do_not_break_or_count(self) -> None:
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "cancelled"),
+            _run(3, "2026-08-12T03:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs, citation=CITATION, budget=2, current_run_id=99
+        )
+        assert decision.streak == 2
+        assert decision.exhausted
+
+    def test_timed_out_counts_as_failure(self) -> None:
+        runs = [_run(1, "2026-08-12T01:00:00Z", "timed_out")]
+        decision = evaluate_attempt_budget(
+            runs, citation=CITATION, budget=1, current_run_id=99
+        )
+        assert decision.streak == 1
+        assert decision.exhausted
+
+    def test_unknown_conclusion_is_neutral(self) -> None:
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "some_future_conclusion"),
+            _run(3, "2026-08-12T03:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs, citation=CITATION, budget=3, current_run_id=99
+        )
+        assert decision.streak == 2
+
+    def test_current_run_excluded(self) -> None:
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs, citation=CITATION, budget=2, current_run_id=2
+        )
+        assert decision.streak == 1
+        assert not decision.exhausted
+
+    def test_other_citations_ignored(self) -> None:
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(
+                2,
+                "2026-08-12T02:00:00Z",
+                "failure",
+                citation="us-ms/statute/27-7-5",
+            ),
+        ]
+        decision = evaluate_attempt_budget(
+            runs, citation=CITATION, budget=2, current_run_id=99
+        )
+        assert decision.streak == 1
+
+    def test_incomplete_runs_ignored(self) -> None:
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "", status="in_progress"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs, citation=CITATION, budget=1, current_run_id=99
+        )
+        assert decision.streak == 1
+
+    def test_order_independent_input(self) -> None:
+        runs = [
+            _run(3, "2026-08-12T03:00:00Z", "failure"),
+            _run(1, "2026-08-12T01:00:00Z", "success"),
+            _run(2, "2026-08-12T02:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs, citation=CITATION, budget=3, current_run_id=99
+        )
+        assert decision.streak == 2
+
+    def test_no_matching_runs(self) -> None:
+        decision = evaluate_attempt_budget(
+            [], citation=CITATION, budget=3, current_run_id=99
+        )
+        assert decision.streak == 0
+        assert not decision.exhausted
+
+
+class TestEncodeJobChecker:
+    """Guard-blocked runs must not feed back into the streak."""
+
+    @staticmethod
+    def _jobs_fixture(jobs_by_run: dict[int, list[dict]]):
+        calls: list[int] = []
+
+        def fetch(run_id: int) -> list[dict]:
+            calls.append(run_id)
+            return jobs_by_run[run_id]
+
+        return fetch, calls
+
+    def test_blocked_runs_are_neutral(self) -> None:
+        # Runs 2 and 3 were blocked by the guard itself: run-level failure,
+        # encode job skipped. Only run 1 actually reached the model.
+        fetch, _ = self._jobs_fixture(
+            {
+                1: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
+                2: [{"name": ENCODE_JOB_NAME, "conclusion": "skipped"}],
+                3: [{"name": "Enforce failed-attempt budget", "conclusion": "failure"}],
+            }
+        )
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "failure"),
+            _run(3, "2026-08-12T03:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs,
+            citation=CITATION,
+            budget=3,
+            current_run_id=99,
+            spent_model_tokens=make_encode_job_checker(fetch),
+        )
+        assert decision.streak == 1
+        assert not decision.exhausted
+
+    def test_real_failures_still_count(self) -> None:
+        fetch, _ = self._jobs_fixture(
+            {
+                run_id: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}]
+                for run_id in (1, 2, 3)
+            }
+        )
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "failure"),
+            _run(3, "2026-08-12T03:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs,
+            citation=CITATION,
+            budget=3,
+            current_run_id=99,
+            spent_model_tokens=make_encode_job_checker(fetch),
+        )
+        assert decision.streak == 3
+        assert decision.exhausted
+
+    def test_lookup_cap_counts_conservatively(self) -> None:
+        fetch, calls = self._jobs_fixture(
+            {
+                run_id: [{"name": ENCODE_JOB_NAME, "conclusion": "skipped"}]
+                for run_id in range(1, 6)
+            }
+        )
+        runs = [
+            _run(run_id, f"2026-08-12T0{run_id}:00:00Z", "failure")
+            for run_id in range(1, 6)
+        ]
+        decision = evaluate_attempt_budget(
+            runs,
+            citation=CITATION,
+            budget=3,
+            current_run_id=99,
+            spent_model_tokens=make_encode_job_checker(fetch, max_lookups=2),
+        )
+        # Two newest runs verified as blocked (neutral); the remaining three
+        # count unverified once the cap is hit.
+        assert len(calls) == 2
+        assert decision.streak == 3
+
+    def test_fetch_error_counts_conservatively(self) -> None:
+        def fetch(run_id: int) -> list[dict]:
+            raise RuntimeError("jobs API down")
+
+        runs = [_run(1, "2026-08-12T01:00:00Z", "failure")]
+        decision = evaluate_attempt_budget(
+            runs,
+            citation=CITATION,
+            budget=1,
+            current_run_id=99,
+            spent_model_tokens=make_encode_job_checker(fetch),
+        )
+        assert decision.streak == 1
+
+    def test_unverified_success_past_cap_stays_neutral(self) -> None:
+        # Ten blocked failures (all verified neutral) exhaust the lookup
+        # cap; an unverifiable phantom success below them must not reset
+        # the streak fed by genuine failures further down.
+        jobs_by_run: dict[int, list[dict]] = {
+            run_id: [{"name": ENCODE_JOB_NAME, "conclusion": "skipped"}]
+            for run_id in range(5, 15)
+        }
+        fetch, calls = self._jobs_fixture(jobs_by_run)
+        runs = (
+            # Genuine failures, oldest.
+            [
+                _run(run_id, f"2026-08-12T0{run_id}:00:00Z", "failure")
+                for run_id in (1, 2, 3)
+            ]
+            # Phantom success above them (encode skipped, unverifiable
+            # once the cap is spent).
+            + [_run(4, "2026-08-12T04:00:00Z", "success")]
+            # Ten newest guard-blocked failures that consume the cap.
+            + [
+                _run(run_id, f"2026-08-12T{run_id}:00:00Z", "failure")
+                for run_id in range(5, 15)
+            ]
+        )
+        decision = evaluate_attempt_budget(
+            runs,
+            citation=CITATION,
+            budget=3,
+            current_run_id=99,
+            spent_model_tokens=make_encode_job_checker(fetch, max_lookups=10),
+        )
+        assert len(calls) == 10
+        # Blocked pile neutral, phantom success neutral (unverified),
+        # genuine failures below count unverified: streak reaches budget.
+        assert decision.streak == 3
+        assert decision.exhausted
+
+    def test_phantom_success_does_not_reset_streak(self) -> None:
+        # A queue run re-run: encode requires attempt 1, so attempt 2 has
+        # only successful/skipped jobs and the run concludes "success"
+        # without any encode having succeeded. It must not lift the block.
+        fetch, _ = self._jobs_fixture(
+            {
+                1: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
+                2: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
+                3: [{"name": ENCODE_JOB_NAME, "conclusion": "skipped"}],
+                4: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
+            }
+        )
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "failure"),
+            _run(3, "2026-08-12T03:00:00Z", "success"),
+            _run(4, "2026-08-12T04:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs,
+            citation=CITATION,
+            budget=3,
+            current_run_id=99,
+            spent_model_tokens=make_encode_job_checker(fetch),
+        )
+        assert decision.streak == 3
+        assert decision.exhausted
+
+    def test_real_success_still_resets_streak(self) -> None:
+        fetch, _ = self._jobs_fixture(
+            {
+                1: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
+                2: [{"name": ENCODE_JOB_NAME, "conclusion": "success"}],
+                3: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
+            }
+        )
+        runs = [
+            _run(1, "2026-08-12T01:00:00Z", "failure"),
+            _run(2, "2026-08-12T02:00:00Z", "success"),
+            _run(3, "2026-08-12T03:00:00Z", "failure"),
+        ]
+        decision = evaluate_attempt_budget(
+            runs,
+            citation=CITATION,
+            budget=3,
+            current_run_id=99,
+            spent_model_tokens=make_encode_job_checker(fetch),
+        )
+        assert decision.streak == 1
+        assert not decision.exhausted
+
+
+class TestMainExitContract:
+    """The workflow consumes only main()'s exit code — pin it."""
+
+    FAILING_HISTORY = [
+        _run(run_id, f"2026-08-12T0{run_id}:00:00Z", "failure") for run_id in (1, 2, 3)
+    ]
+
+    def _set_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        queue_id: str = "",
+        override: str = "",
+        budget: str = "",
+    ) -> None:
+        monkeypatch.setenv("CITATION", CITATION)
+        monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
+        monkeypatch.setenv("GH_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_RUN_ID", "99")
+        monkeypatch.setenv("QUEUE_ID", queue_id)
+        monkeypatch.setenv("ATTEMPT_BUDGET_OVERRIDE", override)
+        monkeypatch.setenv("ATTEMPT_BUDGET", budget)
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    def _stub_api(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        runs: list[dict],
+        jobs: list[dict] | None = None,
+    ) -> None:
+        monkeypatch.setattr(budget_mod, "_fetch_completed_runs", lambda **kwargs: runs)
+        monkeypatch.setattr(
+            budget_mod,
+            "_fetch_run_jobs",
+            lambda **kwargs: (
+                jobs
+                if jobs is not None
+                else [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}]
+            ),
+        )
+
+    def test_blocked_adhoc_exits_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._set_env(monkeypatch)
+        self._stub_api(monkeypatch, self.FAILING_HISTORY)
+        assert budget_mod.main() == 1
+
+    def test_queue_dispatch_reports_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._set_env(monkeypatch, queue_id="q-123")
+        self._stub_api(monkeypatch, self.FAILING_HISTORY)
+        assert budget_mod.main() == 0
+
+    def test_override_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._set_env(monkeypatch, override="true")
+        self._stub_api(monkeypatch, self.FAILING_HISTORY)
+        assert budget_mod.main() == 0
+
+    def test_under_budget_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._set_env(monkeypatch)
+        self._stub_api(monkeypatch, self.FAILING_HISTORY[:2])
+        assert budget_mod.main() == 0
+
+    def test_invalid_budget_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._set_env(monkeypatch, budget="not-a-number")
+        self._stub_api(monkeypatch, self.FAILING_HISTORY)
+        assert budget_mod.main() == 1
+
+    def test_api_error_fails_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._set_env(monkeypatch)
+
+        def boom(**kwargs: object) -> list[dict]:
+            raise RuntimeError("api down")
+
+        monkeypatch.setattr(budget_mod, "_fetch_completed_runs", boom)
+        assert budget_mod.main() == 0
+
+    def test_missing_env_fails_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for name in (
+            "CITATION",
+            "GITHUB_REPOSITORY",
+            "GH_TOKEN",
+            "QUEUE_ID",
+            "ATTEMPT_BUDGET",
+            "ATTEMPT_BUDGET_OVERRIDE",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        assert budget_mod.main() == 0

--- a/tests/test_run_cost_summary.py
+++ b/tests/test_run_cost_summary.py
@@ -1,0 +1,283 @@
+"""Tests for the per-run cost summary (axiom-encode#1495).
+
+Includes the parity pin: the standalone script's pricing math must equal
+``axiom_encode.harness.pricing.estimate_usage_cost_breakdown``, and every
+model the harness dispatches by default must have rates on file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from axiom_encode.constants import (
+    DEFAULT_MODEL,
+    DEFAULT_OPENAI_ESCALATION_MODEL,
+    DEFAULT_OPENAI_MODEL,
+)
+from axiom_encode.harness.encoding_db import TokenUsage
+from axiom_encode.harness.pricing import (
+    estimate_usage_cost_breakdown,
+    get_model_pricing,
+)
+from scripts.summarize_run_cost import (
+    DEFAULT_PRICING_PATH,
+    Attempt,
+    attempt_cost_usd,
+    collect_attempts,
+    load_rates,
+    parse_trace,
+    rates_for_model,
+    render_markdown,
+)
+
+
+def _write_trace(
+    root: Path,
+    runner: str,
+    slug: str,
+    *,
+    model: str,
+    input_tokens: int,
+    cached_tokens: int = 0,
+    output_tokens: int = 0,
+    reasoning_tokens: int = 0,
+) -> Path:
+    trace_dir = root / "lane" / "traces" / runner
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "model": model,
+        "json_result": {
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "input_tokens_details": {"cached_tokens": cached_tokens},
+                "output_tokens_details": {"reasoning_tokens": reasoning_tokens},
+            }
+        },
+    }
+    path = trace_dir / f"{slug}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class TestDefaultModelsArePriced:
+    """Model bumps in constants.py must ship pricing rates alongside."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [DEFAULT_OPENAI_MODEL, DEFAULT_OPENAI_ESCALATION_MODEL, DEFAULT_MODEL],
+    )
+    def test_harness_pricing_covers_default_model(self, model: str) -> None:
+        assert get_model_pricing(model) is not None, (
+            f"{model} has no rates in pricing_rates.toml; cost telemetry "
+            "would silently report it as unpriced"
+        )
+
+    @pytest.mark.parametrize(
+        "model",
+        [DEFAULT_OPENAI_MODEL, DEFAULT_OPENAI_ESCALATION_MODEL, DEFAULT_MODEL],
+    )
+    def test_script_rates_cover_default_model(self, model: str) -> None:
+        models, _ = load_rates(DEFAULT_PRICING_PATH)
+        assert rates_for_model(models, model) is not None
+
+
+class TestPricingParity:
+    """Standalone math must match the harness breakdown exactly."""
+
+    @pytest.mark.parametrize(
+        ("model", "usage"),
+        [
+            (
+                "gpt-5.6-terra",
+                TokenUsage(input_tokens=60_793, output_tokens=1_431),
+            ),
+            (
+                "gpt-5.6-sol",
+                TokenUsage(
+                    input_tokens=78_035,
+                    output_tokens=6_126,
+                    cache_read_tokens=12_000,
+                ),
+            ),
+            (
+                "claude-opus-4-6",
+                TokenUsage(
+                    input_tokens=50_000,
+                    output_tokens=2_000,
+                    cache_read_tokens=30_000,
+                    cache_creation_tokens=10_000,
+                ),
+            ),
+        ],
+    )
+    def test_total_matches_harness(self, model: str, usage: TokenUsage) -> None:
+        attempt = Attempt(
+            trace_path="t.json",
+            model=model,
+            input_tokens=usage.input_tokens,
+            cache_read_tokens=usage.cache_read_tokens,
+            cache_creation_tokens=usage.cache_creation_tokens,
+            output_tokens=usage.output_tokens,
+            reasoning_tokens=0,
+        )
+        models, _ = load_rates(DEFAULT_PRICING_PATH)
+        script_total = attempt_cost_usd(attempt, rates_for_model(models, model))
+        harness = estimate_usage_cost_breakdown(model, usage)
+        assert harness is not None
+        assert script_total == pytest.approx(harness.total_cost_usd, abs=1e-12)
+
+    def test_observed_1491_attempts_price_as_expected(self) -> None:
+        """Regression pin against the #1491 measured attempt (zero cache)."""
+        models, _ = load_rates(DEFAULT_PRICING_PATH)
+        terra = Attempt(
+            trace_path="t.json",
+            model="gpt-5.6-terra",
+            input_tokens=60_793,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            output_tokens=1_431,
+            reasoning_tokens=0,
+        )
+        sol = Attempt(
+            trace_path="s.json",
+            model="gpt-5.6-sol",
+            input_tokens=78_035,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            output_tokens=6_126,
+            reasoning_tokens=0,
+        )
+        terra_cost = attempt_cost_usd(terra, rates_for_model(models, terra.model))
+        sol_cost = attempt_cost_usd(sol, rates_for_model(models, sol.model))
+        assert terra_cost == pytest.approx((60_793 * 2.0 + 1_431 * 12.0) / 1e6)
+        assert sol_cost == pytest.approx((78_035 * 5.0 + 6_126 * 30.0) / 1e6)
+
+
+class TestTraceParsing:
+    def test_parse_openai_responses_trace(self, tmp_path: Path) -> None:
+        path = _write_trace(
+            tmp_path,
+            "openai",
+            "us-ky-141-020",
+            model="gpt-5.6-terra",
+            input_tokens=60_793,
+            cached_tokens=100,
+            output_tokens=1_431,
+            reasoning_tokens=900,
+        )
+        attempt = parse_trace(path)
+        assert attempt is not None
+        assert attempt.model == "gpt-5.6-terra"
+        assert attempt.input_tokens == 60_793
+        assert attempt.cache_read_tokens == 100
+        assert attempt.output_tokens == 1_431
+        assert attempt.reasoning_tokens == 900
+
+    def test_parse_error_trace_without_usage(self, tmp_path: Path) -> None:
+        trace_dir = tmp_path / "lane" / "traces" / "openai"
+        trace_dir.mkdir(parents=True)
+        path = trace_dir / "boom.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "model": "gpt-5.6-terra",
+                    "json_result": {"error": {"message": "quota"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        attempt = parse_trace(path)
+        assert attempt is not None
+        assert attempt.error == "quota"
+        assert not attempt.has_usage
+
+    def test_parse_cache_write_tokens_spelling(self, tmp_path: Path) -> None:
+        """PR #1492's explicit-cache traces record writes as cache_write_tokens."""
+        trace_dir = tmp_path / "lane" / "traces" / "openai"
+        trace_dir.mkdir(parents=True)
+        path = trace_dir / "cw.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "model": "gpt-5.6-terra",
+                    "json_result": {
+                        "usage": {
+                            "input_tokens": 1000,
+                            "output_tokens": 10,
+                            "cache_write_tokens": 900,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        attempt = parse_trace(path)
+        assert attempt is not None
+        assert attempt.cache_creation_tokens == 900
+
+    def test_variant_boundary_matching(self) -> None:
+        models, _ = load_rates(DEFAULT_PRICING_PATH)
+        assert rates_for_model(models, "gpt-5.6-sol") is not None
+        assert rates_for_model(models, "gpt-5.6-sol-fast") is not None
+        assert rates_for_model(models, "gpt-5.6-solstice") is None
+        # The unsuffixed API alias folds onto Sol, mirroring PR #1492.
+        assert rates_for_model(models, "gpt-5.6") == rates_for_model(
+            models, "gpt-5.6-sol"
+        )
+
+    def test_parse_rejects_malformed_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("{not json", encoding="utf-8")
+        assert parse_trace(path) is None
+
+    def test_collect_walks_trace_layout(self, tmp_path: Path) -> None:
+        _write_trace(tmp_path, "openai", "a", model="gpt-5.6-terra", input_tokens=10)
+        _write_trace(tmp_path, "openai", "b", model="gpt-5.6-sol", input_tokens=20)
+        attempts = collect_attempts([tmp_path])
+        assert [attempt.model for attempt in attempts] == [
+            "gpt-5.6-terra",
+            "gpt-5.6-sol",
+        ]
+
+    def test_collect_missing_root(self, tmp_path: Path) -> None:
+        assert collect_attempts([tmp_path / "absent"]) == []
+
+
+class TestRendering:
+    def test_render_totals_and_footer(self, tmp_path: Path) -> None:
+        _write_trace(
+            tmp_path,
+            "openai",
+            "a",
+            model="gpt-5.6-terra",
+            input_tokens=1_000_000,
+            output_tokens=0,
+        )
+        models, meta = load_rates(DEFAULT_PRICING_PATH)
+        markdown, total = render_markdown(collect_attempts([tmp_path]), models, meta)
+        assert total == pytest.approx(2.0)
+        assert "Priced total: $2.0000" in markdown
+        assert "Rates v2" in markdown
+
+    def test_render_flags_unpriced_model(self, tmp_path: Path) -> None:
+        _write_trace(
+            tmp_path,
+            "openai",
+            "a",
+            model="model-without-rates",
+            input_tokens=5,
+        )
+        models, meta = load_rates(DEFAULT_PRICING_PATH)
+        markdown, total = render_markdown(collect_attempts([tmp_path]), models, meta)
+        assert total == 0.0
+        assert "Unpriced model(s): model-without-rates" in markdown
+
+    def test_render_no_traces(self) -> None:
+        models, meta = load_rates(DEFAULT_PRICING_PATH)
+        markdown, total = render_markdown([], models, meta)
+        assert "No model traces found" in markdown
+        assert total == 0.0


### PR DESCRIPTION
Implements the dispatch-side levers from #1495: a failed-attempt budget and per-run cost visibility. Rebased on #1492, which landed the terra/sol pricing rates and encoder bump this branch originally carried — the diff is now purely the guard, the telemetry, and their tests.

## What changed

**1. Failed-attempt budget (new `attempt_budget` job)**
- Runs unprotected before the `production-signing` environment gate, so a doomed dispatch fails fast without consuming an approval or a model call. Context: `us-ky/statute/krs/141.020/document-1` ate 31 runs in the week of 8/5–8/12 (#1494 documents 17 consecutive identical-gate failures).
- Blocks an **ad hoc** dispatch when the citation has ≥ budget (default 3) consecutive completed failures in a 7-day window. Streak counting is evidence-based: a counted failure must have actually reached the encode job (capped jobs-API lookups), so runs the guard itself blocked cannot self-feed the streak, and phantom successes (queue re-runs whose encode job was skipped by the attempt-1 requirement) cannot reset it. Past the lookup cap, classification stays conservative toward blocking in both directions.
- **Queue dispatches skip the job entirely** (its `if` requires `queue_id == ''`), and the encode job admits the skipped need via `!cancelled() && (result == 'success' || result == 'skipped')` — guard infrastructure failures can never stall a tranche.
- Tunables are **repository variables** `ATTEMPT_BUDGET` / `ATTEMPT_BUDGET_OVERRIDE` (both created, `3` / `false`), not inputs: the dispatch input list sits at GitHub's hard cap of 25, pinned by `test_signing_supervisor`.
- Fails **open** on GitHub API trouble, loudly: it is a cost damper, not a security gate. All signing/provenance gates untouched.

**2. Per-run cost telemetry ("Summarize model spend" step, `id: run_cost_summary`)**
- Prices the run's recorded Responses usage (the `traces/<runner>/*.json` files the harness already writes) into `GITHUB_STEP_SUMMARY`, on failures too — failed attempts are the expensive case — and exposes `run_cost_usd` as a step output.
- Standalone stdlib script: in CI the encode binary is the provisioned `/opt/axiom-verification` runtime, so the summary can't import the checkout; `TestPricingParity` pins its math to `estimate_usage_cost_breakdown` exactly, including #1492's `cache_write_tokens` spelling, variant-boundary matching, and the bare `gpt-5.6` → sol alias fold.

## Contract safety

- No changes to `.axiom/toolchain.toml`, workflow pins, or CODEOWNERS (.github#39 rule 1). Input count stays exactly 25.
- The queue verifier (`prepare_signed_queue.py::_verify_attempt_one_job`) filters run jobs by the unchanged encode job name before its exactly-one check, so the added name-distinct job does not affect target-evidence verification.
- New tests: 48 (budget semantics incl. blocked-run/phantom-success neutrality and the cap-order scenario, `main()` exit-code contract with stubbed API, trace parsing, pricing parity, default-models-priced pin).

## Review cycle (per repo PR discipline)

Three independent rounds, all findings applied:
- **Round 1** (self-adjudication): guard-blocked runs self-feeding the streak; pagination depth.
- **Round 2** (independent agent, verified against the live API and actionlint): the 25-input `workflow_dispatch` cap (critical — inputs became repo variables), ruff-format drift, phantom-success streak reset, queue-stall isolation via `needs` semantics, dead `GITHUB_OUTPUT` without a step `id`, missing `main()` exit-code tests.
- **Round 3** (independent agent, delta-scoped; confirmed the encode `if` semantics, zero dangling input references, input count 25, and simulated the lookup-cap ordering): stale triage message pointing at removed inputs; optional cap-direction hardening — both applied.

Checks per CLAUDE.md: `ruff check` + `ruff format --check` clean on the changed files; focused suite + full `test (3.13)` green in CI on the pre-rebase equivalent; fresh CI running on this head.

Refs #1495. Context: #1491, #1492, #1493, #1494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
