### PR TITLE
Signed-apply candidate ratchet: preserve failed candidates, seed re-dispatches

### DIFF
--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -47,6 +47,11 @@ on:
         required: false
         type: string
         default: ""
+      repair-candidate-run-id:
+        description: "Optional failed signed-apply run containing this leg's repair candidate."
+        required: false
+        type: string
+        default: ""
     secrets:
       openai-api-key:
         description: "OpenAI model credential, explicitly passed by the caller."
@@ -123,6 +128,10 @@ jobs:
       matrix:
         item: ${{ fromJSON(needs.dispatch.outputs.matrix).include }}
     permissions:
+      # GitHub does not support step-scoped permissions. actions:read is used
+      # only by the pinned cross-run artifact download action; the model/signer
+      # step receives neither github.token nor any write-capable permission.
+      actions: read
       contents: read
     steps:
       - name: Checkout rules repository (leaf dir must equal the repo name)
@@ -146,6 +155,20 @@ jobs:
         run: |
           set -euo pipefail
           test "$(basename "$GITHUB_WORKSPACE")" = "${{ github.event.repository.name }}"
+
+      - name: Validate repair candidate run ID
+        id: repair_run
+        if: ${{ inputs['repair-candidate-run-id'] != '' }}
+        shell: bash
+        env:
+          REPAIR_CANDIDATE_RUN_ID: ${{ inputs['repair-candidate-run-id'] }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$REPAIR_CANDIDATE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            printf 'invalid repair-candidate-run-id: expected a numeric workflow run ID\n' >&2
+            exit 1
+          fi
+          printf 'run_id=%s\n' "$REPAIR_CANDIDATE_RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Resolve pinned refs and release binding
         id: pins
@@ -188,6 +211,44 @@ jobs:
           ref: ${{ steps.pins.outputs.corpus_ref }}
           path: _axiom/axiom-corpus
           persist-credentials: false
+
+      - name: Download failed encode candidate
+        if: ${{ inputs['repair-candidate-run-id'] != '' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: failed-encode-${{ matrix.item.slug }}
+          path: ${{ runner.temp }}/repair-candidate
+          run-id: ${{ steps.repair_run.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify downloaded repair candidate
+        id: repair_candidate
+        if: ${{ inputs['repair-candidate-run-id'] != '' }}
+        shell: bash
+        env:
+          CITATION: ${{ matrix.item.citation }}
+        run: |
+          set -euo pipefail
+          verified="$RUNNER_TEMP/repair-candidate.json"
+          python3 _axiom/axiom-encode/scripts/verify_failed_encode_candidate.py \
+            "$RUNNER_TEMP/repair-candidate" \
+            --citation "$CITATION" \
+            > "$verified"
+          jq -e '
+            keys == ["path", "root", "rulespec_sha256", "tests_sha256"]
+            and (.root | type == "string" and length > 0)
+            and (.path | type == "string" and length > 0)
+            and (.rulespec_sha256 | test("^[0-9a-f]{64}$"))
+            and (.tests_sha256 | test("^[0-9a-f]{64}$"))
+          ' "$verified" > /dev/null
+          {
+            printf 'root=%s\n' "$(jq -er '.root' "$verified")"
+            printf 'path=%s\n' "$(jq -er '.path' "$verified")"
+            printf 'rulespec_sha256=%s\n' \
+              "$(jq -er '.rulespec_sha256' "$verified")"
+            printf 'tests_sha256=%s\n' \
+              "$(jq -er '.tests_sha256' "$verified")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -324,6 +385,10 @@ jobs:
           CITATION: ${{ matrix.item.citation }}
           INITIAL_MODEL: ${{ inputs['initial-model'] }}
           ESCALATE_AFTER: ${{ inputs['escalate-after'] }}
+          REPAIR_CANDIDATE_ROOT: ${{ steps.repair_candidate.outputs.root }}
+          REPAIR_CANDIDATE_PATH: ${{ steps.repair_candidate.outputs.path }}
+          REPAIR_CANDIDATE_RULESPEC_SHA256: ${{ steps.repair_candidate.outputs.rulespec_sha256 }}
+          REPAIR_CANDIDATE_TESTS_SHA256: ${{ steps.repair_candidate.outputs.tests_sha256 }}
         run: |
           set -euo pipefail
           # Builtin read/conditionals + pure assignment only — no subprocess is
@@ -350,7 +415,8 @@ jobs:
             --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" \
             --policy-repo-path "$genroot" \
             --mode cold --skip-reviewers \
-            --db "$RUNNER_TEMP/enc.db"
+            --db "$RUNNER_TEMP/enc.db" \
+            --emit-final-rejected-candidate "$RUNNER_TEMP/failed-encode"
           if [[ "$require_complete_source_unit" == true ]]; then
             set -- "$@" --require-complete-source-unit
           fi
@@ -374,6 +440,26 @@ jobs:
               exit 1
             fi
             set -- "$@" --escalate-after "$ESCALATE_AFTER"
+          fi
+          if [[ -n "$REPAIR_CANDIDATE_ROOT" ]]; then
+            if [[ -z "$REPAIR_CANDIDATE_PATH" ]] || \
+               [[ ! "$REPAIR_CANDIDATE_RULESPEC_SHA256" =~ ^[0-9a-f]{64}$ ]] || \
+               [[ ! "$REPAIR_CANDIDATE_TESTS_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+              printf 'verified repair candidate outputs are incomplete or malformed\n' >&2
+              exit 1
+            fi
+            set -- "$@" \
+              --repair-candidate-root "$REPAIR_CANDIDATE_ROOT" \
+              --repair-candidate-path "$REPAIR_CANDIDATE_PATH" \
+              --repair-candidate-rulespec-sha256 \
+                "$REPAIR_CANDIDATE_RULESPEC_SHA256" \
+              --repair-candidate-tests-sha256 \
+                "$REPAIR_CANDIDATE_TESTS_SHA256"
+          elif [[ -n "$REPAIR_CANDIDATE_PATH" ]] || \
+               [[ -n "$REPAIR_CANDIDATE_RULESPEC_SHA256" ]] || \
+               [[ -n "$REPAIR_CANDIDATE_TESTS_SHA256" ]]; then
+            printf 'verified repair candidate outputs are incomplete\n' >&2
+            exit 1
           fi
           exec "$@"
 
@@ -512,6 +598,35 @@ jobs:
           path: ${{ runner.temp }}/signed-content
           include-hidden-files: true
           retention-days: 1
+
+      - name: Verify final rejected candidate artifact
+        id: failed_candidate
+        if: ${{ failure() && !cancelled() }}
+        shell: bash
+        env:
+          CITATION: ${{ matrix.item.citation }}
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/failed-encode"
+          if [[ ! -e "$root" && ! -L "$root" ]]; then
+            printf 'present=false\n' >> "$GITHUB_OUTPUT"
+            printf 'No final validator-rejected candidate was emitted for this failure.\n'
+            exit 0
+          fi
+          python3 _axiom/axiom-encode/scripts/verify_failed_encode_candidate.py \
+            "$root" \
+            --citation "$CITATION" \
+            > "$RUNNER_TEMP/failed-encode-verified.json"
+          printf 'present=true\n' >> "$GITHUB_OUTPUT"
+
+      - name: Upload failed encode candidate
+        if: ${{ failure() && !cancelled() && steps.failed_candidate.outputs.present == 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: failed-encode-${{ matrix.item.slug }}
+          path: ${{ runner.temp }}/failed-encode
+          if-no-files-found: error
+          retention-days: 30
 
   open_pr:
     needs: [dispatch, encode]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1693"
+version = "0.2.1694"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/run_snap_queue_until_idle.py
+++ b/scripts/run_snap_queue_until_idle.py
@@ -757,9 +757,7 @@ def build_run_record(
             "generalist_review_score": metrics.get("generalist_review_score"),
             "policyengine_score": metrics.get("policyengine_score"),
             "estimated_cost_usd": (
-                estimated_cost_usd
-                if result_rows and estimated_cost_complete
-                else None
+                estimated_cost_usd if result_rows and estimated_cost_complete else None
             ),
             "actual_cost_usd": actual_cost_usd,
             **token_fields,

--- a/scripts/verify_failed_encode_candidate.py
+++ b/scripts/verify_failed_encode_candidate.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Verify one exact signed-apply failed-candidate artifact directory."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import runpy
+import stat
+from pathlib import Path, PurePosixPath
+
+SCHEMA = "axiom-encode/failed-encode-candidate/v1"
+ATOMIC_ROOTS = frozenset({"legislation", "policies", "regulations", "statutes"})
+PROTECTED_SEGMENTS = frozenset({".git", ".github", "_axiom", "scripts"})
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+JURISDICTION_PATTERN = re.compile(r"[a-z]{2}(?:-[a-z0-9_]+)*")
+VERSION_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9.+_-]{0,127}")
+MAX_ISSUES_BYTES = 512 * 1024
+MAX_ISSUES = 4096
+CONTRACT = runpy.run_path(
+    Path(__file__).parents[1] / "src/axiom_encode/repair_candidate_contract.py"
+)
+MAX_CANDIDATE_BYTES = CONTRACT["VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES"]
+MAX_CANDIDATE_TOTAL_BYTES = CONTRACT[
+    "VALIDATION_RETRY_CANDIDATE_MAX_TOTAL_BYTES"
+]
+METADATA_FIELDS = {
+    "schema",
+    "citation",
+    "path",
+    "issues",
+    "rulespec_sha256",
+    "tests_sha256",
+    "encoder_version",
+    "attempt_count",
+}
+
+
+def _canonical_candidate_path(raw_path: object) -> PurePosixPath:
+    if not isinstance(raw_path, str):
+        raise ValueError("failed candidate path must be text")
+    path = PurePosixPath(raw_path)
+    if (
+        not raw_path
+        or path.is_absolute()
+        or path.as_posix() != raw_path
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or any(part in PROTECTED_SEGMENTS for part in path.parts)
+    ):
+        raise ValueError("failed candidate path is not canonical")
+    parts = path.parts
+    if parts and parts[0] in ATOMIC_ROOTS:
+        module_parts = parts
+    elif (
+        len(parts) >= 2
+        and JURISDICTION_PATTERN.fullmatch(parts[0]) is not None
+        and parts[1] in ATOMIC_ROOTS
+    ):
+        module_parts = parts[1:]
+    else:
+        module_parts = ()
+    if (
+        len(module_parts) < 2
+        or path.suffix != ".yaml"
+        or path.name.endswith(".test.yaml")
+    ):
+        raise ValueError("failed candidate path is not a canonical RuleSpec module")
+    return path
+
+
+def _read_bounded_regular_file(
+    root: Path,
+    relative: PurePosixPath,
+    *,
+    label: str,
+    max_bytes: int,
+) -> bytes:
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory is None:
+        raise ValueError(f"{label} cannot be opened safely on this platform")
+    directory_flags = os.O_RDONLY | os.O_CLOEXEC | nofollow | directory
+    descriptors: list[int] = []
+    file_descriptor: int | None = None
+    try:
+        parent_descriptor = os.open(root, directory_flags)
+        descriptors.append(parent_descriptor)
+        for part in relative.parts[:-1]:
+            parent_descriptor = os.open(
+                part,
+                directory_flags,
+                dir_fd=parent_descriptor,
+            )
+            descriptors.append(parent_descriptor)
+        file_descriptor = os.open(
+            relative.parts[-1],
+            os.O_RDONLY | os.O_CLOEXEC | nofollow | os.O_NONBLOCK,
+            dir_fd=parent_descriptor,
+        )
+        file_stat = os.fstat(file_descriptor)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError(f"{label} is not a regular file")
+        if file_stat.st_size > max_bytes:
+            raise ValueError(f"{label} exceeds its size limit")
+        chunks: list[bytes] = []
+        remaining = max_bytes + 1
+        while remaining:
+            chunk = os.read(file_descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        if len(payload) > max_bytes:
+            raise ValueError(f"{label} exceeds its size limit")
+        return payload
+    except ValueError:
+        raise
+    except OSError as exc:
+        raise ValueError(f"could not safely open {label}") from exc
+    finally:
+        if file_descriptor is not None:
+            os.close(file_descriptor)
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def _directory_inventory(root: Path) -> tuple[set[str], set[str]]:
+    try:
+        root_stat = os.lstat(root)
+    except OSError as exc:
+        raise ValueError("failed candidate root is unavailable") from exc
+    if not stat.S_ISDIR(root_stat.st_mode):
+        raise ValueError("failed candidate root must be a real directory")
+
+    directories: set[str] = set()
+    files: set[str] = set()
+    for current_raw, dirnames, filenames in os.walk(root, followlinks=False):
+        current = Path(current_raw)
+        for name in dirnames:
+            candidate = current / name
+            try:
+                candidate_stat = os.lstat(candidate)
+            except OSError as exc:
+                raise ValueError("failed candidate directory changed during scan") from exc
+            if not stat.S_ISDIR(candidate_stat.st_mode):
+                raise ValueError("failed candidate artifact contains a symlink")
+            directories.add(candidate.relative_to(root).as_posix())
+        for name in filenames:
+            candidate = current / name
+            try:
+                candidate_stat = os.lstat(candidate)
+            except OSError as exc:
+                raise ValueError("failed candidate file changed during scan") from exc
+            if not stat.S_ISREG(candidate_stat.st_mode):
+                raise ValueError(
+                    "failed candidate artifact contains a symlink or non-regular file"
+                )
+            files.add(candidate.relative_to(root).as_posix())
+    return directories, files
+
+
+def _expected_directories(*paths: PurePosixPath) -> set[str]:
+    expected: set[str] = set()
+    for path in paths:
+        for parent in path.parents:
+            if parent == PurePosixPath("."):
+                break
+            expected.add(parent.as_posix())
+    return expected
+
+
+def verify_candidate_directory(
+    raw_root: Path,
+    *,
+    citation: str | None = None,
+) -> dict[str, str]:
+    """Verify exact content, metadata shape, paths, and content digests."""
+
+    root = Path(os.path.abspath(raw_root))
+    directories, files = _directory_inventory(root)
+    issues_raw = _read_bounded_regular_file(
+        root,
+        PurePosixPath("issues.json"),
+        label="failed candidate issues.json",
+        max_bytes=MAX_ISSUES_BYTES,
+    )
+    try:
+        metadata = json.loads(issues_raw.decode("utf-8", errors="strict"))
+    except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("failed candidate issues.json is not valid UTF-8 JSON") from exc
+    if not isinstance(metadata, dict) or set(metadata) != METADATA_FIELDS:
+        raise ValueError("failed candidate issues.json has an invalid shape")
+    if metadata.get("schema") != SCHEMA:
+        raise ValueError("failed candidate issues.json schema is invalid")
+    metadata_citation = metadata.get("citation")
+    if not isinstance(metadata_citation, str) or not metadata_citation:
+        raise ValueError("failed candidate citation is invalid")
+    if citation is not None and metadata_citation != citation:
+        raise ValueError("failed candidate citation mismatch")
+
+    relative_rulespec = _canonical_candidate_path(metadata.get("path"))
+    relative_tests = relative_rulespec.with_name(
+        f"{relative_rulespec.stem}.test.yaml"
+    )
+    expected_files = {
+        "issues.json",
+        relative_rulespec.as_posix(),
+        relative_tests.as_posix(),
+    }
+    expected_directories = _expected_directories(relative_rulespec, relative_tests)
+    if files != expected_files or directories != expected_directories:
+        raise ValueError(
+            "failed candidate artifact must contain exactly the rejected RuleSpec, "
+            "companion tests, and issues.json"
+        )
+
+    issues = metadata.get("issues")
+    if (
+        not isinstance(issues, list)
+        or not issues
+        or len(issues) > MAX_ISSUES
+        or any(not isinstance(issue, str) or not issue for issue in issues)
+    ):
+        raise ValueError("failed candidate issues must be a nonempty string array")
+    attempt_count = metadata.get("attempt_count")
+    if (
+        not isinstance(attempt_count, int)
+        or isinstance(attempt_count, bool)
+        or attempt_count < 1
+    ):
+        raise ValueError("failed candidate attempt count must be positive")
+    encoder_version = metadata.get("encoder_version")
+    if (
+        not isinstance(encoder_version, str)
+        or VERSION_PATTERN.fullmatch(encoder_version) is None
+    ):
+        raise ValueError("failed candidate encoder version is invalid")
+    for field in ("rulespec_sha256", "tests_sha256"):
+        digest = metadata.get(field)
+        if not isinstance(digest, str) or SHA256_PATTERN.fullmatch(digest) is None:
+            raise ValueError(f"failed candidate {field} is invalid")
+
+    rulespec = _read_bounded_regular_file(
+        root,
+        relative_rulespec,
+        label="failed candidate RuleSpec",
+        max_bytes=MAX_CANDIDATE_BYTES,
+    )
+    tests = _read_bounded_regular_file(
+        root,
+        relative_tests,
+        label="failed candidate companion tests",
+        max_bytes=MAX_CANDIDATE_BYTES,
+    )
+    if len(rulespec) + len(tests) > MAX_CANDIDATE_TOTAL_BYTES:
+        raise ValueError("failed candidate pair exceeds its aggregate size limit")
+    try:
+        rulespec.decode("utf-8", errors="strict")
+        tests.decode("utf-8", errors="strict")
+    except UnicodeError as exc:
+        raise ValueError("failed candidate pair is not valid UTF-8") from exc
+    rulespec_sha256 = hashlib.sha256(rulespec).hexdigest()
+    tests_sha256 = hashlib.sha256(tests).hexdigest()
+    if rulespec_sha256 != metadata["rulespec_sha256"]:
+        raise ValueError("failed candidate RuleSpec SHA-256 mismatch")
+    if tests_sha256 != metadata["tests_sha256"]:
+        raise ValueError("failed candidate tests SHA-256 mismatch")
+
+    return {
+        "root": str(root),
+        "path": relative_rulespec.as_posix(),
+        "rulespec_sha256": rulespec_sha256,
+        "tests_sha256": tests_sha256,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("candidate_root", type=Path)
+    parser.add_argument("--citation", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    result = verify_candidate_directory(
+        args.candidate_root,
+        citation=args.citation,
+    )
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_failed_encode_candidate.py
+++ b/scripts/verify_failed_encode_candidate.py
@@ -49,6 +49,10 @@ def _canonical_candidate_path(raw_path: object) -> PurePosixPath:
         or path.as_posix() != raw_path
         or any(part in {"", ".", ".."} for part in path.parts)
         or any(part in PROTECTED_SEGMENTS for part in path.parts)
+        or any(
+            any(ord(character) < 32 or ord(character) == 127 for character in part)
+            for part in path.parts
+        )
     ):
         raise ValueError("failed candidate path is not canonical")
     parts = path.parts

--- a/scripts/verify_failed_encode_candidate.py
+++ b/scripts/verify_failed_encode_candidate.py
@@ -24,9 +24,7 @@ CONTRACT = runpy.run_path(
     Path(__file__).parents[1] / "src/axiom_encode/repair_candidate_contract.py"
 )
 MAX_CANDIDATE_BYTES = CONTRACT["VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES"]
-MAX_CANDIDATE_TOTAL_BYTES = CONTRACT[
-    "VALIDATION_RETRY_CANDIDATE_MAX_TOTAL_BYTES"
-]
+MAX_CANDIDATE_TOTAL_BYTES = CONTRACT["VALIDATION_RETRY_CANDIDATE_MAX_TOTAL_BYTES"]
 METADATA_FIELDS = {
     "schema",
     "citation",
@@ -150,7 +148,9 @@ def _directory_inventory(root: Path) -> tuple[set[str], set[str]]:
             try:
                 candidate_stat = os.lstat(candidate)
             except OSError as exc:
-                raise ValueError("failed candidate directory changed during scan") from exc
+                raise ValueError(
+                    "failed candidate directory changed during scan"
+                ) from exc
             if not stat.S_ISDIR(candidate_stat.st_mode):
                 raise ValueError("failed candidate artifact contains a symlink")
             directories.add(candidate.relative_to(root).as_posix())
@@ -196,7 +196,9 @@ def verify_candidate_directory(
     try:
         metadata = json.loads(issues_raw.decode("utf-8", errors="strict"))
     except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
-        raise ValueError("failed candidate issues.json is not valid UTF-8 JSON") from exc
+        raise ValueError(
+            "failed candidate issues.json is not valid UTF-8 JSON"
+        ) from exc
     if not isinstance(metadata, dict) or set(metadata) != METADATA_FIELDS:
         raise ValueError("failed candidate issues.json has an invalid shape")
     if metadata.get("schema") != SCHEMA:
@@ -208,9 +210,7 @@ def verify_candidate_directory(
         raise ValueError("failed candidate citation mismatch")
 
     relative_rulespec = _canonical_candidate_path(metadata.get("path"))
-    relative_tests = relative_rulespec.with_name(
-        f"{relative_rulespec.stem}.test.yaml"
-    )
+    relative_tests = relative_rulespec.with_name(f"{relative_rulespec.stem}.test.yaml")
     expected_files = {
         "issues.json",
         relative_rulespec.as_posix(),

--- a/scripts/verify_failed_encode_candidate.py
+++ b/scripts/verify_failed_encode_candidate.py
@@ -47,6 +47,7 @@ def _canonical_candidate_path(raw_path: object) -> PurePosixPath:
         not raw_path
         or path.is_absolute()
         or path.as_posix() != raw_path
+        or "\\" in raw_path
         or any(part in {"", ".", ".."} for part in path.parts)
         or any(part in PROTECTED_SEGMENTS for part in path.parts)
         or any(

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1693"
+__version__ = "0.2.1694"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19,7 +19,6 @@ import csv
 import difflib
 import fcntl
 import hashlib
-import itertools
 import json
 import math
 import os
@@ -55121,41 +55120,6 @@ def _full_overlay_validator_issues(
         return issues
     error = getattr(validator_result, "error", None)
     return (f"{prefix}{error}",) if isinstance(error, str) and error else ()
-
-
-def _bounded_overlay_validator_issues(
-    validator_result: object,
-    *,
-    relative_file: Path,
-    validator_name: str,
-) -> tuple[str, ...]:
-    """Preserve bounded validator diagnostics across the apply-overlay boundary."""
-
-    prefix = f"{relative_file}: {validator_name}: "
-    raw_issues = getattr(validator_result, "issues", ())
-    candidates = (
-        raw_issues
-        if isinstance(raw_issues, Sequence) and not isinstance(raw_issues, (str, bytes))
-        else ()
-    )
-    inspection_limit = VALIDATION_RETRY_FEEDBACK_MAX_ITEMS * 4
-    bounded: list[str] = []
-    seen: set[str] = set()
-    for raw_issue in itertools.islice(iter(candidates), inspection_limit):
-        if not isinstance(raw_issue, str):
-            continue
-        issue = bounded_validation_retry_feedback_item(f"{prefix}{raw_issue}")
-        if not issue or issue in seen:
-            continue
-        seen.add(issue)
-        bounded.append(issue)
-    if bounded:
-        return tuple(bounded)
-    error = getattr(validator_result, "error", None)
-    if not isinstance(error, str):
-        return ()
-    fallback = bounded_validation_retry_feedback_item(f"{prefix}{error}")
-    return (fallback,) if fallback else ()
 
 
 # Keep the apply-overlay validator importable for focused tests and internal

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26786,6 +26786,7 @@ class _EncodeAttemptExecution(NamedTuple):
     apply_passed: bool
     logged_run: EncodingRun | None
     validation_issues: tuple[str, ...]
+    validation_retry_issues: tuple[str, ...]
 
 
 class _EncodeReplacementTarget(NamedTuple):
@@ -29157,9 +29158,7 @@ def _run_encode_attempts_with_retries(
                     result=execution.result,
                     error=retry_error,
                     candidate=candidate,
-                    validation_issues=_validation_retry_issue_snapshot(
-                        execution.validation_issues
-                    ),
+                    validation_issues=execution.validation_retry_issues,
                 )
         if next_model is not None:
             action = "retrying" if next_model == current_model else "escalating"
@@ -29580,12 +29579,19 @@ def _run_encode_attempt(
 
     outcome = _initial_encode_outcome(result, apply_requested=apply_requested)
     apply_passed = False
+    full_validation_issues: tuple[str, ...] = ()
     retry_validation_issues: tuple[str, ...] = ()
     metrics = getattr(result, "metrics", None)
     if metrics is not None:
-        retry_validation_issues = _full_validation_issue_list(
-            getattr(metrics, "compile_issues", ()),
-            getattr(metrics, "ci_issues", ()),
+        compile_issues = getattr(metrics, "compile_issues", ())
+        ci_issues = getattr(metrics, "ci_issues", ())
+        full_validation_issues = _full_validation_issue_list(
+            compile_issues,
+            ci_issues,
+        )
+        retry_validation_issues = _validation_retry_issue_snapshot(
+            compile_issues,
+            ci_issues,
         )
     if apply_requested:
         if not _can_attempt_apply(result):
@@ -29601,6 +29607,7 @@ def _run_encode_attempt(
                 output_root=args.output,
             )
             if yaml_preflight_issue is not None:
+                full_validation_issues = (yaml_preflight_issue,)
                 retry_validation_issues = (yaml_preflight_issue,)
                 outcome["status"] = "apply_blocked_validation"
                 outcome["overlay_validation_success"] = False
@@ -29616,7 +29623,8 @@ def _run_encode_attempt(
                     outcome=outcome,
                     apply_passed=False,
                     logged_run=logged_run,
-                    validation_issues=retry_validation_issues,
+                    validation_issues=full_validation_issues,
+                    validation_retry_issues=retry_validation_issues,
                 )
 
             def _retry_generated_unsafe_formula_output_deferrals() -> list[str]:
@@ -32230,7 +32238,10 @@ def _run_encode_attempt(
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                retry_validation_issues = _full_validation_issue_list(apply_issues)
+                full_validation_issues = _full_validation_issue_list(apply_issues)
+                retry_validation_issues = _validation_retry_issue_snapshot(
+                    apply_issues
+                )
                 detail = (
                     apply_issues[0]
                     if apply_issues
@@ -32321,7 +32332,10 @@ def _run_encode_attempt(
                         apply_issues = required_import_issues
                         outcome["overlay_validation_success"] = False
                 if not can_apply:
-                    retry_validation_issues = _full_validation_issue_list(apply_issues)
+                    full_validation_issues = _full_validation_issue_list(apply_issues)
+                    retry_validation_issues = _validation_retry_issue_snapshot(
+                        apply_issues
+                    )
                     detail = (
                         apply_issues[0]
                         if apply_issues
@@ -32363,7 +32377,8 @@ def _run_encode_attempt(
         outcome=outcome,
         apply_passed=apply_passed,
         logged_run=logged_run,
-        validation_issues=retry_validation_issues,
+        validation_issues=full_validation_issues,
+        validation_retry_issues=retry_validation_issues,
     )
 
 
@@ -55043,7 +55058,6 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                 dependents=dependents,
             )
         issues: list[str] = []
-        seen_issues: set[str] = set()
         for validated_file, validation in validations:
             if getattr(validation, "all_passed", False):
                 continue
@@ -55053,16 +55067,39 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                     overlay_content_root,
                 )
                 validator_name = getattr(validator_result, "validator_name", "ci")
-                for issue in _bounded_overlay_validator_issues(
+                for issue in _full_overlay_validator_issues(
                     validator_result,
                     relative_file=relative_file,
                     validator_name=validator_name,
                 ):
-                    if issue in seen_issues:
-                        continue
-                    seen_issues.add(issue)
                     issues.append(issue)
         return False, issues, {}
+
+
+def _full_overlay_validator_issues(
+    validator_result: object,
+    *,
+    relative_file: Path,
+    validator_name: str,
+) -> tuple[str, ...]:
+    """Preserve every finite validator diagnostic for durable artifacts."""
+
+    prefix = f"{relative_file}: {validator_name}: "
+    raw_issues = getattr(validator_result, "issues", ())
+    candidates = (
+        raw_issues
+        if isinstance(raw_issues, Sequence) and not isinstance(raw_issues, (str, bytes))
+        else ()
+    )
+    issues = tuple(
+        f"{prefix}{raw_issue}"
+        for raw_issue in candidates
+        if isinstance(raw_issue, str) and raw_issue
+    )
+    if issues:
+        return issues
+    error = getattr(validator_result, "error", None)
+    return (f"{prefix}{error}",) if isinstance(error, str) and error else ()
 
 
 def _bounded_overlay_validator_issues(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26192,6 +26192,13 @@ def _validation_retry_candidate_location(
             part in _FAILED_ENCODE_CANDIDATE_PROTECTED_SEGMENTS
             for part in relative_output.parts
         )
+        or any(
+            any(
+                ord(character) < 32 or ord(character) == 127
+                for character in part
+            )
+            for part in relative_output.parts
+        )
     ):
         raise RuntimeError(
             "Validator-rejected retry candidate is not a canonical RuleSpec module"

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26381,6 +26381,14 @@ def _load_initial_validation_retry_candidate(
         or not relative_output.parts
         or "\\" in relative_output.as_posix()
         or any(part in {"", ".", ".."} for part in relative_output.parts)
+        or any(
+            part in _FAILED_ENCODE_CANDIDATE_PROTECTED_SEGMENTS
+            for part in relative_output.parts
+        )
+        or any(
+            any(ord(character) < 32 or ord(character) == 127 for character in part)
+            for part in relative_output.parts
+        )
     ):
         raise ValueError("encode --repair-candidate-path must be a safe relative path")
     parts = relative_output.parts

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26194,10 +26194,7 @@ def _validation_retry_candidate_location(
             for part in relative_output.parts
         )
         or any(
-            any(
-                ord(character) < 32 or ord(character) == 127
-                for character in part
-            )
+            any(ord(character) < 32 or ord(character) == 127 for character in part)
             for part in relative_output.parts
         )
     ):
@@ -26469,9 +26466,7 @@ def _load_initial_validation_retry_feedback(args: Any) -> tuple[str, ...]:
         raise ValueError("preserved repair candidate issues.json has an invalid shape")
 
     expected_path = Path(getattr(args, "repair_candidate_path")).as_posix()
-    expected_rulespec_sha256 = getattr(
-        args, "repair_candidate_rulespec_sha256", None
-    )
+    expected_rulespec_sha256 = getattr(args, "repair_candidate_rulespec_sha256", None)
     expected_tests_sha256 = getattr(args, "repair_candidate_tests_sha256", None)
     if metadata.get("citation") != str(getattr(args, "citation", "") or ""):
         raise ValueError("preserved repair candidate issues citation mismatch")
@@ -26484,8 +26479,7 @@ def _load_initial_validation_retry_feedback(args: Any) -> tuple[str, ...]:
     encoder_version = metadata.get("encoder_version")
     if (
         not isinstance(encoder_version, str)
-        or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9.+_-]{0,127}", encoder_version)
-        is None
+        or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9.+_-]{0,127}", encoder_version) is None
     ):
         raise ValueError("preserved repair candidate encoder version is invalid")
     attempt_count = metadata.get("attempt_count")

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26500,7 +26500,7 @@ def _load_initial_validation_retry_feedback(args: Any) -> tuple[str, ...]:
         or any(not isinstance(issue, str) or not issue for issue in issues)
     ):
         raise ValueError("preserved repair candidate issues are invalid")
-    return _validation_retry_issue_snapshot(issues)
+    return _finite_validation_retry_issue_snapshot(issues)
 
 
 def _validate_tests_only_repair_contract(
@@ -26578,12 +26578,18 @@ def _full_validation_issue_list(*issue_groups: object) -> tuple[str, ...]:
 
 def _validation_retry_issue_snapshot(
     *issue_groups: object,
+    inspection_limit_per_group: int = VALIDATION_RETRY_FEEDBACK_MAX_ITEMS * 4,
 ) -> tuple[str, ...]:
     """Snapshot bounded, category-diverse issues for one captured candidate."""
 
+    if (
+        isinstance(inspection_limit_per_group, bool)
+        or not isinstance(inspection_limit_per_group, int)
+        or inspection_limit_per_group < 1
+    ):
+        raise ValueError("Validation retry issue inspection limit must be positive")
     candidates: list[str] = []
     seen: set[str] = set()
-    inspection_limit = VALIDATION_RETRY_FEEDBACK_MAX_ITEMS * 4
     for issue_group in issue_groups:
         if not isinstance(issue_group, Sequence) or isinstance(
             issue_group, (str, bytes)
@@ -26591,7 +26597,7 @@ def _validation_retry_issue_snapshot(
             continue
         inspected = 0
         issue_iterator = iter(issue_group)
-        while inspected < inspection_limit:
+        while inspected < inspection_limit_per_group:
             try:
                 issue = next(issue_iterator)
             except StopIteration:
@@ -26605,6 +26611,17 @@ def _validation_retry_issue_snapshot(
             seen.add(item)
             candidates.append(item)
     return _category_diverse_validation_retry_issues(candidates)
+
+
+def _finite_validation_retry_issue_snapshot(
+    issue_group: Sequence[str],
+) -> tuple[str, ...]:
+    """Scan one materialized artifact-bounded issue list before prompt capping."""
+
+    return _validation_retry_issue_snapshot(
+        issue_group,
+        inspection_limit_per_group=_FAILED_ENCODE_CANDIDATE_MAX_ISSUES,
+    )
 
 
 def _category_diverse_validation_retry_issues(
@@ -32239,7 +32256,7 @@ def _run_encode_attempt(
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
                 full_validation_issues = _full_validation_issue_list(apply_issues)
-                retry_validation_issues = _validation_retry_issue_snapshot(
+                retry_validation_issues = _finite_validation_retry_issue_snapshot(
                     apply_issues
                 )
                 detail = (
@@ -32333,7 +32350,7 @@ def _run_encode_attempt(
                         outcome["overlay_validation_success"] = False
                 if not can_apply:
                     full_validation_issues = _full_validation_issue_list(apply_issues)
-                    retry_validation_issues = _validation_retry_issue_snapshot(
+                    retry_validation_issues = _finite_validation_retry_issue_snapshot(
                         apply_issues
                     )
                     detail = (

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26614,12 +26614,12 @@ def _validation_retry_issue_snapshot(
 
 
 def _finite_validation_retry_issue_snapshot(
-    issue_group: Sequence[str],
+    *issue_groups: Sequence[str],
 ) -> tuple[str, ...]:
-    """Scan one materialized artifact-bounded issue list before prompt capping."""
+    """Scan materialized artifact-bounded issue groups before prompt capping."""
 
     return _validation_retry_issue_snapshot(
-        issue_group,
+        *issue_groups,
         inspection_limit_per_group=_FAILED_ENCODE_CANDIDATE_MAX_ISSUES,
     )
 
@@ -29606,7 +29606,7 @@ def _run_encode_attempt(
             compile_issues,
             ci_issues,
         )
-        retry_validation_issues = _validation_retry_issue_snapshot(
+        retry_validation_issues = _finite_validation_retry_issue_snapshot(
             compile_issues,
             ci_issues,
         )

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26267,6 +26267,7 @@ def _emit_final_rejected_candidate(
     *,
     output_root: Path,
     destination: Path,
+    citation: str,
     validation_issues: Sequence[str],
     attempt_count: int,
 ) -> Path:
@@ -26303,9 +26304,14 @@ def _emit_final_rejected_candidate(
 
     rulespec_raw = candidate.rulespec.encode("utf-8")
     tests_raw = candidate.tests.encode("utf-8")
+    if not isinstance(citation, str) or not citation:
+        raise ValueError("Final rejected candidate citation is unavailable")
     metadata = {
         "schema": _FAILED_ENCODE_CANDIDATE_SCHEMA,
-        "citation": str(getattr(result, "citation", "") or ""),
+        # Preserve the requested identity exactly. EvalResult.citation is
+        # normalized by the harness, while workflow matrix entries and the
+        # subsequent repair invocation carry the original request spelling.
+        "citation": citation,
         "path": relative_output.as_posix(),
         "issues": issues,
         "rulespec_sha256": hashlib.sha256(rulespec_raw).hexdigest(),
@@ -26313,8 +26319,6 @@ def _emit_final_rejected_candidate(
         "encoder_version": __version__,
         "attempt_count": attempt_count,
     }
-    if not metadata["citation"]:
-        raise ValueError("Final rejected candidate citation is unavailable")
     metadata_raw = (
         json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     ).encode("utf-8")
@@ -29185,6 +29189,7 @@ def _run_encode_attempts_with_retries(
                 execution.result,
                 output_root=args.output,
                 destination=emit_destination,
+                citation=str(args.citation),
                 validation_issues=final_issues,
                 attempt_count=len(failed_attempts) + 1,
             )

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26144,6 +26144,7 @@ _FAILED_ENCODE_CANDIDATE_METADATA_FIELDS = {
 }
 _FAILED_ENCODE_CANDIDATE_MAX_ISSUES_BYTES = 512 * 1024
 _FAILED_ENCODE_CANDIDATE_MAX_ISSUES = 4096
+_FAILED_ENCODE_CANDIDATE_EMPTY_TESTS = "[]\n"
 _FAILED_ENCODE_CANDIDATE_PROTECTED_SEGMENTS = {
     ".git",
     ".github",
@@ -26279,10 +26280,6 @@ def _emit_final_rejected_candidate(
         _validation_retry_candidate_location(result, output_root=output_root)
     )
     candidate = _capture_validation_retry_candidate(result, output_root=output_root)
-    if candidate.tests is None:
-        raise RuntimeError(
-            "Final validator-rejected candidate has no companion test file"
-        )
     if (
         not isinstance(attempt_count, int)
         or isinstance(attempt_count, bool)
@@ -26304,7 +26301,14 @@ def _emit_final_rejected_candidate(
         )
 
     rulespec_raw = candidate.rulespec.encode("utf-8")
-    tests_raw = candidate.tests.encode("utf-8")
+    # A missing companion is itself a rejected-candidate state. Materialize the
+    # canonical empty case list so the durable repair contract remains an exact
+    # three-file pair while representing that no test cases were generated.
+    tests_raw = (
+        candidate.tests
+        if candidate.tests is not None
+        else _FAILED_ENCODE_CANDIDATE_EMPTY_TESTS
+    ).encode("utf-8")
     if not isinstance(citation, str) or not citation:
         raise ValueError("Final rejected candidate citation is unavailable")
     metadata = {

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26188,6 +26188,7 @@ def _validation_retry_candidate_location(
         len(module_parts) < 2
         or output_file.suffix != RULESPEC_FILE_SUFFIX
         or output_file.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+        or "\\" in relative_output.as_posix()
         or any(
             part in _FAILED_ENCODE_CANDIDATE_PROTECTED_SEGMENTS
             for part in relative_output.parts
@@ -26378,6 +26379,7 @@ def _load_initial_validation_retry_candidate(
     if (
         relative_output.is_absolute()
         or not relative_output.parts
+        or "\\" in relative_output.as_posix()
         or any(part in {"", ".", ".."} for part in relative_output.parts)
     ):
         raise ValueError("encode --repair-candidate-path must be a safe relative path")

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -191,6 +191,7 @@ from .harness.evals import (
     _render_eval_result_verdict_evidence,
     _resolve_eval_output_path,
     _rulespec_root_execution_identity,
+    _secure_atomic_eval_write,
     _source_metadata_citation_path,
     _source_metadata_with_attestation,
     _suite_retry_attempts_from_execution_identity,
@@ -2779,6 +2780,14 @@ def main():
             "Keep the hash-bound repair candidate RuleSpec immutable and permit "
             "only a non-weakening companion-test expansion required by a v2 "
             "review contract"
+        ),
+    )
+    encode_parser.add_argument(
+        "--emit-final-rejected-candidate",
+        type=Path,
+        help=(
+            "Write the final validator-rejected RuleSpec, companion tests, and "
+            "issue metadata to one fresh absolute directory"
         ),
     )
     encode_parser.add_argument(
@@ -26122,12 +26131,33 @@ class _FailedEncodeAttempt(NamedTuple):
     validation_issues: Sequence[str] = ()
 
 
-def _capture_validation_retry_candidate(
+_FAILED_ENCODE_CANDIDATE_SCHEMA = "axiom-encode/failed-encode-candidate/v1"
+_FAILED_ENCODE_CANDIDATE_METADATA_FIELDS = {
+    "schema",
+    "citation",
+    "path",
+    "issues",
+    "rulespec_sha256",
+    "tests_sha256",
+    "encoder_version",
+    "attempt_count",
+}
+_FAILED_ENCODE_CANDIDATE_MAX_ISSUES_BYTES = 512 * 1024
+_FAILED_ENCODE_CANDIDATE_MAX_ISSUES = 4096
+_FAILED_ENCODE_CANDIDATE_PROTECTED_SEGMENTS = {
+    ".git",
+    ".github",
+    "_axiom",
+    "scripts",
+}
+
+
+def _validation_retry_candidate_location(
     result: Any,
     *,
     output_root: Path,
-) -> ValidationRetryCandidate:
-    """Read one generated candidate through contained, bounded file handles."""
+) -> tuple[Path, Path, Path]:
+    """Resolve one generated candidate to a canonical contained module path."""
 
     runner = str(getattr(result, "runner", "") or "")
     if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", runner) is None:
@@ -26158,10 +26188,27 @@ def _capture_validation_retry_candidate(
         len(module_parts) < 2
         or output_file.suffix != RULESPEC_FILE_SUFFIX
         or output_file.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+        or any(
+            part in _FAILED_ENCODE_CANDIDATE_PROTECTED_SEGMENTS
+            for part in relative_output.parts
+        )
     ):
         raise RuntimeError(
             "Validator-rejected retry candidate is not a canonical RuleSpec module"
         )
+    return generated_root, output_file, relative_output
+
+
+def _capture_validation_retry_candidate(
+    result: Any,
+    *,
+    output_root: Path,
+) -> ValidationRetryCandidate:
+    """Read one generated candidate through contained, bounded file handles."""
+
+    generated_root, output_file, _relative_output = (
+        _validation_retry_candidate_location(result, output_root=output_root)
+    )
     rulespec = read_bounded_regular_file(
         generated_root,
         output_file,
@@ -26180,6 +26227,111 @@ def _capture_validation_retry_candidate(
         else None
     )
     return ValidationRetryCandidate(rulespec=rulespec, tests=tests)
+
+
+def _resolve_final_rejected_candidate_destination(raw_destination: object) -> Path:
+    """Resolve a fresh absolute output directory without symlinked ancestors."""
+
+    if not isinstance(raw_destination, (str, os.PathLike)):
+        raise TypeError("encode rejected-candidate destination must be a path")
+    lexical = Path(raw_destination)
+    destination = Path(os.path.abspath(lexical))
+    if not lexical.is_absolute() or lexical != destination:
+        raise ValueError(
+            "encode --emit-final-rejected-candidate must be a normalized absolute path"
+        )
+    try:
+        parent = destination.parent.resolve(strict=True)
+    except OSError as exc:
+        raise ValueError(
+            "encode rejected-candidate destination parent must already exist"
+        ) from exc
+    if parent != destination.parent or not parent.is_dir():
+        raise ValueError(
+            "encode rejected-candidate destination parent must be canonical"
+        )
+    if destination.exists() or destination.is_symlink():
+        raise ValueError("encode rejected-candidate destination must not exist")
+    return destination
+
+
+def _emit_final_rejected_candidate(
+    result: Any,
+    *,
+    output_root: Path,
+    destination: Path,
+    validation_issues: Sequence[str],
+    attempt_count: int,
+) -> Path:
+    """Materialize exactly one final rejected pair and its bounded issue metadata."""
+
+    resolved_destination = _resolve_final_rejected_candidate_destination(destination)
+    _generated_root, _output_file, relative_output = (
+        _validation_retry_candidate_location(result, output_root=output_root)
+    )
+    candidate = _capture_validation_retry_candidate(result, output_root=output_root)
+    if candidate.tests is None:
+        raise RuntimeError(
+            "Final validator-rejected candidate has no companion test file"
+        )
+    if (
+        not isinstance(attempt_count, int)
+        or isinstance(attempt_count, bool)
+        or attempt_count < 1
+    ):
+        raise ValueError("Final rejected candidate attempt count must be positive")
+    if isinstance(validation_issues, (str, bytes)) or not isinstance(
+        validation_issues, Sequence
+    ):
+        raise TypeError("Final rejected candidate issues must be a sequence")
+    issues = list(validation_issues)
+    if (
+        not issues
+        or len(issues) > _FAILED_ENCODE_CANDIDATE_MAX_ISSUES
+        or any(not isinstance(issue, str) or not issue for issue in issues)
+    ):
+        raise ValueError(
+            "Final rejected candidate issues must be a nonempty bounded string list"
+        )
+
+    rulespec_raw = candidate.rulespec.encode("utf-8")
+    tests_raw = candidate.tests.encode("utf-8")
+    metadata = {
+        "schema": _FAILED_ENCODE_CANDIDATE_SCHEMA,
+        "citation": str(getattr(result, "citation", "") or ""),
+        "path": relative_output.as_posix(),
+        "issues": issues,
+        "rulespec_sha256": hashlib.sha256(rulespec_raw).hexdigest(),
+        "tests_sha256": hashlib.sha256(tests_raw).hexdigest(),
+        "encoder_version": __version__,
+        "attempt_count": attempt_count,
+    }
+    if not metadata["citation"]:
+        raise ValueError("Final rejected candidate citation is unavailable")
+    metadata_raw = (
+        json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+    if len(metadata_raw) > _FAILED_ENCODE_CANDIDATE_MAX_ISSUES_BYTES:
+        raise ValueError("Final rejected candidate issues.json exceeds its size limit")
+
+    _secure_atomic_eval_write(
+        resolved_destination,
+        relative_output,
+        rulespec_raw,
+    )
+    _secure_atomic_eval_write(
+        resolved_destination,
+        _rulespec_test_path(relative_output),
+        tests_raw,
+    )
+    # Write metadata last: its presence marks a complete candidate pair for the
+    # independent workflow verifier. Any interrupted partial root is rejected.
+    _secure_atomic_eval_write(
+        resolved_destination,
+        Path("issues.json"),
+        metadata_raw,
+    )
+    return resolved_destination
 
 
 def _load_initial_validation_retry_candidate(
@@ -26262,6 +26414,74 @@ def _load_initial_validation_retry_candidate(
     )
 
 
+def _load_initial_validation_retry_feedback(args: Any) -> tuple[str, ...]:
+    """Load optional issue metadata bound to the existing repair flag quartet."""
+
+    raw_root = getattr(args, "repair_candidate_root", None)
+    if raw_root is None:
+        return ()
+    root = Path(os.path.abspath(Path(raw_root)))
+    issues_path = root / "issues.json"
+    if not issues_path.exists() and not issues_path.is_symlink():
+        # Targeted-reencode repair roots predate this optional metadata file.
+        return ()
+    issues_raw = read_bounded_regular_file(
+        root,
+        issues_path,
+        label="preserved validator-rejected issues",
+        max_bytes=_FAILED_ENCODE_CANDIDATE_MAX_ISSUES_BYTES,
+    )
+    try:
+        metadata = json.loads(issues_raw.decode("utf-8", errors="strict"))
+    except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError(
+            "preserved repair candidate issues.json is not valid UTF-8 JSON"
+        ) from exc
+    if (
+        not isinstance(metadata, dict)
+        or set(metadata) != _FAILED_ENCODE_CANDIDATE_METADATA_FIELDS
+        or metadata.get("schema") != _FAILED_ENCODE_CANDIDATE_SCHEMA
+    ):
+        raise ValueError("preserved repair candidate issues.json has an invalid shape")
+
+    expected_path = Path(getattr(args, "repair_candidate_path")).as_posix()
+    expected_rulespec_sha256 = getattr(
+        args, "repair_candidate_rulespec_sha256", None
+    )
+    expected_tests_sha256 = getattr(args, "repair_candidate_tests_sha256", None)
+    if metadata.get("citation") != str(getattr(args, "citation", "") or ""):
+        raise ValueError("preserved repair candidate issues citation mismatch")
+    if metadata.get("path") != expected_path:
+        raise ValueError("preserved repair candidate issues path mismatch")
+    if metadata.get("rulespec_sha256") != expected_rulespec_sha256:
+        raise ValueError("preserved repair candidate issues RuleSpec SHA-256 mismatch")
+    if metadata.get("tests_sha256") != expected_tests_sha256:
+        raise ValueError("preserved repair candidate issues tests SHA-256 mismatch")
+    encoder_version = metadata.get("encoder_version")
+    if (
+        not isinstance(encoder_version, str)
+        or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9.+_-]{0,127}", encoder_version)
+        is None
+    ):
+        raise ValueError("preserved repair candidate encoder version is invalid")
+    attempt_count = metadata.get("attempt_count")
+    if (
+        not isinstance(attempt_count, int)
+        or isinstance(attempt_count, bool)
+        or attempt_count < 1
+    ):
+        raise ValueError("preserved repair candidate attempt count is invalid")
+    issues = metadata.get("issues")
+    if (
+        not isinstance(issues, list)
+        or not issues
+        or len(issues) > _FAILED_ENCODE_CANDIDATE_MAX_ISSUES
+        or any(not isinstance(issue, str) or not issue for issue in issues)
+    ):
+        raise ValueError("preserved repair candidate issues are invalid")
+    return _validation_retry_issue_snapshot(issues)
+
+
 def _validate_tests_only_repair_contract(
     args: Any,
     candidate: ValidationRetryCandidate | None,
@@ -26320,6 +26540,19 @@ def _latest_validation_retry_candidate(
     """Return only the immediately preceding candidate, when safely captured."""
 
     return prior_attempts[-1].candidate if prior_attempts else None
+
+
+def _full_validation_issue_list(*issue_groups: object) -> tuple[str, ...]:
+    """Preserve every string issue from finite validator-produced sequences."""
+
+    issues: list[str] = []
+    for issue_group in issue_groups:
+        if not isinstance(issue_group, Sequence) or isinstance(
+            issue_group, (str, bytes)
+        ):
+            continue
+        issues.extend(issue for issue in issue_group if isinstance(issue, str))
+    return tuple(issues)
 
 
 def _validation_retry_issue_snapshot(
@@ -26503,12 +26736,15 @@ def _encode_validation_retry_context(
     prior_attempts: Sequence[_FailedEncodeAttempt],
     *,
     initial_retry_candidate: ValidationRetryCandidate | None,
+    initial_retry_feedback: Sequence[str] = (),
     preserve_initial_candidate: bool = False,
 ) -> tuple[tuple[str, ...], ValidationRetryCandidate | None]:
     """Bind validator feedback to the exact candidate that produced it."""
 
     if not prior_attempts:
-        return (), initial_retry_candidate
+        if initial_retry_feedback and initial_retry_candidate is None:
+            raise RuntimeError("Initial validation retry feedback has no candidate")
+        return tuple(initial_retry_feedback), initial_retry_candidate
     if preserve_initial_candidate:
         if initial_retry_candidate is None:
             raise RuntimeError("Preserved validation retry candidate is unavailable")
@@ -28847,7 +29083,14 @@ def _run_encode_attempts_with_retries(
     resolved_policy_checkout_path: Path | None = None,
 ):
     """Bounded validator-retry loop for one encode invocation."""
+    raw_emit_destination = getattr(args, "emit_final_rejected_candidate", None)
+    emit_destination = (
+        _resolve_final_rejected_candidate_destination(raw_emit_destination)
+        if raw_emit_destination is not None
+        else None
+    )
     initial_retry_candidate = _load_initial_validation_retry_candidate(args)
+    initial_retry_feedback = _load_initial_validation_retry_feedback(args)
     _validate_tests_only_repair_contract(args, initial_retry_candidate)
     failed_attempts: tuple[_FailedEncodeAttempt, ...] = ()
     current_model = config.initial_model
@@ -28858,6 +29101,7 @@ def _run_encode_attempts_with_retries(
             model=current_model,
             prior_attempts=failed_attempts,
             initial_retry_candidate=initial_retry_candidate,
+            initial_retry_feedback=initial_retry_feedback,
             defer_logging=config.enabled,
             apply_signing_broker=apply_signing_broker,
             resolved_policy_checkout_path=resolved_policy_checkout_path,
@@ -28892,7 +29136,9 @@ def _run_encode_attempts_with_retries(
                     result=execution.result,
                     error=retry_error,
                     candidate=candidate,
-                    validation_issues=execution.validation_issues,
+                    validation_issues=_validation_retry_issue_snapshot(
+                        execution.validation_issues
+                    ),
                 )
         if next_model is not None:
             action = "retrying" if next_model == current_model else "escalating"
@@ -28920,6 +29166,22 @@ def _run_encode_attempts_with_retries(
                 continue
 
         outcome = execution.outcome
+        final_validator_rejected = _encode_attempt_was_validator_rejected(
+            execution.result,
+            outcome,
+        )
+        if emit_destination is not None and final_validator_rejected:
+            final_issues = execution.validation_issues or (
+                _encode_outcome_issue(execution.result, outcome),
+            )
+            emitted_candidate = _emit_final_rejected_candidate(
+                execution.result,
+                output_root=args.output,
+                destination=emit_destination,
+                validation_issues=final_issues,
+                attempt_count=len(failed_attempts) + 1,
+            )
+            print(f"  final_rejected_candidate={emitted_candidate}")
         escalated = (
             current_model == config.escalation_model
             and config.escalation_model != config.initial_model
@@ -28999,6 +29261,7 @@ def _run_encode_attempt(
     model: str,
     prior_attempts: Sequence[_FailedEncodeAttempt] = (),
     initial_retry_candidate: ValidationRetryCandidate | None = None,
+    initial_retry_feedback: Sequence[str] = (),
     defer_logging: bool = True,
     apply_signing_broker: SigningBroker | None = None,
     resolved_policy_checkout_path: Path | None = None,
@@ -29127,6 +29390,7 @@ def _run_encode_attempt(
         _encode_validation_retry_context(
             prior_attempts,
             initial_retry_candidate=initial_retry_candidate,
+            initial_retry_feedback=initial_retry_feedback,
             preserve_initial_candidate=(
                 getattr(args, "repair_candidate_tests_only", False) is True
             ),
@@ -29297,7 +29561,7 @@ def _run_encode_attempt(
     retry_validation_issues: tuple[str, ...] = ()
     metrics = getattr(result, "metrics", None)
     if metrics is not None:
-        retry_validation_issues = _validation_retry_issue_snapshot(
+        retry_validation_issues = _full_validation_issue_list(
             getattr(metrics, "compile_issues", ()),
             getattr(metrics, "ci_issues", ()),
         )
@@ -31944,7 +32208,7 @@ def _run_encode_attempt(
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                retry_validation_issues = _validation_retry_issue_snapshot(apply_issues)
+                retry_validation_issues = _full_validation_issue_list(apply_issues)
                 detail = (
                     apply_issues[0]
                     if apply_issues
@@ -32035,9 +32299,7 @@ def _run_encode_attempt(
                         apply_issues = required_import_issues
                         outcome["overlay_validation_success"] = False
                 if not can_apply:
-                    retry_validation_issues = _validation_retry_issue_snapshot(
-                        apply_issues
-                    )
+                    retry_validation_issues = _full_validation_issue_list(apply_issues)
                     detail = (
                         apply_issues[0]
                         if apply_issues

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1693"
+ENCODER_VERSION = "0.2.1694"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14300,6 +14300,74 @@ rules:
             ["current CI issue"],
         ) == ("duplicate compile issue", "current CI issue")
 
+    def test_encode_retry_preserves_ci_feedback_after_compile_issue_flood(
+        self, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=False,
+            sync=False,
+            escalation_enabled=True,
+        )
+        compile_issue = "duplicate compile issue"
+        ci_issue = "current CI completeness issue"
+        generated_attempts = 0
+
+        def generate(**kwargs):
+            nonlocal generated_attempts
+            generated_attempts += 1
+            backend, model = kwargs["runner_specs"][0].split(":", 1)
+            result = self._make_eval_result(generated_attempts == 2)
+            result.backend = backend
+            result.model = model
+            result.runner = f"{backend}-{model}"
+            output_file = (
+                args.output
+                / result.runner
+                / "statutes"
+                / "26"
+                / "1"
+                / "j"
+                / "2.yaml"
+            )
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_text("format: rulespec/v1\nrules: []\n")
+            output_file.with_suffix(".test.yaml").write_text("[]\n")
+            result.output_file = str(output_file)
+            if generated_attempts == 1:
+                assert kwargs["validation_retry_feedback"] == ()
+                result.error = "Generated RuleSpec failed CI validation"
+                result.metrics = SimpleNamespace(
+                    compile_pass=False,
+                    ci_pass=False,
+                    compile_issues=[compile_issue] * 48,
+                    ci_issues=[ci_issue],
+                    grounded_numeric_count=0,
+                    ungrounded_numeric_count=0,
+                    embedded_source_present=False,
+                    generalist_review_score=None,
+                    policyengine_score=None,
+                    grounding=[],
+                )
+            else:
+                assert kwargs["validation_retry_feedback"] == (
+                    "Generated RuleSpec failed CI validation",
+                    compile_issue,
+                    ci_issue,
+                )
+            return [result]
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", side_effect=generate) as model,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        assert generated_attempts == 2
+        assert model.call_count == 2
+
     def test_encode_retry_issue_snapshot_pairs_structure_with_formula_remediation(self):
         import axiom_encode.cli as cli_module
 
@@ -14429,6 +14497,25 @@ rules:
         assert flooded.inspected == 48
         assert len(issues) == 48
         assert fallback == ("statutes/26/1.yaml: ci: fallback",)
+
+    def test_full_overlay_validator_issues_preserve_post_prompt_bound_diagnostics(
+        self,
+    ):
+        import axiom_encode.cli as cli_module
+
+        long_issue = "long issue " + ("x" * 17_000)
+        raw_issues = [long_issue, *(f"issue {index}" for index in range(63))]
+        raw_issues.append(long_issue)
+
+        issues = cli_module._full_overlay_validator_issues(
+            SimpleNamespace(issues=raw_issues, error=raw_issues[0]),
+            relative_file=Path("statutes/26/1.yaml"),
+            validator_name="ci",
+        )
+
+        assert len(issues) == 65
+        assert issues[0] == f"statutes/26/1.yaml: ci: {long_issue}"
+        assert issues[-1] == issues[0]
 
     def test_encode_retry_feedback_retains_compound_diagnostic_tail(self):
         import axiom_encode.cli as cli_module
@@ -14644,7 +14731,13 @@ rules:
         assert "rejected-attempt-4" in (
             failed_candidate_root / relative_rulespec
         ).read_text()
+        assert "deterministic-post-repair-4" in (
+            failed_candidate_root / relative_rulespec
+        ).read_text()
         assert "historical-and-current-cases-4" in (
+            failed_candidate_root / relative_tests
+        ).read_text()
+        assert "deterministic-post-repair-tests-4" in (
             failed_candidate_root / relative_tests
         ).read_text()
         issues = json.loads((failed_candidate_root / "issues.json").read_text())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15115,6 +15115,58 @@ rules:
 
         model_call.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("metadata_kind", "message"),
+        [
+            ("invalid-json", "issues.json is not valid UTF-8 JSON"),
+            ("wrong-sha", "issues RuleSpec SHA-256 mismatch"),
+        ],
+    )
+    def test_encode_rejects_invalid_seed_issue_metadata_before_model_call(
+        self, tmp_path, metadata_kind, message
+    ):
+        candidate_root = tmp_path / "preserved-candidate"
+        candidate_path = Path("statutes/26/1/j/2.yaml")
+        output_file = candidate_root / candidate_path
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text("format: rulespec/v1\nrules: []\n")
+        test_file = output_file.with_suffix(".test.yaml")
+        test_file.write_text("[]\n")
+        rulespec_sha256 = hashlib.sha256(output_file.read_bytes()).hexdigest()
+        tests_sha256 = hashlib.sha256(test_file.read_bytes()).hexdigest()
+        issues_file = candidate_root / "issues.json"
+        if metadata_kind == "invalid-json":
+            issues_file.write_text("{\n")
+        else:
+            issues_file.write_text(
+                json.dumps(
+                    {
+                        "schema": "axiom-encode/failed-encode-candidate/v1",
+                        "citation": "26 USC 1(j)(2)",
+                        "path": candidate_path.as_posix(),
+                        "issues": ["validator rejected candidate"],
+                        "rulespec_sha256": "0" * 64,
+                        "tests_sha256": tests_sha256,
+                        "encoder_version": AXIOM_ENCODE_TEST_VERSION,
+                        "attempt_count": 1,
+                    }
+                )
+                + "\n"
+            )
+        args = self._make_args(
+            tmp_path,
+            repair_candidate_root=candidate_root,
+            repair_candidate_path=candidate_path,
+            repair_candidate_rulespec_sha256=rulespec_sha256,
+            repair_candidate_tests_sha256=tests_sha256,
+        )
+
+        with patch("axiom_encode.cli.run_model_eval") as model_call:
+            with pytest.raises(ValueError, match=message):
+                cmd_encode(args)
+
+        model_call.assert_not_called()
+
     @pytest.mark.parametrize("unsafe_kind", ["symlink", "invalid-utf8", "oversize"])
     def test_encode_retry_candidate_capture_rejects_unsafe_content(
         self, tmp_path, unsafe_kind

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13321,6 +13321,9 @@ class TestCmdEncode:
             runner_name = f"{backend}-{model}"
             generated_models.append(model)
             result = self._make_eval_result(True)
+            # Match the real harness: EvalResult stores a normalized citation,
+            # even when the CLI request used a supported human-readable alias.
+            result.citation = normalize_corpus_identifier(args.citation)
             result.backend = backend
             result.model = model
             result.runner = runner_name
@@ -14706,6 +14709,7 @@ rules:
                 ),
                 output_root=output_root,
                 destination=tmp_path / "failed-encode",
+                citation="26 USC 1(j)(2)",
                 validation_issues=("validator rejected candidate",),
                 attempt_count=1,
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13117,6 +13117,9 @@ class TestCmdEncode:
         args.repair_candidate_tests_only = overrides.get(
             "repair_candidate_tests_only", False
         )
+        args.emit_final_rejected_candidate = overrides.get(
+            "emit_final_rejected_candidate", None
+        )
         args.policyengine_rule_hint = overrides.get("policyengine_rule_hint", None)
         args.db = overrides.get("db", tmp_path / "encodings.db")
         args.sync = overrides.get("sync", True)
@@ -14546,6 +14549,140 @@ rules:
         assert "preserved-rule" in candidate.rulespec
         assert candidate.tests is not None
         assert "preserved-companion" in candidate.tests
+
+    def test_encode_passes_cross_run_candidate_issues_to_first_attempt_feedback(
+        self, tmp_path
+    ):
+        candidate_root = tmp_path / "preserved-candidate"
+        candidate_path = Path("statutes/26/1/j/2.yaml")
+        output_file = candidate_root / candidate_path
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text("format: rulespec/v1\n# preserved-rule\nrules: []\n")
+        test_file = output_file.with_suffix(".test.yaml")
+        test_file.write_text("# preserved-companion\n[]\n")
+        rulespec_sha256 = hashlib.sha256(output_file.read_bytes()).hexdigest()
+        tests_sha256 = hashlib.sha256(test_file.read_bytes()).hexdigest()
+        seeded_issues = [
+            "[complete-source-unit:structure] missing branch: section 66(1)",
+            "[complete-source-unit:formula-output] section 66(1) has no output",
+        ]
+        (candidate_root / "issues.json").write_text(
+            json.dumps(
+                {
+                    "schema": "axiom-encode/failed-encode-candidate/v1",
+                    "path": candidate_path.as_posix(),
+                    "issues": seeded_issues,
+                    "rulespec_sha256": rulespec_sha256,
+                    "tests_sha256": tests_sha256,
+                    "encoder_version": AXIOM_ENCODE_TEST_VERSION,
+                    "attempt_count": 4,
+                }
+            )
+            + "\n"
+        )
+        args = self._make_args(
+            tmp_path,
+            repair_candidate_root=candidate_root,
+            repair_candidate_path=candidate_path,
+            repair_candidate_rulespec_sha256=rulespec_sha256,
+            repair_candidate_tests_sha256=tests_sha256,
+        )
+
+        mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
+
+        assert exit_code == 0
+        assert mock_run.call_args.kwargs["validation_retry_feedback"] == tuple(
+            seeded_issues
+        )
+
+    def test_encode_emits_only_final_validator_rejected_candidate(self, tmp_path):
+        failed_candidate_root = tmp_path / "failed-encode"
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+            emit_final_rejected_candidate=failed_candidate_root,
+        )
+        final_issues = [
+            "[complete-source-unit:structure] missing branch: section 66(1)",
+            "[complete-source-unit:formula-output] section 66(1) has no output",
+        ]
+
+        exit_code, generated, _validated, _run, _validate, _apply = (
+            self._run_validator_escalation_case(
+                args,
+                [
+                    (False, ["terra attempt one"]),
+                    (False, ["terra attempt two"]),
+                    (False, ["sol attempt one"]),
+                    (False, final_issues),
+                ],
+            )
+        )
+
+        assert exit_code == 1
+        assert len(generated) == 4
+        relative_rulespec = Path("statutes/26/1/j/2.yaml")
+        relative_tests = relative_rulespec.with_suffix(".test.yaml")
+        emitted_files = {
+            path.relative_to(failed_candidate_root).as_posix()
+            for path in failed_candidate_root.rglob("*")
+            if path.is_file()
+        }
+        assert emitted_files == {
+            "issues.json",
+            relative_rulespec.as_posix(),
+            relative_tests.as_posix(),
+        }
+        assert "rejected-attempt-4" in (
+            failed_candidate_root / relative_rulespec
+        ).read_text()
+        assert "historical-and-current-cases-4" in (
+            failed_candidate_root / relative_tests
+        ).read_text()
+        issues = json.loads((failed_candidate_root / "issues.json").read_text())
+        assert issues == {
+            "schema": "axiom-encode/failed-encode-candidate/v1",
+            "path": relative_rulespec.as_posix(),
+            "issues": final_issues,
+            "rulespec_sha256": hashlib.sha256(
+                (failed_candidate_root / relative_rulespec).read_bytes()
+            ).hexdigest(),
+            "tests_sha256": hashlib.sha256(
+                (failed_candidate_root / relative_tests).read_bytes()
+            ).hexdigest(),
+            "encoder_version": AXIOM_ENCODE_TEST_VERSION,
+            "attempt_count": 4,
+        }
+
+    @pytest.mark.parametrize(
+        "relative_output",
+        [Path("metrics/result.yaml"), Path("statutes/26/1.test.yaml")],
+    )
+    def test_final_rejected_candidate_emission_rejects_noncanonical_output(
+        self, tmp_path, relative_output
+    ):
+        import axiom_encode.cli as cli_module
+
+        output_root = tmp_path / "out"
+        output_file = output_root / "codex-terra" / relative_output
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text("format: rulespec/v1\nrules: []\n")
+        output_file.with_suffix(".test.yaml").write_text("[]\n")
+
+        with pytest.raises(RuntimeError, match="canonical RuleSpec module"):
+            cli_module._emit_final_rejected_candidate(
+                SimpleNamespace(
+                    runner="codex-terra",
+                    output_file=str(output_file),
+                ),
+                output_root=output_root,
+                destination=tmp_path / "failed-encode",
+                validation_issues=("validator rejected candidate",),
+                attempt_count=1,
+            )
 
     def test_encode_tests_only_repair_requires_bound_apply_contract(self, tmp_path):
         import axiom_encode.cli as cli_module

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14341,7 +14341,9 @@ rules:
             escalation_enabled=True,
         )
         compile_issue = "duplicate compile issue"
-        ci_issue = "current CI completeness issue"
+        ci_issue = (
+            "[complete-source-unit:structure] current CI completeness issue"
+        )
         generated_attempts = 0
 
         def generate(**kwargs):
@@ -14372,7 +14374,10 @@ rules:
                     compile_pass=False,
                     ci_pass=False,
                     compile_issues=[compile_issue] * 48,
-                    ci_issues=[ci_issue],
+                    ci_issues=[
+                        *(f"generic CI issue {index}" for index in range(48)),
+                        ci_issue,
+                    ],
                     grounded_numeric_count=0,
                     ungrounded_numeric_count=0,
                     embedded_source_present=False,
@@ -14381,7 +14386,7 @@ rules:
                     grounding=[],
                 )
             else:
-                assert kwargs["validation_retry_feedback"] == (
+                assert kwargs["validation_retry_feedback"][:3] == (
                     "Generated RuleSpec failed CI validation",
                     compile_issue,
                     ci_issue,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14570,6 +14570,7 @@ rules:
             json.dumps(
                 {
                     "schema": "axiom-encode/failed-encode-candidate/v1",
+                    "citation": "26 USC 1(j)(2)",
                     "path": candidate_path.as_posix(),
                     "issues": seeded_issues,
                     "rulespec_sha256": rulespec_sha256,
@@ -14645,6 +14646,7 @@ rules:
         issues = json.loads((failed_candidate_root / "issues.json").read_text())
         assert issues == {
             "schema": "axiom-encode/failed-encode-candidate/v1",
+            "citation": "26 USC 1(j)(2)",
             "path": relative_rulespec.as_posix(),
             "issues": final_issues,
             "rulespec_sha256": hashlib.sha256(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14688,7 +14688,11 @@ rules:
 
     @pytest.mark.parametrize(
         "relative_output",
-        [Path("metrics/result.yaml"), Path("statutes/26/1.test.yaml")],
+        [
+            Path("metrics/result.yaml"),
+            Path("statutes/26/1.test.yaml"),
+            Path(r"statutes/26/foo\bar.yaml"),
+        ],
     )
     def test_final_rejected_candidate_emission_rejects_noncanonical_output(
         self, tmp_path, relative_output
@@ -14890,6 +14894,11 @@ rules:
             (Path("candidate"), None, "must be supplied together"),
             (None, Path("statutes/26/1.yaml"), "must be supplied together"),
             (Path("candidate"), Path("../1.yaml"), "safe relative path"),
+            (
+                Path("candidate"),
+                Path(r"statutes/26/foo\bar.yaml"),
+                "safe relative path",
+            ),
             (Path("candidate"), Path("metrics/1.yaml"), "canonical RuleSpec"),
         ],
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13844,6 +13844,36 @@ class TestCmdEncode:
             "escalation_model": DEFAULT_OPENAI_ESCALATION_MODEL,
         }
 
+    def test_encode_retry_scans_full_overlay_issue_list_for_actionable_feedback(
+        self, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+        )
+        actionable_issue = (
+            "[complete-source-unit:structure] missing final completeness branch"
+        )
+        overlay_issues = [
+            *(f"generic overlay issue {index}" for index in range(48)),
+            actionable_issue,
+        ]
+
+        exit_code, _generated, _validated, mock_run, _validate, _apply = (
+            self._run_validator_escalation_case(
+                args,
+                [(False, overlay_issues), (True, [])],
+            )
+        )
+
+        assert exit_code == 0
+        assert actionable_issue in mock_run.call_args_list[1].kwargs[
+            "validation_retry_feedback"
+        ]
+
     @pytest.mark.parametrize(
         "issue",
         (
@@ -14653,9 +14683,13 @@ rules:
         test_file.write_text("# preserved-companion\n[]\n")
         rulespec_sha256 = hashlib.sha256(output_file.read_bytes()).hexdigest()
         tests_sha256 = hashlib.sha256(test_file.read_bytes()).hexdigest()
-        seeded_issues = [
+        actionable_seeded_issues = [
             "[complete-source-unit:structure] missing branch: section 66(1)",
             "[complete-source-unit:formula-output] section 66(1) has no output",
+        ]
+        seeded_issues = [
+            *(f"generic seeded issue {index}" for index in range(48)),
+            *actionable_seeded_issues,
         ]
         (candidate_root / "issues.json").write_text(
             json.dumps(
@@ -14683,9 +14717,9 @@ rules:
         mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
 
         assert exit_code == 0
-        assert mock_run.call_args.kwargs["validation_retry_feedback"] == tuple(
-            seeded_issues
-        )
+        feedback = mock_run.call_args.kwargs["validation_retry_feedback"]
+        assert len(feedback) == 12
+        assert all(issue in feedback for issue in actionable_seeded_issues)
 
     def test_encode_emits_only_final_validator_rejected_candidate(self, tmp_path):
         failed_candidate_root = tmp_path / "failed-encode"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14858,6 +14858,15 @@ rules:
         with pytest.raises(ValueError, match="must not exist"):
             cli_module._resolve_final_rejected_candidate_destination(existing)
 
+        real_parent = tmp_path / "real-parent"
+        real_parent.mkdir()
+        symlinked_parent = tmp_path / "symlinked-parent"
+        symlinked_parent.symlink_to(real_parent, target_is_directory=True)
+        with pytest.raises(ValueError, match="parent must be canonical"):
+            cli_module._resolve_final_rejected_candidate_destination(
+                symlinked_parent / "failed-encode"
+            )
+
     def test_encode_tests_only_repair_requires_bound_apply_contract(self, tmp_path):
         import axiom_encode.cli as cli_module
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14899,6 +14899,21 @@ rules:
                 Path(r"statutes/26/foo\bar.yaml"),
                 "safe relative path",
             ),
+            (
+                Path("candidate"),
+                Path("statutes/.github/injected.yaml"),
+                "safe relative path",
+            ),
+            (
+                Path("candidate"),
+                Path("statutes/_axiom/injected.yaml"),
+                "safe relative path",
+            ),
+            (
+                Path("candidate"),
+                Path("statutes/26/control\x1fname.yaml"),
+                "safe relative path",
+            ),
             (Path("candidate"), Path("metrics/1.yaml"), "canonical RuleSpec"),
         ],
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14496,52 +14496,6 @@ rules:
         assert feedback[:3] == (first, structure, formula)
         assert candidate is failed_attempt.candidate
 
-    def test_overlay_validator_issues_preserve_all_bounded_deduplicated_issues(self):
-        import axiom_encode.cli as cli_module
-
-        validator_result = SimpleNamespace(
-            issues=["first issue", "second issue", "first issue", None],
-            error="first issue",
-        )
-
-        issues = cli_module._bounded_overlay_validator_issues(
-            validator_result,
-            relative_file=Path("policies/income_tax/schedule.yaml"),
-            validator_name="ci",
-        )
-
-        assert issues == (
-            "policies/income_tax/schedule.yaml: ci: first issue",
-            "policies/income_tax/schedule.yaml: ci: second issue",
-        )
-
-    def test_overlay_validator_issues_bound_diagnostic_flood_and_fallback(self):
-        import axiom_encode.cli as cli_module
-
-        class CountingIssues(list):
-            inspected = 0
-
-            def __iter__(self):
-                for index in range(10_000):
-                    self.inspected += 1
-                    yield f"issue {index}"
-
-        flooded = CountingIssues()
-        issues = cli_module._bounded_overlay_validator_issues(
-            SimpleNamespace(issues=flooded, error="fallback"),
-            relative_file=Path("statutes/26/1.yaml"),
-            validator_name="ci",
-        )
-        fallback = cli_module._bounded_overlay_validator_issues(
-            SimpleNamespace(issues=[None], error="fallback"),
-            relative_file=Path("statutes/26/1.yaml"),
-            validator_name="ci",
-        )
-
-        assert flooded.inspected == 48
-        assert len(issues) == 48
-        assert fallback == ("statutes/26/1.yaml: ci: fallback",)
-
     def test_full_overlay_validator_issues_preserve_post_prompt_bound_diagnostics(
         self,
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15078,8 +15078,15 @@ rules:
                 )
             )
 
+    @pytest.mark.parametrize(
+        ("mutated_file", "message"),
+        [
+            ("rulespec", "RuleSpec SHA-256 mismatch"),
+            ("tests", "tests SHA-256 mismatch"),
+        ],
+    )
     def test_encode_rejects_mutated_cross_run_candidate_before_model_call(
-        self, tmp_path
+        self, tmp_path, mutated_file, message
     ):
         candidate_root = tmp_path / "preserved-candidate"
         candidate_path = Path("statutes/26/1/j/2.yaml")
@@ -15090,7 +15097,10 @@ rules:
         test_file.write_text("[]\n")
         expected_rulespec_sha256 = hashlib.sha256(output_file.read_bytes()).hexdigest()
         expected_tests_sha256 = hashlib.sha256(test_file.read_bytes()).hexdigest()
-        output_file.write_text("format: rulespec/v1\n# mutated\nrules: []\n")
+        if mutated_file == "rulespec":
+            output_file.write_text("format: rulespec/v1\n# mutated\nrules: []\n")
+        else:
+            test_file.write_text("# mutated\n[]\n")
         args = self._make_args(
             tmp_path,
             repair_candidate_root=candidate_root,
@@ -15100,7 +15110,7 @@ rules:
         )
 
         with patch("axiom_encode.cli.run_model_eval") as model_call:
-            with pytest.raises(ValueError, match="RuleSpec SHA-256 mismatch"):
+            with pytest.raises(ValueError, match=message):
                 cmd_encode(args)
 
         model_call.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3067,6 +3067,7 @@ class TestMain:
                 assert args.escalation_model == DEFAULT_OPENAI_ESCALATION_MODEL
                 assert args.escalate_after == DEFAULT_OPENAI_ESCALATE_AFTER
                 assert args.escalation_enabled is True
+                assert args.emit_final_rejected_candidate is None
 
     def test_encode_accepts_policyengine_rule_hint(self):
         with patch(
@@ -14607,8 +14608,8 @@ rules:
             emit_final_rejected_candidate=failed_candidate_root,
         )
         final_issues = [
-            "[complete-source-unit:structure] missing branch: section 66(1)",
-            "[complete-source-unit:formula-output] section 66(1) has no output",
+            f"[complete-source-unit:structure] missing branch {index}: section 66(1)"
+            for index in range(24)
         ]
 
         exit_code, generated, _validated, _run, _validate, _apply = (
@@ -14660,6 +14661,29 @@ rules:
         }
 
     @pytest.mark.parametrize(
+        ("success", "error", "expected_exit"),
+        [
+            (True, None, 0),
+            (False, "model transport failed", 1),
+        ],
+    )
+    def test_encode_does_not_emit_candidate_without_validator_rejection(
+        self, tmp_path, success, error, expected_exit
+    ):
+        destination = tmp_path / "failed-encode"
+        args = self._make_args(
+            tmp_path,
+            emit_final_rejected_candidate=destination,
+        )
+        result = self._make_eval_result(success)
+        result.error = error
+
+        _mock_run, exit_code = self._run_encode(args, result)
+
+        assert exit_code == expected_exit
+        assert not destination.exists()
+
+    @pytest.mark.parametrize(
         "relative_output",
         [Path("metrics/result.yaml"), Path("statutes/26/1.test.yaml")],
     )
@@ -14685,6 +14709,21 @@ rules:
                 validation_issues=("validator rejected candidate",),
                 attempt_count=1,
             )
+
+    def test_final_rejected_candidate_emission_requires_absolute_fresh_destination(
+        self, tmp_path
+    ):
+        import axiom_encode.cli as cli_module
+
+        with pytest.raises(ValueError, match="normalized absolute path"):
+            cli_module._resolve_final_rejected_candidate_destination(
+                Path("failed-encode")
+            )
+
+        existing = tmp_path / "failed-encode"
+        existing.mkdir()
+        with pytest.raises(ValueError, match="must not exist"):
+            cli_module._resolve_final_rejected_candidate_destination(existing)
 
     def test_encode_tests_only_repair_requires_bound_apply_contract(self, tmp_path):
         import axiom_encode.cli as cli_module

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13310,10 +13310,17 @@ class TestCmdEncode:
                     cmd_encode(args)
             return mock_run, exc_info.value.code
 
-    def _run_validator_escalation_case(self, args, validator_outcomes):
+    def _run_validator_escalation_case(
+        self,
+        args,
+        validator_outcomes,
+        *,
+        omit_final_tests: bool = False,
+    ):
         generated_models = []
         validated_models = []
         remaining_outcomes = list(validator_outcomes)
+        total_attempts = len(remaining_outcomes)
 
         def generate(**kwargs):
             runner_spec = kwargs["runner_specs"][0]
@@ -13337,9 +13344,10 @@ class TestCmdEncode:
             output_file.write_text(
                 f"format: rulespec/v1\n# rejected-attempt-{attempt_number}\nrules: []\n"
             )
-            output_file.with_suffix(".test.yaml").write_text(
-                f"# historical-and-current-cases-{attempt_number}\n[]\n"
-            )
+            if not (omit_final_tests and attempt_number == total_attempts):
+                output_file.with_suffix(".test.yaml").write_text(
+                    f"# historical-and-current-cases-{attempt_number}\n[]\n"
+                )
             result.output_file = str(output_file)
             return [result]
 
@@ -13352,10 +13360,11 @@ class TestCmdEncode:
                 + f"# deterministic-post-repair-{attempt_number}\n"
             )
             test_file = output_file.with_suffix(".test.yaml")
-            test_file.write_text(
-                test_file.read_text()
-                + f"# deterministic-post-repair-tests-{attempt_number}\n"
-            )
+            if test_file.exists():
+                test_file.write_text(
+                    test_file.read_text()
+                    + f"# deterministic-post-repair-tests-{attempt_number}\n"
+                )
             outcome = remaining_outcomes.pop(0)
             if isinstance(outcome, tuple):
                 passed, issues = outcome
@@ -14794,6 +14803,36 @@ rules:
             "encoder_version": AXIOM_ENCODE_TEST_VERSION,
             "attempt_count": 4,
         }
+
+    def test_encode_emits_empty_companion_when_final_rejection_has_no_tests(
+        self, tmp_path
+    ):
+        failed_candidate_root = tmp_path / "failed-encode"
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=False,
+            emit_final_rejected_candidate=failed_candidate_root,
+        )
+
+        exit_code, generated, _validated, _run, _validate, _apply = (
+            self._run_validator_escalation_case(
+                args,
+                [(False, ["No tests found."])],
+                omit_final_tests=True,
+            )
+        )
+
+        assert exit_code == 1
+        assert len(generated) == 1
+        relative_rulespec = Path("statutes/26/1/j/2.yaml")
+        relative_tests = relative_rulespec.with_suffix(".test.yaml")
+        assert (failed_candidate_root / relative_tests).read_text() == "[]\n"
+        metadata = json.loads((failed_candidate_root / "issues.json").read_text())
+        assert metadata["issues"] == ["No tests found."]
+        assert metadata["tests_sha256"] == hashlib.sha256(b"[]\n").hexdigest()
 
     @pytest.mark.parametrize(
         ("success", "error", "expected_exit"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13879,9 +13879,10 @@ class TestCmdEncode:
         )
 
         assert exit_code == 0
-        assert actionable_issue in mock_run.call_args_list[1].kwargs[
-            "validation_retry_feedback"
-        ]
+        assert (
+            actionable_issue
+            in mock_run.call_args_list[1].kwargs["validation_retry_feedback"]
+        )
 
     @pytest.mark.parametrize(
         "issue",
@@ -14350,9 +14351,7 @@ rules:
             escalation_enabled=True,
         )
         compile_issue = "duplicate compile issue"
-        ci_issue = (
-            "[complete-source-unit:structure] current CI completeness issue"
-        )
+        ci_issue = "[complete-source-unit:structure] current CI completeness issue"
         generated_attempts = 0
 
         def generate(**kwargs):
@@ -14364,13 +14363,7 @@ rules:
             result.model = model
             result.runner = f"{backend}-{model}"
             output_file = (
-                args.output
-                / result.runner
-                / "statutes"
-                / "26"
-                / "1"
-                / "j"
-                / "2.yaml"
+                args.output / result.runner / "statutes" / "26" / "1" / "j" / "2.yaml"
             )
             output_file.parent.mkdir(parents=True, exist_ok=True)
             output_file.write_text("format: rulespec/v1\nrules: []\n")
@@ -14730,18 +14723,22 @@ rules:
             relative_rulespec.as_posix(),
             relative_tests.as_posix(),
         }
-        assert "rejected-attempt-4" in (
-            failed_candidate_root / relative_rulespec
-        ).read_text()
-        assert "deterministic-post-repair-4" in (
-            failed_candidate_root / relative_rulespec
-        ).read_text()
-        assert "historical-and-current-cases-4" in (
-            failed_candidate_root / relative_tests
-        ).read_text()
-        assert "deterministic-post-repair-tests-4" in (
-            failed_candidate_root / relative_tests
-        ).read_text()
+        assert (
+            "rejected-attempt-4"
+            in (failed_candidate_root / relative_rulespec).read_text()
+        )
+        assert (
+            "deterministic-post-repair-4"
+            in (failed_candidate_root / relative_rulespec).read_text()
+        )
+        assert (
+            "historical-and-current-cases-4"
+            in (failed_candidate_root / relative_tests).read_text()
+        )
+        assert (
+            "deterministic-post-repair-tests-4"
+            in (failed_candidate_root / relative_tests).read_text()
+        )
         issues = json.loads((failed_candidate_root / "issues.json").read_text())
         assert issues == {
             "schema": "axiom-encode/failed-encode-candidate/v1",

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1693"
+ENCODER_VERSION = "0.2.1694"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1693"
+ENCODER_VERSION = "0.2.1694"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1693"
+ENCODER_VERSION = "0.2.1694"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1693"
+ENCODER_VERSION = "0.2.1694"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1693"
+ENCODER_VERSION = "0.2.1694"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1693"
+ENCODER_VERSION = "0.2.1694"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1693"')
+        .startswith('__version__ = "0.2.1694"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1693"
+    assert encoder_package["version"] == "0.2.1694"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1693"
+    assert project["project"]["version"] == "0.2.1694"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1693"')
+        .startswith('__version__ = "0.2.1694"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1693"
+    assert encoder_package["version"] == "0.2.1694"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1693"
+    assert project["project"]["version"] == "0.2.1694"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1693"')
+        .startswith('__version__ = "0.2.1694"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1693"
+ENCODER_VERSION = "0.2.1694"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signed_apply_reusable.py
+++ b/tests/test_signed_apply_reusable.py
@@ -231,6 +231,9 @@ def test_repair_candidate_download_has_minimal_read_permission_and_exact_binding
         "run-id": "${{ steps.repair_run.outputs.run_id }}",
         "github-token": "${{ github.token }}",
     }
+    verify = _workflow_step("Verify downloaded repair candidate")
+    assert verify["env"] == {"CITATION": "${{ matrix.item.citation }}"}
+    assert '--citation "$CITATION"' in verify["run"]
 
 
 @pytest.mark.parametrize("run_id", ["0", "7", "001", "32062103227"])

--- a/tests/test_signed_apply_reusable.py
+++ b/tests/test_signed_apply_reusable.py
@@ -12,6 +12,13 @@ WORKFLOW = ROOT / ".github/workflows/signed-apply-reusable.yml"
 COMPLETE_SOURCE_FLAG = "--require-complete-source-unit"
 MODEL_FLAG = "--model"
 ESCALATE_FLAG = "--escalate-after"
+EMIT_REJECTED_FLAG = "--emit-final-rejected-candidate"
+REPAIR_FLAG_QUAD = (
+    "--repair-candidate-root",
+    "--repair-candidate-path",
+    "--repair-candidate-rulespec-sha256",
+    "--repair-candidate-tests-sha256",
+)
 
 
 def _workflow_payload() -> dict:
@@ -23,6 +30,14 @@ def _signed_apply_step() -> dict:
         step
         for step in _workflow_payload()["jobs"]["encode"]["steps"]
         if step.get("name") == "Signed re-encode under supervisor + leaf signer"
+    )
+
+
+def _workflow_step(name: str) -> dict:
+    return next(
+        step
+        for step in _workflow_payload()["jobs"]["encode"]["steps"]
+        if step.get("name") == name
     )
 
 
@@ -62,6 +77,8 @@ def _base_encoder_argv(tmp_path: Path) -> list[str]:
         "--skip-reviewers",
         "--db",
         f"{tmp_path}/enc.db",
+        EMIT_REJECTED_FLAG,
+        f"{tmp_path}/failed-encode",
     ]
 
 
@@ -100,6 +117,10 @@ def _run_signed_apply_script(
     require_complete_source_unit: bool = False,
     initial_model: str = "",
     escalate_after: str = "",
+    repair_candidate_root: str = "",
+    repair_candidate_path: str = "",
+    repair_candidate_rulespec_sha256: str = "",
+    repair_candidate_tests_sha256: str = "",
 ) -> tuple[subprocess.CompletedProcess[str], bytes | None]:
     launcher = tmp_path / "axiom-encode-apply-signer"
     launcher.write_text(
@@ -129,6 +150,10 @@ def _run_signed_apply_script(
             "GITHUB_REPOSITORY": "TheAxiomFoundation/rulespec-de",
             "GITHUB_WORKSPACE": str(workspace),
             "INITIAL_MODEL": initial_model,
+            "REPAIR_CANDIDATE_PATH": repair_candidate_path,
+            "REPAIR_CANDIDATE_ROOT": repair_candidate_root,
+            "REPAIR_CANDIDATE_RULESPEC_SHA256": repair_candidate_rulespec_sha256,
+            "REPAIR_CANDIDATE_TESTS_SHA256": repair_candidate_tests_sha256,
             "RUNNER_TEMP": str(tmp_path),
         },
         capture_output=True,
@@ -169,6 +194,12 @@ def test_generation_budget_reusable_inputs_are_typed_and_default_off():
         "type": "string",
         "default": "",
     }
+    assert inputs["repair-candidate-run-id"] == {
+        "description": "Optional failed signed-apply run containing this leg's repair candidate.",
+        "required": "false",
+        "type": "string",
+        "default": "",
+    }
 
 
 def test_generation_budget_inputs_enter_only_through_step_environment():
@@ -180,6 +211,72 @@ def test_generation_budget_inputs_enter_only_through_step_environment():
     assert "${{ inputs['escalate-after'] }}" not in step["run"]
 
 
+def test_repair_candidate_download_has_minimal_read_permission_and_exact_binding():
+    workflow = _workflow_payload()
+    encode_job = workflow["jobs"]["encode"]
+    assert encode_job["permissions"] == {"actions": "read", "contents": "read"}
+
+    validate = _workflow_step("Validate repair candidate run ID")
+    assert validate["if"] == "${{ inputs['repair-candidate-run-id'] != '' }}"
+    assert validate["env"]["REPAIR_CANDIDATE_RUN_ID"] == (
+        "${{ inputs['repair-candidate-run-id'] }}"
+    )
+    assert "${{ inputs['repair-candidate-run-id'] }}" not in validate["run"]
+
+    download = _workflow_step("Download failed encode candidate")
+    assert download["if"] == "${{ inputs['repair-candidate-run-id'] != '' }}"
+    assert download["with"] == {
+        "name": "failed-encode-${{ matrix.item.slug }}",
+        "path": "${{ runner.temp }}/repair-candidate",
+        "run-id": "${{ steps.repair_run.outputs.run_id }}",
+        "github-token": "${{ github.token }}",
+    }
+
+
+@pytest.mark.parametrize("run_id", ["0", "7", "001", "32062103227"])
+def test_repair_candidate_run_id_accepts_only_numeric_strings(tmp_path, run_id):
+    step = _workflow_step("Validate repair candidate run ID")
+    output = tmp_path / "github-output"
+
+    result = subprocess.run(
+        ["/bin/bash", "-c", step["run"]],
+        env={
+            **os.environ,
+            "GITHUB_OUTPUT": str(output),
+            "REPAIR_CANDIDATE_RUN_ID": run_id,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.read_text() == f"run_id={run_id}\n"
+
+
+@pytest.mark.parametrize(
+    "run_id", ["", "-1", "+1", "1.0", "1 2", "12x", "$(touch injected)"]
+)
+def test_repair_candidate_run_id_rejects_non_numeric_strings(tmp_path, run_id):
+    step = _workflow_step("Validate repair candidate run ID")
+
+    result = subprocess.run(
+        ["/bin/bash", "-c", step["run"]],
+        env={
+            **os.environ,
+            "GITHUB_OUTPUT": str(tmp_path / "github-output"),
+            "REPAIR_CANDIDATE_RUN_ID": run_id,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "expected a numeric workflow run ID" in result.stderr
+    assert not (tmp_path / "injected").exists()
+
+
 def test_default_generation_budget_inputs_preserve_exact_launcher_argv(tmp_path):
     result, raw_argv = _run_signed_apply_script(tmp_path)
 
@@ -188,6 +285,70 @@ def test_default_generation_budget_inputs_preserve_exact_launcher_argv(tmp_path)
         argument.encode() + b"\0" for argument in _base_launcher_argv(tmp_path)
     )
     assert raw_argv == expected_raw
+
+
+def test_repair_candidate_absence_preserves_exact_default_launcher_argv(tmp_path):
+    baseline, baseline_raw = _run_signed_apply_script(tmp_path)
+    explicit_absent, absent_raw = _run_signed_apply_script(
+        tmp_path,
+        repair_candidate_root="",
+        repair_candidate_path="",
+        repair_candidate_rulespec_sha256="",
+        repair_candidate_tests_sha256="",
+    )
+
+    assert baseline.returncode == explicit_absent.returncode == 0
+    assert absent_raw == baseline_raw
+
+
+def test_repair_candidate_composes_exact_flag_quad(tmp_path):
+    digest_a = "a" * 64
+    digest_b = "b" * 64
+    root = str(tmp_path / "repair-candidate")
+    path = "de/statutes/estg/66.yaml"
+
+    result, raw_argv = _run_signed_apply_script(
+        tmp_path,
+        repair_candidate_root=root,
+        repair_candidate_path=path,
+        repair_candidate_rulespec_sha256=digest_a,
+        repair_candidate_tests_sha256=digest_b,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert raw_argv is not None
+    encoder_argv = _encoder_argv(raw_argv)
+    assert encoder_argv == [
+        *_base_encoder_argv(tmp_path),
+        "--repair-candidate-root",
+        root,
+        "--repair-candidate-path",
+        path,
+        "--repair-candidate-rulespec-sha256",
+        digest_a,
+        "--repair-candidate-tests-sha256",
+        digest_b,
+    ]
+    for flag in REPAIR_FLAG_QUAD:
+        assert encoder_argv.count(flag) == 1
+
+
+def test_failed_candidate_upload_is_failure_only_and_exactly_preverified():
+    verify = _workflow_step("Verify final rejected candidate artifact")
+    upload = _workflow_step("Upload failed encode candidate")
+
+    assert verify["if"] == "${{ failure() && !cancelled() }}"
+    assert "verify_failed_encode_candidate.py" in verify["run"]
+    assert upload["if"] == (
+        "${{ failure() && !cancelled() "
+        "&& steps.failed_candidate.outputs.present == 'true' }}"
+    )
+    assert upload["with"] == {
+        "name": "failed-encode-${{ matrix.item.slug }}",
+        "path": "${{ runner.temp }}/failed-encode",
+        "if-no-files-found": "error",
+        "retention-days": "30",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_verify_failed_encode_candidate.py
+++ b/tests/test_verify_failed_encode_candidate.py
@@ -54,6 +54,13 @@ def test_rejects_issues_json_sha_mismatch(tmp_path):
         verify_candidate_directory(root, citation="de/statute/estg/66")
 
 
+def test_rejects_candidate_from_a_slug_collision_with_another_citation(tmp_path):
+    root, _metadata = _candidate_directory(tmp_path)
+
+    with pytest.raises(ValueError, match="citation mismatch"):
+        verify_candidate_directory(root, citation="de/statute/estg-66")
+
+
 @pytest.mark.parametrize(
     "extra_path",
     [

--- a/tests/test_verify_failed_encode_candidate.py
+++ b/tests/test_verify_failed_encode_candidate.py
@@ -45,12 +45,19 @@ def test_verifies_exact_checksum_bound_candidate_directory(tmp_path):
     }
 
 
-def test_rejects_issues_json_sha_mismatch(tmp_path):
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("rulespec_sha256", "RuleSpec SHA-256 mismatch"),
+        ("tests_sha256", "tests SHA-256 mismatch"),
+    ],
+)
+def test_rejects_issues_json_sha_mismatch(tmp_path, field, message):
     root, metadata = _candidate_directory(tmp_path)
-    metadata["rulespec_sha256"] = "0" * 64
+    metadata[field] = "0" * 64
     (root / "issues.json").write_text(json.dumps(metadata) + "\n")
 
-    with pytest.raises(ValueError, match="RuleSpec SHA-256 mismatch"):
+    with pytest.raises(ValueError, match=message):
         verify_candidate_directory(root, citation="de/statute/estg/66")
 
 

--- a/tests/test_verify_failed_encode_candidate.py
+++ b/tests/test_verify_failed_encode_candidate.py
@@ -92,9 +92,7 @@ def test_rejects_backslash_in_noncanonical_candidate_path(tmp_path):
         Path("diagnostics.log"),
     ],
 )
-def test_rejects_every_path_outside_exact_three_file_allowlist(
-    tmp_path, extra_path
-):
+def test_rejects_every_path_outside_exact_three_file_allowlist(tmp_path, extra_path):
     root, _metadata = _candidate_directory(tmp_path)
     extra = root / extra_path
     extra.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_verify_failed_encode_candidate.py
+++ b/tests/test_verify_failed_encode_candidate.py
@@ -20,6 +20,7 @@ def _candidate_directory(tmp_path: Path) -> tuple[Path, dict[str, object]]:
     tests.write_text("[]\n")
     metadata: dict[str, object] = {
         "schema": "axiom-encode/failed-encode-candidate/v1",
+        "citation": "de/statute/estg/66",
         "path": "de/statutes/estg/66.yaml",
         "issues": ["[complete-source-unit:structure] missing branch"],
         "rulespec_sha256": hashlib.sha256(rulespec.read_bytes()).hexdigest(),
@@ -34,7 +35,7 @@ def _candidate_directory(tmp_path: Path) -> tuple[Path, dict[str, object]]:
 def test_verifies_exact_checksum_bound_candidate_directory(tmp_path):
     root, metadata = _candidate_directory(tmp_path)
 
-    result = verify_candidate_directory(root)
+    result = verify_candidate_directory(root, citation="de/statute/estg/66")
 
     assert result == {
         "root": str(root),
@@ -50,7 +51,7 @@ def test_rejects_issues_json_sha_mismatch(tmp_path):
     (root / "issues.json").write_text(json.dumps(metadata) + "\n")
 
     with pytest.raises(ValueError, match="RuleSpec SHA-256 mismatch"):
-        verify_candidate_directory(root)
+        verify_candidate_directory(root, citation="de/statute/estg/66")
 
 
 @pytest.mark.parametrize(
@@ -71,7 +72,7 @@ def test_rejects_every_path_outside_exact_three_file_allowlist(
     extra.write_text("must not cross artifact boundary\n")
 
     with pytest.raises(ValueError, match="exactly the rejected RuleSpec"):
-        verify_candidate_directory(root)
+        verify_candidate_directory(root, citation="de/statute/estg/66")
 
 
 def test_rejects_symlinked_candidate_file(tmp_path):
@@ -83,4 +84,4 @@ def test_rejects_symlinked_candidate_file(tmp_path):
     tests.symlink_to(external)
 
     with pytest.raises(ValueError, match="symlink|regular file"):
-        verify_candidate_directory(root)
+        verify_candidate_directory(root, citation="de/statute/estg/66")

--- a/tests/test_verify_failed_encode_candidate.py
+++ b/tests/test_verify_failed_encode_candidate.py
@@ -61,6 +61,21 @@ def test_rejects_candidate_from_a_slug_collision_with_another_citation(tmp_path)
         verify_candidate_directory(root, citation="de/statute/estg-66")
 
 
+def test_rejects_backslash_in_noncanonical_candidate_path(tmp_path):
+    root, metadata = _candidate_directory(tmp_path)
+    rulespec = root / str(metadata["path"])
+    tests = rulespec.with_suffix(".test.yaml")
+    noncanonical_rulespec = rulespec.with_name(r"66\branch.yaml")
+    noncanonical_tests = noncanonical_rulespec.with_suffix(".test.yaml")
+    rulespec.rename(noncanonical_rulespec)
+    tests.rename(noncanonical_tests)
+    metadata["path"] = noncanonical_rulespec.relative_to(root).as_posix()
+    (root / "issues.json").write_text(json.dumps(metadata) + "\n")
+
+    with pytest.raises(ValueError, match="not canonical"):
+        verify_candidate_directory(root, citation="de/statute/estg/66")
+
+
 @pytest.mark.parametrize(
     "extra_path",
     [

--- a/tests/test_verify_failed_encode_candidate.py
+++ b/tests/test_verify_failed_encode_candidate.py
@@ -1,0 +1,86 @@
+"""Tests for the signed-apply failed-candidate artifact boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.verify_failed_encode_candidate import verify_candidate_directory
+
+
+def _candidate_directory(tmp_path: Path) -> tuple[Path, dict[str, object]]:
+    root = tmp_path / "failed-encode"
+    rulespec = root / "de/statutes/estg/66.yaml"
+    rulespec.parent.mkdir(parents=True)
+    rulespec.write_text("format: rulespec/v1\nrules: []\n")
+    tests = rulespec.with_suffix(".test.yaml")
+    tests.write_text("[]\n")
+    metadata: dict[str, object] = {
+        "schema": "axiom-encode/failed-encode-candidate/v1",
+        "path": "de/statutes/estg/66.yaml",
+        "issues": ["[complete-source-unit:structure] missing branch"],
+        "rulespec_sha256": hashlib.sha256(rulespec.read_bytes()).hexdigest(),
+        "tests_sha256": hashlib.sha256(tests.read_bytes()).hexdigest(),
+        "encoder_version": "0.2.1692",
+        "attempt_count": 4,
+    }
+    (root / "issues.json").write_text(json.dumps(metadata) + "\n")
+    return root, metadata
+
+
+def test_verifies_exact_checksum_bound_candidate_directory(tmp_path):
+    root, metadata = _candidate_directory(tmp_path)
+
+    result = verify_candidate_directory(root)
+
+    assert result == {
+        "root": str(root),
+        "path": metadata["path"],
+        "rulespec_sha256": metadata["rulespec_sha256"],
+        "tests_sha256": metadata["tests_sha256"],
+    }
+
+
+def test_rejects_issues_json_sha_mismatch(tmp_path):
+    root, metadata = _candidate_directory(tmp_path)
+    metadata["rulespec_sha256"] = "0" * 64
+    (root / "issues.json").write_text(json.dumps(metadata) + "\n")
+
+    with pytest.raises(ValueError, match="RuleSpec SHA-256 mismatch"):
+        verify_candidate_directory(root)
+
+
+@pytest.mark.parametrize(
+    "extra_path",
+    [
+        Path(".github/workflows/injected.yml"),
+        Path("scripts/injected.py"),
+        Path("_axiom/private.txt"),
+        Path("diagnostics.log"),
+    ],
+)
+def test_rejects_every_path_outside_exact_three_file_allowlist(
+    tmp_path, extra_path
+):
+    root, _metadata = _candidate_directory(tmp_path)
+    extra = root / extra_path
+    extra.parent.mkdir(parents=True, exist_ok=True)
+    extra.write_text("must not cross artifact boundary\n")
+
+    with pytest.raises(ValueError, match="exactly the rejected RuleSpec"):
+        verify_candidate_directory(root)
+
+
+def test_rejects_symlinked_candidate_file(tmp_path):
+    root, _metadata = _candidate_directory(tmp_path)
+    tests = root / "de/statutes/estg/66.test.yaml"
+    tests.unlink()
+    external = tmp_path / "external.test.yaml"
+    external.write_text("secret\n")
+    tests.symlink_to(external)
+
+    with pytest.raises(ValueError, match="symlink|regular file"):
+        verify_candidate_directory(root)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1693"
+version = "0.2.1694"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes the visibility-and-convergence gap for per-leg signed-apply iteration (live case: rulespec-de estg/66, three runs failing on one demand with candidates discarded; local diagnosis is broker-gated by design, so CI artifacts are the only sanctioned specimen path).

## The loop
- **Emit + upload on failure**: a validator-rejected final attempt writes the module + companion tests + `issues.json` (full bounded issue list, dual SHA-256s, encoder version, attempt count) via `--emit-final-rejected-candidate` (canonical-path fail-closed), independently re-verified by `scripts/verify_failed_encode_candidate.py` (rejects extra files, protected paths, symlinks, oversize, sha/citation mismatch) before a failure-only `failed-encode-<slug>` artifact upload — same twice-allowlisted discipline as the success artifact.
- **Consume on re-dispatch**: typed `repair-candidate-run-id` input (numeric-validated) downloads the prior run's artifact, verifies shas, and passes the existing `--repair-candidate-*` quartet. The seeded candidate's issues enter first-attempt retry feedback, so round N+1 starts where round N ended. Absent input = byte-identical argv (tested).
- Bounds fail closed (4,096 issues / 512 KiB metadata ceiling) instead of silently truncating.

Also in the stack: full rejected-candidate diagnostics preserved separately from prompt bounds; finite issue-group scanning before prompt capping; repair-candidate path admission alignment; obsolete overlay prompt collector removed.

## Verification
Focused ratchet matrix 78 passed (baseline: 32/36 fail — the new contracts); focused signed-apply+cli suites 1,331 passed (sole failure = the pre-bump version gate, resolved by 0.2.1694 + pin sweep); full suite +43 passes vs baseline with identical environment-failure sets; ruff/compileall/diff-check clean; four independent review passes. Rebased onto 0.2.1693 main (clean, no conflicts).

Caller passthrough (rulespec-de) follows in lockstep; first ratcheted §66 dispatch after the pin pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
