### PR TITLE
Fix amendment-document visibility and apply-path grounding hints (unblocks DE §66 signing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1690"
+version = "0.2.1691"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1690"
+__version__ = "0.2.1691"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29075,7 +29075,7 @@ def _run_encode_attempt(
         )
 
     deferred_output_review_contract = getattr(args, "review_contract_json", None)
-    amendment_source_texts: dict[str, str] = {}
+    amendment_source_texts: dict[str, str] | None = None
 
     def _validate_generated_encoding_in_policy_overlay(
         result,
@@ -29085,6 +29085,22 @@ def _run_encode_attempt(
         axiom_rules_path: Path,
         validate_dependents: bool = True,
     ) -> tuple[bool, list[str], dict[Path, str]]:
+        nonlocal amendment_source_texts
+        if amendment_source_texts is None:
+            amendment_source_texts = (
+                {
+                    document.citation_path: document.body
+                    for document in _amendment_documents_visible_in_context_manifest(
+                        source_unit.amendment_documents,
+                        Path(result.context_manifest_file),
+                        expected_manifest_sha256=(
+                            result.context_manifest_sha256 or ""
+                        ),
+                    )
+                }
+                if source_unit.amendment_documents
+                else {}
+            )
         return _run_generated_encoding_overlay_validation(
             result,
             output_root=output_root,
@@ -29173,14 +29189,6 @@ def _run_encode_attempt(
     )
 
     result = results[0]
-    if source_unit.amendment_documents:
-        amendment_source_texts = {
-            document.citation_path: document.body
-            for document in _amendment_documents_visible_in_context_manifest(
-                source_unit.amendment_documents,
-                Path(result.context_manifest_file),
-            )
-        }
     if getattr(args, "repair_candidate_tests_only", False) is True:
         assert initial_retry_candidate is not None
         assert initial_retry_candidate.tests is not None
@@ -59987,6 +59995,7 @@ def _cmd_eval_suite_revalidate_with_signer(args, evidence_signing_key):
             amendment_documents=_amendment_documents_visible_in_context_manifest(
                 source_unit.amendment_documents,
                 Path(result.context_manifest_file),
+                expected_manifest_sha256=result.context_manifest_sha256 or "",
             ),
         )
         validation_error = _eval_artifact_validation_error(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29075,6 +29075,7 @@ def _run_encode_attempt(
         )
 
     deferred_output_review_contract = getattr(args, "review_contract_json", None)
+    amendment_source_texts: dict[str, str] = {}
 
     def _validate_generated_encoding_in_policy_overlay(
         result,
@@ -29096,6 +29097,7 @@ def _run_encode_attempt(
                 getattr(args, "require_complete_source_unit", False) is True
             ),
             deferred_output_review_contract=deferred_output_review_contract,
+            amendment_source_texts=amendment_source_texts,
         )
 
     skip_reviewers = bool(getattr(args, "skip_reviewers", False))
@@ -29171,6 +29173,14 @@ def _run_encode_attempt(
     )
 
     result = results[0]
+    if source_unit.amendment_documents:
+        amendment_source_texts = {
+            document.citation_path: document.body
+            for document in _amendment_documents_visible_in_context_manifest(
+                source_unit.amendment_documents,
+                Path(result.context_manifest_file),
+            )
+        }
     if getattr(args, "repair_candidate_tests_only", False) is True:
         assert initial_retry_candidate is not None
         assert initial_retry_candidate.tests is not None
@@ -53992,6 +54002,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
     rulespec_dependency_roots: Sequence[Path] = (),
     require_complete_source_unit: bool = False,
     deferred_output_review_contract: _DeferredOutputReviewContract | None = None,
+    amendment_source_texts: Mapping[str, str] | None = None,
 ) -> tuple[bool, list[str], dict[Path, str]]:
     """Validate generated artifacts in a temporary policy-repo overlay."""
     setattr(result, _APPLY_VALIDATION_SNAPSHOT_ATTR, None)
@@ -54245,6 +54256,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             local_corpus_release=local_corpus_release,
             rulespec_dependency_roots=staged_dependency_roots,
             source_metadata=source_metadata,
+            amendment_source_texts=amendment_source_texts,
             require_complete_source_unit=require_complete_source_unit,
             existing_target_oracle_contract=existing_target_oracle_contract,
         )
@@ -54816,6 +54828,7 @@ def _run_generated_encoding_overlay_validation(
     rulespec_dependency_roots: Sequence[Path] = (),
     require_complete_source_unit: bool = False,
     deferred_output_review_contract: _DeferredOutputReviewContract | None = None,
+    amendment_source_texts: Mapping[str, str] | None = None,
 ) -> tuple[bool, list[str], dict[Path, str]]:
     """Dispatch a release-bound overlay run through the patchable test seam."""
 
@@ -54829,6 +54842,7 @@ def _run_generated_encoding_overlay_validation(
         rulespec_dependency_roots=rulespec_dependency_roots,
         require_complete_source_unit=require_complete_source_unit,
         deferred_output_review_contract=deferred_output_review_contract,
+        amendment_source_texts=amendment_source_texts,
     )
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29093,9 +29093,7 @@ def _run_encode_attempt(
                     for document in _amendment_documents_visible_in_context_manifest(
                         source_unit.amendment_documents,
                         Path(result.context_manifest_file),
-                        expected_manifest_sha256=(
-                            result.context_manifest_sha256 or ""
-                        ),
+                        expected_manifest_sha256=(result.context_manifest_sha256 or ""),
                     )
                 }
                 if source_unit.amendment_documents

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -20,7 +20,7 @@ import unicodedata
 import uuid
 from collections import Counter, defaultdict
 from contextvars import ContextVar
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import date, datetime, timezone
 from pathlib import Path
 from statistics import mean
@@ -995,15 +995,28 @@ class CorpusAmendmentDocument:
 def _amendment_documents_visible_in_context_manifest(
     amendment_documents: Sequence[CorpusAmendmentDocument],
     manifest_file: Path,
+    *,
+    expected_manifest_sha256: str,
 ) -> tuple[CorpusAmendmentDocument, ...]:
-    """Recover the amendment evidence actually visible to a persisted eval."""
+    """Recover only amendment body text actually visible to a persisted eval."""
 
+    manifest_path = Path(manifest_file)
     try:
-        payload = json.loads(Path(manifest_file).read_text())
-    except (OSError, json.JSONDecodeError) as exc:
+        manifest_raw = _corpus_resolver.read_bounded_regular_file(
+            manifest_path.parent,
+            manifest_path,
+            label="eval context manifest",
+            max_bytes=32 * 1024 * 1024,
+        )
+        payload = json.loads(manifest_raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError(
             f"Eval context manifest is unreadable or malformed: {manifest_file}"
         ) from exc
+    if not re.fullmatch(r"[0-9a-f]{64}", str(expected_manifest_sha256)):
+        raise ValueError("Eval context manifest digest is missing or invalid")
+    if hashlib.sha256(manifest_raw).hexdigest() != expected_manifest_sha256:
+        raise ValueError("Eval context manifest digest does not match the result")
     if not isinstance(payload, dict):
         raise ValueError(f"Eval context manifest must be an object: {manifest_file}")
     context_files = payload.get("context_files", [])
@@ -1055,8 +1068,36 @@ def _amendment_documents_visible_in_context_manifest(
                 "Eval context manifest admits an unknown amendment citation path "
                 f"{citation_path!r}"
             )
+        workspace_path = item.get("workspace_path")
+        if not isinstance(workspace_path, str) or not workspace_path:
+            raise ValueError(
+                "Eval context manifest amendment item lacks workspace_path: "
+                f"{manifest_file}"
+            )
+        context_path = manifest_path.parent / workspace_path
+        try:
+            context_raw = _corpus_resolver.read_bounded_regular_file(
+                manifest_path.parent,
+                context_path,
+                label=f"eval amendment context {citation_path}",
+                max_bytes=128 * 1024,
+            )
+            context_text = context_raw.decode("utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise ValueError(
+                f"Eval amendment context is unreadable: {context_path}"
+            ) from exc
+        if not context_text.endswith("\n"):
+            raise ValueError(
+                f"Eval amendment context lacks its materialized newline: {context_path}"
+            )
+        visible_body = _visible_amendment_body_from_rendered_text(
+            document,
+            context_text[:-1],
+        )
         seen.add(citation_path)
-        visible.append(document)
+        if visible_body:
+            visible.append(replace(document, body=visible_body))
     return tuple(visible)
 
 
@@ -1708,6 +1749,15 @@ _PROVISION_METADATA_LIMIT = 6_000
 _AMENDMENT_BODY_LIMIT = 12_000
 _INJECTED_CONTEXT_LIMIT = 32_000
 _AMENDMENT_CONTEXT_SEPARATOR = "\n\n"
+_AMENDMENT_BODY_OMITTED_MARKER = (
+    "[body omitted: exceeds 12000-character amendment context cap]"
+)
+_AMENDMENT_BODY_TRUNCATED_MARKER = (
+    "... [amendment body truncated to satisfy aggregate context cap]"
+)
+_AMENDMENT_CONTEXT_TRUNCATED_MARKER = (
+    "... [amendment context truncated at aggregate context cap]"
+)
 _MECHANICAL_METADATA_KEYS = {
     "block_count",
     "content_type",
@@ -2185,13 +2235,58 @@ def _render_amendment_document(
         body = (
             document.body
             if len(document.body) <= _AMENDMENT_BODY_LIMIT
-            else "[body omitted: exceeds 12000-character amendment context cap]"
+            else _AMENDMENT_BODY_OMITTED_MARKER
         )
     return (
         f"Title: {document.title}\n"
         f"Corpus citation path: {document.citation_path}\n"
         f"Expression date: {document.expression_date or 'unknown'}\n"
         f"Metadata:\n{metadata}\n\nBody:\n{body}"
+    )
+
+
+def _visible_amendment_body_from_rendered_text(
+    document: CorpusAmendmentDocument,
+    rendered_text: str,
+) -> str | None:
+    """Authenticate and recover the exact body prefix exposed to the model."""
+
+    full_render = _render_amendment_document(document, body=document.body)
+    if rendered_text == full_render:
+        return document.body
+
+    omitted_render = _render_amendment_document(
+        document,
+        body=_AMENDMENT_BODY_OMITTED_MARKER,
+    )
+    if rendered_text == omitted_render:
+        return None
+
+    body_prefix = _render_amendment_document(document, body="")
+    if not rendered_text.startswith(body_prefix):
+        if rendered_text.endswith(_AMENDMENT_CONTEXT_TRUNCATED_MARKER):
+            return None
+        raise ValueError(
+            "Eval amendment context header does not match discovered corpus document "
+            f"{document.citation_path!r}"
+        )
+    rendered_body = rendered_text[len(body_prefix) :]
+    for marker in (
+        _AMENDMENT_BODY_TRUNCATED_MARKER,
+        _AMENDMENT_CONTEXT_TRUNCATED_MARKER,
+    ):
+        if not rendered_body.endswith(marker):
+            continue
+        visible_prefix = rendered_body[: -len(marker)]
+        if not document.body.startswith(visible_prefix):
+            raise ValueError(
+                "Eval amendment context body does not match discovered corpus document "
+                f"{document.citation_path!r}"
+            )
+        return visible_prefix or None
+    raise ValueError(
+        "Eval amendment context body does not match discovered corpus document "
+        f"{document.citation_path!r}"
     )
 
 
@@ -2223,7 +2318,7 @@ def _render_legacy_name_tier_context(
         }
         for document in amendment_documents[2:]
     )
-    marker = "... [amendment body truncated to satisfy aggregate context cap]"
+    marker = _AMENDMENT_BODY_TRUNCATED_MARKER
     for index in range(len(documents) - 1, -1, -1):
         if overflow <= 0:
             break
@@ -2241,7 +2336,7 @@ def _render_legacy_name_tier_context(
         )
         overflow -= old_length - len(rendered[index])
     if overflow > 0:
-        fallback_marker = "... [amendment context truncated at aggregate context cap]"
+        fallback_marker = _AMENDMENT_CONTEXT_TRUNCATED_MARKER
         for index in range(len(rendered) - 1, -1, -1):
             if overflow <= 0:
                 break
@@ -2279,9 +2374,23 @@ def _render_injected_context(
             provision_metadata,
             amendment_documents,
         )
+        visible_documents = tuple(
+            replace(
+                document,
+                body=(
+                    _visible_amendment_body_from_rendered_text(document, rendered_text)
+                    or ""
+                ),
+            )
+            for document, rendered_text in zip(
+                amendment_documents[:2],
+                amendment_texts,
+                strict=True,
+            )
+        )
         return _RenderedInjectedContext(
             provision_text=provision_text,
-            amendment_documents=tuple(amendment_documents[:2]),
+            amendment_documents=visible_documents,
             amendment_texts=tuple(amendment_texts),
             dropped_amendment_documents=dropped,
         )
@@ -2299,9 +2408,7 @@ def _render_injected_context(
                 body=(
                     document.body
                     if len(document.body) <= _AMENDMENT_BODY_LIMIT
-                    else (
-                        "[body omitted: exceeds 12000-character amendment context cap]"
-                    )
+                    else _AMENDMENT_BODY_OMITTED_MARKER
                 ),
             ),
         )
@@ -2350,7 +2457,16 @@ def _render_injected_context(
         raise AssertionError("Structured amendment context cap was not enforced")
     return _RenderedInjectedContext(
         provision_text=provision_text,
-        amendment_documents=tuple(document for document, _ in retained),
+        amendment_documents=tuple(
+            replace(
+                document,
+                body=(
+                    _visible_amendment_body_from_rendered_text(document, rendered_text)
+                    or ""
+                ),
+            )
+            for document, rendered_text in retained
+        ),
         amendment_texts=tuple(text for _, text in retained),
         dropped_amendment_documents=tuple(dropped),
     )
@@ -4519,6 +4635,7 @@ def _revalidate_persisted_eval_suite_case_results(
                 amendment_documents=_amendment_documents_visible_in_context_manifest(
                     source_unit.amendment_documents,
                     Path(result.context_manifest_file),
+                    expected_manifest_sha256=result.context_manifest_sha256 or "",
                 ),
             )
         fresh_success = bool(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2151,9 +2151,9 @@ def _discover_amendment_documents(
     # Legal-time-slice encoding needs the complete amendment timeline (including
     # both in-force amendments and forward-dated overlays), so the old two-act
     # cap remains only a false-positive guard for name-tier discovery. The 12k
-    # per-body and 32k aggregate byte caps are the volume bounds for structured
-    # evidence; name matches may fill only the legacy two-document allowance and
-    # can never displace structured context.
+    # per-body character cap and 32k aggregate byte cap are the volume bounds for
+    # structured evidence; name matches may fill only the legacy two-document
+    # allowance and can never displace structured context.
     selected_rows = (
         structured_candidates
         + name_candidates[: max(0, 2 - len(structured_candidates))]
@@ -2298,7 +2298,7 @@ def _render_injected_context(
                 document,
                 body=(
                     document.body
-                    if utf8_size(document.body) <= _AMENDMENT_BODY_LIMIT
+                    if len(document.body) <= _AMENDMENT_BODY_LIMIT
                     else (
                         "[body omitted: exceeds 12000-character amendment context cap]"
                     )

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -15007,7 +15007,9 @@ def _companion_test_issues(
             "pre-rounding derived amount to 100.49 -> 100 and 100.50 -> 101; "
             "assert both the reached unrounded intermediate and the affected "
             "principal output in each case."
-            if any(direction == "nearest" for _branch, direction in missing_rounding_tests)
+            if any(
+                direction == "nearest" for _branch, direction in missing_rounding_tests
+            )
             else ""
         )
         issues.append(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -15001,10 +15001,20 @@ def _companion_test_issues(
             _branch_citation(corpus_citation_path, branch)
             for branch, _direction in missing_rounding_tests
         )
+        nearest_guidance = (
+            " A satisfying nearest/kaufmännisch shape is same-period paired "
+            "cases with otherwise-identical inputs that drive the executed "
+            "pre-rounding derived amount to 100.49 -> 100 and 100.50 -> 101; "
+            "assert both the reached unrounded intermediate and the affected "
+            "principal output in each case."
+            if any(direction == "nearest" for _branch, direction in missing_rounding_tests)
+            else ""
+        )
         issues.append(
             "[complete-source-unit:tests] Companion tests do not demonstrate "
             "every source-stated rounding rule with distinct fractional input "
             f"evidence on its affected principal output; missing at {rendered}."
+            f"{nearest_guidance}"
         )
     return issues
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -9178,7 +9178,7 @@ def _attached_amendment_ungrounded_literal_hint(
         "the exact owning literal `path` (for a scalar parameter, for example, "
         "`path: versions[0].formula`), an appropriate `kind`, and nested "
         f"`source: {{corpus_citation_path: {citations[0]}, excerpt: <exact "
-        "verbatim source span>}}`."
+        "verbatim source span>}`."
     )
 
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1690"
+ENCODER_VERSION = "0.2.1691"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -318,6 +318,7 @@ from axiom_encode.harness.evals import (
     _bind_eval_result_payload,
     _build_eval_suite_manifest_identity,
     _eval_result_from_payload,
+    _render_amendment_document,
     _signed_eval_result_verdict_evidence_payload,
     load_eval_suite_manifest,
     resolve_corpus_source_unit,
@@ -4602,6 +4603,23 @@ class TestCmdEvalSuiteRevalidate:
         trace_file = source_output / "trace.json"
         context_manifest_file = source_output / "context.json"
         trace_file.write_text("{}\n")
+        visible_amendment = CorpusAmendmentDocument(
+            citation_path="us/statute/amendment-visible",
+            title="Visible amendment",
+            expression_date="2026-01-01",
+            metadata={},
+            body="Visible amendment body.",
+            match_tier="structured",
+        )
+        amendment_context_file = source_output / "context/amendment-act-1.txt"
+        amendment_context_file.parent.mkdir()
+        amendment_context_file.write_text(
+            _render_amendment_document(
+                visible_amendment,
+                body=visible_amendment.body,
+            )
+            + "\n"
+        )
         context_manifest_file.write_text(
             json.dumps(
                 {
@@ -19624,6 +19642,16 @@ rules: []
                 "reason": "aggregate_context_limit",
             }
         ]
+        amendment_context_file = manifest_path.parent / "context/amendment-act-1.txt"
+        amendment_context_file.parent.mkdir()
+        visible_amendment = source_unit.amendment_documents[0]
+        amendment_context_file.write_text(
+            _render_amendment_document(
+                visible_amendment,
+                body=visible_amendment.body,
+            )
+            + "\n"
+        )
         manifest_path.write_text(json.dumps(manifest) + "\n")
         result.context_manifest_sha256 = hashlib.sha256(
             manifest_path.read_bytes()
@@ -33467,9 +33495,39 @@ rules: []
         output_file.parent.mkdir(parents=True)
         output_file.write_text("format: rulespec/v1\nrules: []\n")
         result.output_file = str(output_file)
+        original_source_unit = resolve_corpus_source_unit(
+            args.citation,
+            args.corpus_release,
+        )
+        source_unit = CorpusSourceUnit(
+            requested=original_source_unit.requested,
+            citation_path=original_source_unit.citation_path,
+            body=original_source_unit.body,
+            source=original_source_unit.source,
+            source_attestation=original_source_unit.source_attestation,
+            resolved_source=original_source_unit.resolved_source,
+            provision_metadata=original_source_unit.provision_metadata,
+            amendment_documents=(
+                CorpusAmendmentDocument(
+                    citation_path="us/statute/amendment-visible",
+                    title="Visible amendment",
+                    expression_date="2026-01-01",
+                    metadata={},
+                    body="Visible amendment body.",
+                    match_tier="structured",
+                ),
+            ),
+        )
 
         with (
+            patch(
+                "axiom_encode.cli.resolve_corpus_source_unit",
+                return_value=source_unit,
+            ),
             patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._amendment_documents_visible_in_context_manifest"
+            ) as amendment_visibility,
             patch(
                 "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
                 return_value=(True, [], {}),
@@ -33487,6 +33545,7 @@ rules: []
         assert exc_info.value.code == 1
         output = capsys.readouterr().out
         assert "apply=blocked_generation:backend timed out" in output
+        amendment_visibility.assert_not_called()
         mock_overlay.assert_not_called()
         mock_apply.assert_not_called()
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19556,6 +19556,110 @@ rules: []
             "encode_issue",
         ]
 
+    def test_estg_66_apply_passes_only_prompt_visible_amendment_texts(self, tmp_path):
+        amendment_citation = (
+            "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+        )
+        amendment_sentence = (
+            "In § 66 Absatz 1 wird die Angabe „250 Euro“ durch die Angabe "
+            "„255 Euro“ ersetzt."
+        )
+        dropped_citation = "de/statute/bgbl-2023-i-999/document-1"
+        args = self._make_args(
+            tmp_path,
+            backend="codex",
+            citation="de/statute/estg/66",
+            policy_repo_path=tmp_path / "rulespec-de",
+        )
+        args.apply = True
+        original_source_unit = resolve_corpus_source_unit(
+            args.citation,
+            args.corpus_release,
+        )
+        source_unit = CorpusSourceUnit(
+            requested=original_source_unit.requested,
+            citation_path=original_source_unit.citation_path,
+            body=original_source_unit.body,
+            source=original_source_unit.source,
+            source_attestation=original_source_unit.source_attestation,
+            resolved_source=original_source_unit.resolved_source,
+            provision_metadata=original_source_unit.provision_metadata,
+            amendment_documents=(
+                CorpusAmendmentDocument(
+                    citation_path=amendment_citation,
+                    title="Steuerfortentwicklungsgesetz – SteFeG",
+                    expression_date="2024-12-23",
+                    metadata={},
+                    body=amendment_sentence,
+                    match_tier="structured",
+                ),
+                CorpusAmendmentDocument(
+                    citation_path=dropped_citation,
+                    title="Dropped amendment",
+                    expression_date="2023-01-01",
+                    metadata={},
+                    body="A dropped amendment containing 255.",
+                    match_tier="structured",
+                ),
+            ),
+        )
+        result = self._make_eval_result(True)
+        result.citation = args.citation
+        output_file = args.output / result.runner / "statutes/estg/66.yaml"
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text("format: rulespec/v1\nrules: []\n")
+        result.output_file = str(output_file)
+        manifest_path = Path(result.context_manifest_file)
+        manifest = json.loads(manifest_path.read_text())
+        manifest["context_files"] = [
+            {
+                "kind": "corpus_amendment_act",
+                "citation_path": amendment_citation,
+                "workspace_path": "context/amendment-act-1.txt",
+            }
+        ]
+        manifest["dropped_amendment_documents"] = [
+            {
+                "citation_path": dropped_citation,
+                "reason": "aggregate_context_limit",
+            }
+        ]
+        manifest_path.write_text(json.dumps(manifest) + "\n")
+        result.context_manifest_sha256 = hashlib.sha256(
+            manifest_path.read_bytes()
+        ).hexdigest()
+
+        with (
+            patch(
+                "axiom_encode.cli.resolve_corpus_source_unit",
+                return_value=source_unit,
+            ),
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._run_generated_encoding_overlay_validation",
+                return_value=(
+                    False,
+                    ["statutes/estg/66.yaml: ci: rejected for test"],
+                    {},
+                ),
+            ) as mock_overlay,
+            patch("axiom_encode.cli._apply_generated_encoding_result") as mock_apply,
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+                clear=True,
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 1
+        mock_apply.assert_not_called()
+        mock_overlay.assert_called_once()
+        assert mock_overlay.call_args.kwargs["amendment_source_texts"] == {
+            amendment_citation: amendment_sentence,
+        }
+
     def test_encode_apply_auto_repairs_nonnegative_taxable_income_floor(
         self, capsys, tmp_path
     ):
@@ -44068,6 +44172,65 @@ rules: []
             "statutes/27-7-5.yaml: ci: second diagnostic",
         ]
         assert supplemental == {}
+
+    def test_estg_66_apply_pipeline_receives_amendment_grounding_text(self, tmp_path):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-de" / "de"
+        generated = output_root / "codex-test-model/statutes/estg/66.yaml"
+        policy_repo.mkdir(parents=True)
+        generated.parent.mkdir(parents=True)
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+        result = SimpleNamespace(
+            output_file=str(generated), runner="codex-test-model", backend="codex"
+        )
+        amendment_citation = (
+            "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+        )
+        amendment_sentence = (
+            "In § 66 Absatz 1 wird die Angabe „250 Euro“ durch die Angabe "
+            "„255 Euro“ ersetzt."
+        )
+        observed_pipeline_kwargs = []
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                observed_pipeline_kwargs.append(kwargs)
+
+            def validate(self, _path, *, skip_reviewers):
+                assert skip_reviewers is True
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={
+                        "ci": SimpleNamespace(
+                            validator_name="ci",
+                            issues=["rejected for test"],
+                            error=None,
+                        )
+                    },
+                )
+
+        with patch("axiom_encode.cli.ValidatorPipeline", FakePipeline):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                local_corpus_release=_bind_test_corpus_release(
+                    policy_repo,
+                    tmp_path / "axiom-corpus",
+                    citation_path="de/statute/estg/66",
+                ),
+                validate_dependents=False,
+                amendment_source_texts={amendment_citation: amendment_sentence},
+            )
+
+        assert ok is False
+        assert issues == ["statutes/estg/66.yaml: ci: rejected for test"]
+        assert supplemental == {}
+        assert len(observed_pipeline_kwargs) == 1
+        assert observed_pipeline_kwargs[0]["amendment_source_texts"] == {
+            amendment_citation: amendment_sentence,
+        }
 
     def test_standalone_contract_failure_cannot_be_rescued_by_apply_overlay(
         self, tmp_path

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1297,9 +1297,7 @@ def test_estg_66_multibyte_amendment_body_remains_visible_in_prompt(tmp_path):
     # The sentence itself contributes nine UTF-8 continuation bytes; the suffix
     # supplies the remaining 433 needed to reproduce the 12,317-byte document.
     multibyte_suffix = "ä" * 433
-    ascii_padding = "x" * (
-        11_875 - len(amendment_sentence) - len(multibyte_suffix) - 1
-    )
+    ascii_padding = "x" * (11_875 - len(amendment_sentence) - len(multibyte_suffix) - 1)
     amendment_body = f"{amendment_sentence}\n{ascii_padding}{multibyte_suffix}"
     amendment = CorpusAmendmentDocument(
         citation_path=amendment_citation,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1336,6 +1336,13 @@ def test_estg_66_multibyte_amendment_body_remains_visible_in_prompt(tmp_path):
     assert amendment_sentence in prompt
     assert amendment_citation in prompt
     assert "body omitted: exceeds 12000-character amendment context cap" not in prompt
+    assert evals_module._amendment_documents_visible_in_context_manifest(
+        (amendment,),
+        workspace.manifest_file,
+        expected_manifest_sha256=hashlib.sha256(
+            workspace.manifest_file.read_bytes()
+        ).hexdigest(),
+    ) == (amendment,)
 
 
 def test_bkgg_amendment_context_is_proof_evidence_never_an_import_target(tmp_path):
@@ -1734,7 +1741,12 @@ def test_name_tier_legacy_budget_records_sliced_document_without_changing_bytes(
 
     assert rendered.provision_text == legacy_provision
     assert rendered.amendment_texts == tuple(legacy_texts)
-    assert rendered.amendment_documents == first_two
+    assert [document.citation_path for document in rendered.amendment_documents] == [
+        document.citation_path for document in first_two
+    ]
+    assert rendered.amendment_documents[0].body == first_two[0].body
+    assert first_two[1].body.startswith(rendered.amendment_documents[1].body)
+    assert len(rendered.amendment_documents[1].body) < len(first_two[1].body)
     assert rendered.dropped_amendment_documents == (
         {
             "citation_path": "n2025",
@@ -1804,6 +1816,115 @@ def test_injected_context_enforces_aggregate_character_cap_newest_last(tmp_path)
     )
 
 
+def test_legacy_truncated_amendment_exposes_only_authenticated_body_prefix(tmp_path):
+    amendments = (
+        CorpusAmendmentDocument(
+            citation_path="dk/statute/amendment-2027",
+            title="Amendment 2027",
+            expression_date="2027-01-01",
+            metadata={"source_note": "m" * 5_500},
+            body="A" * 11_500,
+            match_tier="name",
+        ),
+        CorpusAmendmentDocument(
+            citation_path="dk/statute/amendment-2026",
+            title="Amendment 2026",
+            expression_date="2026-01-01",
+            metadata={"source_note": "m" * 5_500},
+            body="250 " + ("B" * 11_490) + " 255",
+            match_tier="name",
+        ),
+    )
+    workspace = prepare_eval_workspace(
+        citation="dk/statute/benefit/section-1",
+        runner=parse_runner_spec("openai:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="Provision.",
+        axiom_rules_path=_canonical_rulespec_content_root(tmp_path, "dk"),
+        mode="cold",
+        provision_metadata={"source_note": "p" * 5_500},
+        amendment_documents=amendments,
+        extra_context_paths=[],
+    )
+
+    visible = evals_module._amendment_documents_visible_in_context_manifest(
+        amendments,
+        workspace.manifest_file,
+        expected_manifest_sha256=hashlib.sha256(
+            workspace.manifest_file.read_bytes()
+        ).hexdigest(),
+    )
+
+    assert [document.citation_path for document in visible] == [
+        document.citation_path for document in amendments
+    ]
+    assert "250" in visible[1].body
+    assert "255" not in visible[1].body
+    assert workspace.amendment_documents[1].body == visible[1].body
+
+
+def test_structured_omitted_amendment_body_is_not_grounding_evidence(tmp_path):
+    amendment = CorpusAmendmentDocument(
+        citation_path="dk/statute/amendment-2027",
+        title="Amendment 2027",
+        expression_date="2027-01-01",
+        metadata={},
+        body=("A" * 12_001) + " hidden 255",
+        match_tier="structured",
+    )
+    workspace = prepare_eval_workspace(
+        citation="dk/statute/benefit/section-1",
+        runner=parse_runner_spec("openai:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="Provision.",
+        axiom_rules_path=_canonical_rulespec_content_root(tmp_path, "dk"),
+        mode="cold",
+        amendment_documents=(amendment,),
+        extra_context_paths=[],
+    )
+
+    visible = evals_module._amendment_documents_visible_in_context_manifest(
+        (amendment,),
+        workspace.manifest_file,
+        expected_manifest_sha256=hashlib.sha256(
+            workspace.manifest_file.read_bytes()
+        ).hexdigest(),
+    )
+
+    assert workspace.amendment_documents[0].body == ""
+    assert visible == ()
+
+
+def test_amendment_visibility_rejects_manifest_digest_drift(tmp_path):
+    amendment = CorpusAmendmentDocument(
+        citation_path="dk/statute/amendment-2027",
+        title="Amendment 2027",
+        expression_date="2027-01-01",
+        metadata={},
+        body="Visible body.",
+        match_tier="structured",
+    )
+    workspace = prepare_eval_workspace(
+        citation="dk/statute/benefit/section-1",
+        runner=parse_runner_spec("openai:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="Provision.",
+        axiom_rules_path=_canonical_rulespec_content_root(tmp_path, "dk"),
+        mode="cold",
+        amendment_documents=(amendment,),
+        extra_context_paths=[],
+    )
+    expected_sha256 = hashlib.sha256(workspace.manifest_file.read_bytes()).hexdigest()
+    workspace.manifest_file.write_text(workspace.manifest_file.read_text() + "\n")
+
+    with pytest.raises(ValueError, match="digest does not match"):
+        evals_module._amendment_documents_visible_in_context_manifest(
+            (amendment,),
+            workspace.manifest_file,
+            expected_manifest_sha256=expected_sha256,
+        )
+
+
 def test_structured_aggregate_cap_drops_oldest_document_and_records_manifest(
     tmp_path,
 ):
@@ -1861,6 +1982,9 @@ def test_structured_aggregate_cap_drops_oldest_document_and_records_manifest(
         evals_module._amendment_documents_visible_in_context_manifest(
             amendments,
             workspace.manifest_file,
+            expected_manifest_sha256=hashlib.sha256(
+                workspace.manifest_file.read_bytes()
+            ).hexdigest(),
         )
         == amendments[:2]
     )
@@ -22493,25 +22617,42 @@ def _run_case_revalidation(
     )
     with tempfile.TemporaryDirectory() as tmpdir:
         context_manifest = Path(tmpdir) / "context.json"
+        context_items = []
+        documents_by_citation = {
+            document.citation_path: document for document in amendment_documents
+        }
+        for index, citation in enumerate(visible_amendment_citations, start=1):
+            workspace_path = Path("context") / f"amendment-act-{index}.txt"
+            materialized = context_manifest.parent / workspace_path
+            materialized.parent.mkdir(parents=True, exist_ok=True)
+            document = documents_by_citation[citation]
+            materialized.write_text(
+                evals_module._render_amendment_document(
+                    document,
+                    body=document.body,
+                )
+                + "\n"
+            )
+            context_items.append(
+                (
+                    {
+                        "kind": "corpus_amendment_act",
+                        "source_path": citation,
+                        "workspace_path": str(workspace_path),
+                        "import_path": citation,
+                    }
+                    if historical_amendment_manifest
+                    else {
+                        "kind": "corpus_amendment_act",
+                        "citation_path": citation,
+                        "workspace_path": str(workspace_path),
+                    }
+                )
+            )
         context_manifest.write_text(
             json.dumps(
                 {
-                    "context_files": [
-                        (
-                            {
-                                "kind": "corpus_amendment_act",
-                                "source_path": citation,
-                                "workspace_path": "context/amendment-act-1.txt",
-                                "import_path": citation,
-                            }
-                            if historical_amendment_manifest
-                            else {
-                                "kind": "corpus_amendment_act",
-                                "citation_path": citation,
-                            }
-                        )
-                        for citation in visible_amendment_citations
-                    ],
+                    "context_files": context_items,
                     "dropped_amendment_documents": [
                         {
                             "citation_path": document.citation_path,
@@ -22525,6 +22666,9 @@ def _run_case_revalidation(
         )
         result = _revalidation_result(persisted, **result_overrides)
         result.context_manifest_file = str(context_manifest)
+        result.context_manifest_sha256 = hashlib.sha256(
+            context_manifest.read_bytes()
+        ).hexdigest()
         with (
             patch.object(
                 evals_module, "resolve_corpus_source_unit", return_value=source_unit

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1286,6 +1286,58 @@ def test_sibling_amendments_are_context_with_bounded_bodies(tmp_path):
     )
 
 
+def test_estg_66_multibyte_amendment_body_remains_visible_in_prompt(tmp_path):
+    amendment_citation = (
+        "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+    )
+    amendment_sentence = (
+        "In § 66 Absatz 1 wird die Angabe „250 Euro“ durch die Angabe "
+        "„255 Euro“ ersetzt."
+    )
+    # The sentence itself contributes nine UTF-8 continuation bytes; the suffix
+    # supplies the remaining 433 needed to reproduce the 12,317-byte document.
+    multibyte_suffix = "ä" * 433
+    ascii_padding = "x" * (
+        11_875 - len(amendment_sentence) - len(multibyte_suffix) - 1
+    )
+    amendment_body = f"{amendment_sentence}\n{ascii_padding}{multibyte_suffix}"
+    amendment = CorpusAmendmentDocument(
+        citation_path=amendment_citation,
+        title="Steuerfortentwicklungsgesetz – SteFeG",
+        expression_date="2024-12-23",
+        metadata={},
+        body=amendment_body,
+        match_tier="structured",
+    )
+    rulespec_root = _canonical_rulespec_content_root(tmp_path, "de")
+
+    workspace = prepare_eval_workspace(
+        citation="de/statute/estg/66",
+        runner=parse_runner_spec("openai:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.",
+        axiom_rules_path=rulespec_root,
+        mode="cold",
+        amendment_documents=(amendment,),
+        extra_context_paths=[],
+    )
+    prompt = _build_eval_prompt(
+        "de/statute/estg/66",
+        "cold",
+        workspace,
+        workspace.context_files,
+        target_file_name="66.yaml",
+        include_tests=True,
+        runner_backend="openai",
+    )
+
+    assert len(amendment_body) == 11_875
+    assert len(amendment_body.encode("utf-8")) == 12_317
+    assert amendment_sentence in prompt
+    assert amendment_citation in prompt
+    assert "body omitted: exceeds 12000-character amendment context cap" not in prompt
+
+
 def test_bkgg_amendment_context_is_proof_evidence_never_an_import_target(tmp_path):
     amendment_citation = (
         "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1690"
+ENCODER_VERSION = "0.2.1691"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1690"
+ENCODER_VERSION = "0.2.1691"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1690"
+ENCODER_VERSION = "0.2.1691"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1690"
+ENCODER_VERSION = "0.2.1691"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1690"
+ENCODER_VERSION = "0.2.1691"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1690"
+ENCODER_VERSION = "0.2.1691"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1690"')
+        .startswith('__version__ = "0.2.1691"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1690"
+    assert encoder_package["version"] == "0.2.1691"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1690"
+    assert project["project"]["version"] == "0.2.1691"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1690"')
+        .startswith('__version__ = "0.2.1691"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1690"
+    assert encoder_package["version"] == "0.2.1691"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1690"
+    assert project["project"]["version"] == "0.2.1691"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1690"')
+        .startswith('__version__ = "0.2.1691"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -14174,6 +14174,47 @@ rules:
     assert cited_issues == []
 
 
+def test_estg_66_amendment_hint_renders_copyable_proof_source_shape():
+    amendment_citation = (
+        "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+    )
+    amendment_sentence = (
+        "In § 66 Absatz 1 wird die Angabe „250 Euro“ durch die Angabe "
+        "„255 Euro“ ersetzt."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/66
+rules:
+  - name: kindergeld_monthly_amount_per_child
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 255
+"""
+
+    issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text=(
+            "(1) Das Kindergeld beträgt monatlich für jedes Kind 259 Euro."
+        ),
+        module_citation_path="de/statute/estg/66",
+        amendment_source_texts={amendment_citation: amendment_sentence},
+    )
+
+    assert len(issues) == 1
+    assert "`path: versions[0].formula`" in issues[0]
+    assert (
+        f"`source: {{corpus_citation_path: {amendment_citation}, "
+        "excerpt: <exact verbatim source span>}`."
+    ) in issues[0]
+    assert "<exact verbatim source span>}}`" not in issues[0]
+
+
 def test_ungrounded_literal_omits_amendment_hint_when_value_is_absent():
     content = """format: rulespec/v1
 rules:

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1690"
+ENCODER_VERSION = "0.2.1691"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -32698,6 +32698,147 @@ def test_generic_german_rounding_requires_nearest_rounding_and_fractional_proof(
     assert not complete.issues
 
 
+def test_estg_66_precise_absatz_3_deferral_suppresses_rounding_test_demand():
+    source = """\
+(1) Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.
+(2) Das Kindergeld wird monatlich vom Beginn des Monats an gezahlt, in dem die Anspruchsvoraussetzungen erfüllt sind, bis zum Ende des Monats, in dem die Anspruchsvoraussetzungen wegfallen.
+(3) Werden die Freibeträge für Kinder nach § 31 Satz 1 in Verbindung mit § 32 Absatz 6 Satz 1 angehoben, wird das Kindergeld entsprechend erhöht. Das Kindergeld ist dabei auf volle Euro kaufmännisch zu runden.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/66
+  deferred_outputs:
+    - output: de:statutes/estg/66/3#child_benefit_increase
+      reason: >-
+        Cannot be computed until de/statute/estg/32 Absatz 6 Satz 1 and
+        de/statute/estg/31 Satz 1 are available.
+rules:
+  - name: child_benefit_amount
+    kind: parameter
+    source: de/statute/estg/66(1)
+    versions: [{formula: 259}]
+  - name: child_benefit_payable_for_month
+    kind: derived
+    dtype: Judgment
+    source: de/statute/estg/66(2)
+    versions: [{formula: claim_conditions_hold_in_month}]
+"""
+    test_cases = [
+        {
+            "name": "payment month",
+            "period": "2026-01",
+            "input": {"claim_conditions_hold_in_month": True},
+            "output": {
+                "child_benefit_amount": 259,
+                "child_benefit_payable_for_month": "holds",
+            },
+        }
+    ]
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="de/statute/estg/66",
+        test_cases=test_cases,
+    )
+
+    assert not result.issues
+
+
+def test_estg_66_rounding_retry_shows_and_accepts_paired_half_boundary_shape():
+    source = """\
+(3) Werden die Freibeträge für Kinder nach § 31 Satz 1 in Verbindung mit § 32 Absatz 6 Satz 1 angehoben, wird das Kindergeld entsprechend erhöht. Das Kindergeld ist dabei auf volle Euro kaufmännisch zu runden.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/66
+inputs:
+  - name: child_benefit_amount_before_increase
+    dtype: Money
+  - name: child_allowance_increase_rate
+    dtype: Rate
+rules:
+  - name: unrounded_child_benefit_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/66(3)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: child_benefit_amount_before_increase * (1 + child_allowance_increase_rate)
+  - name: child_benefit_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/66(3)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: floor(unrounded_child_benefit_amount + 0.5)
+"""
+    integral_only = _analyze(
+        content,
+        source,
+        corpus_citation_path="de/statute/estg/66",
+        test_cases=[
+            {
+                "name": "integral increase",
+                "period": "2026",
+                "input": {
+                    "child_benefit_amount_before_increase": 100,
+                    "child_allowance_increase_rate": 0,
+                },
+                "output": {
+                    "unrounded_child_benefit_amount": 100,
+                    "child_benefit_amount": 100,
+                },
+            }
+        ],
+    )
+    rounding_issue = next(
+        issue for issue in integral_only.issues if "rounding rule" in issue
+    )
+    paired = _analyze(
+        content,
+        source,
+        corpus_citation_path="de/statute/estg/66",
+        test_cases=[
+            {
+                "name": "below half",
+                "period": "2026",
+                "input": {
+                    "child_benefit_amount_before_increase": 100,
+                    "child_allowance_increase_rate": 0.0049,
+                },
+                "output": {
+                    "unrounded_child_benefit_amount": 100.49,
+                    "child_benefit_amount": 100,
+                },
+            },
+            {
+                "name": "half up",
+                "period": "2026",
+                "input": {
+                    "child_benefit_amount_before_increase": 100,
+                    "child_allowance_increase_rate": 0.005,
+                },
+                "output": {
+                    "unrounded_child_benefit_amount": 100.5,
+                    "child_benefit_amount": 101,
+                },
+            },
+        ],
+    )
+
+    assert "same-period paired cases" in rounding_issue
+    assert "100.49 -> 100" in rounding_issue
+    assert "100.50 -> 101" in rounding_issue
+    assert "unrounded intermediate" in rounding_issue
+    assert "affected principal output" in rounding_issue
+    assert not paired.issues
+
+
 @pytest.mark.parametrize(
     ("source", "output"),
     [

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1690"
+version = "0.2.1691"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Root-cause fixes from a 10-attempt signed-apply run on rulespec-de `estg/66` (run 31964897406) that oscillated between two demands without converging. Every mechanical layer was first exonerated by direct probe (corpus resolution, proof-evidence text, verbatim containment, de-DE tokenization of `„quoted“` amounts) — the faults were in what the model could *see*:

## The two-link failure
1. **Multibyte cap bug**: the per-document 12,000-character cap was applied to the SteFeG amendment's 12,317 UTF-8 **bytes** (body is 11,875 **characters** — umlauts and `„…“` inflate bytes), so the prompt replaced the document with an omission marker. The model could never copy the "„250 Euro“ → „255 Euro“" sentence it needed. Renderer now caps on `len(body)` characters while keeping UTF-8 accounting for the 32k aggregate.
2. **Apply-path hint plumbing**: `--apply` overlay validation never received `amendment_source_texts`, so the attached-amendment grounding hint (naming the citation path and the copyable atom shape) silently skipped. Now recovered lazily from the digest-bound prompt context and passed through, with the amendment text authenticated against the release-bound corpus document.

Plus: the nearest/kaufmännisch rounding-test demand now steers retries with the exact satisfying shape (same-period paired cases driving the pre-rounding amount to `100.49 → 100` and `100.50 → 101`), and the §66(3) typed-deferral interaction was verified gate-clean (deferred branches drop both structure and rounding demands — regression pinned).

## Proof of satisfiability
A diagnostic-only §66 candidate (dual 2025/2026 effective versions; 2025 grounded via a verbatim SteFeG `document-1` excerpt; Abs. 3 precisely deferred naming §31/§32(6)) passes the **full** apply-validation battery locally — compile, CI, completeness, apply-overlay, installed validator, proof validator. Never committed to rulespec-de (generated-guard); it proves a re-dispatched CI run can converge.

## Verification
Scenario regressions across evals/cli/rulespec-validation/source-completeness; completeness suite 5,816 passed; version 0.2.1691 with the 9-file pin sweep; ruff clean. Built cross-family (sol implements from a probe-annotated brief; Claude verified the diff scope and reran the suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
