### PR TITLE
ci: bump signed-apply encoder pin (candidate ratchet, 0.2.1694)

### DIFF
--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -76,7 +76,7 @@ env:
   # wave pin 185b2457). The validate workflow's encode-ref is bumped to the
   # same sha in this PR so the signed PRs' CI verifies manifests with the
   # same encoder generation that produced them.
-  AXIOM_ENCODE_REF: 2c99f8016e0d930f7d56f1c55ce3becbabce79fa
+  AXIOM_ENCODE_REF: 7b17413dc9833dbb59c1faa67715488087d31085
   AXIOM_RULES_ENGINE_REF: 05eac9d2f89dabe5c6673176260762cef3a58f47
 
 jobs:


### PR DESCRIPTION
One-line pin for #1503. Caller passthrough + first ratcheted §66 dispatch follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)