### PR TITLE
ci: bump signed-apply encoder pin to current main (0.2.1690)

### DIFF
--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -71,7 +71,7 @@ env:
   # wave pin 185b2457). The validate workflow's encode-ref is bumped to the
   # same sha in this PR so the signed PRs' CI verifies manifests with the
   # same encoder generation that produced them.
-  AXIOM_ENCODE_REF: 226be976c12e268e7b319fcfa5ae66a4de97f85b
+  AXIOM_ENCODE_REF: 29b30fb7855c7306d9ead9ddba020dea40f938cc
   AXIOM_RULES_ENGINE_REF: 05eac9d2f89dabe5c6673176260762cef3a58f47
 
 jobs:


### PR DESCRIPTION
One-line pin bump — see commit message. Lockstep rulespec-de bump + DE wave-5 dispatch follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)