### PR TITLE
Notary admission design v1

### DIFF
--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -145,8 +145,14 @@ body's schema:
 | admin-approver | `axiom/notary-admin-approval/v1` | genesis or transition administrative candidate (its body digest); signed by the **administrative** key of §8, never the correction-reviewer key — approving trust-root rotation is a wider power than validating a correction |
 | notary | `axiom/notary-receipt/v1` | notary receipt |
 
-Signatures are detached files beside the body (`<digest>.json`,
-`<digest>.json.<role>.sig`), each canonical JSON:
+Signatures are detached files beside the body, under a **normative
+store-name grammar**: a record body is named `<digest>.json` where
+`<digest>` is exactly the lowercase 64-hex SHA-256 of the body's raw
+bytes — **the stem is the address; the `.json` suffix is grammar, not
+digest** — and a signature sidecar is named `<digest>.json.<role>.sig`
+with `<role>` one of the store's lineage scopes (`producer`, `actor`,
+`review`; chain artifacts live on the chain branch, never in the
+store). Each sidecar is canonical JSON:
 `{schema: "axiom/detached-signature/v1", body_sha256, scope,
 signer_spki_sha256, signature_base64}`. Every cross-scope verification
 must fail, legacy `apply_ed25519`/`eval_ed25519` included (§10 tests the
@@ -216,10 +222,15 @@ check. Its exact ordered members: `base_commit_git_oid`,
 `base_tree_manifest_sha256`, `subject_tree_manifest_sha256`,
 `profile_sha256`, `path_policy_sha256`, `eligible_records`,
 `ineligible_records` — types as in the pass schema. A refusal during
-repository or predecessor resolution therefore carries a truthful
-all-null prefix rather than impossible mandatory fields. Stage
-maxima: `structural` and `preflight` refusals stop wherever the prefix
-stopped; `eligibility` and `assignment` refusals may establish through
+repository or predecessor resolution is a `resolution`-stage refusal —
+`chain-unresolvable` when the finalized chain state cannot be
+reconstructed, `subject-unresolvable` when the subject commit or tree
+cannot be resolved — and carries the truthful prefix resolution
+actually established: all-null when chain reconstruction failed (it
+runs first), the three chain fields when the subject failed after the
+chain resolved. Stage
+maxima: `resolution`, `structural`, and `preflight` refusals stop
+wherever the prefix stopped; `eligibility` and `assignment` refusals may establish through
 the record lists — **an assignment-stage refusal never carries an
 assignment or unused list** (an ambiguity refusal has neither a unique
 assignment nor a determinate unused partition); only `gates`-stage
@@ -228,6 +239,7 @@ refusals carry `coverage_assignment`, `unused_eligible_records`,
 
 | `stage` | `established` content |
 |---|---|
+| `"resolution"` | the actual completed prefix — all-null when chain reconstruction fails (it runs first); the three chain fields when subject resolution fails after the chain resolved |
 | `"structural"` | the actual completed prefix — a late structural failure (an empty subtree found while building the subject manifest, after resolution and the base manifest succeeded) truthfully carries the resolved predecessor and base fields; manifests establish in fixed order, **base first, then subject**, so identical faults establish identical prefixes |
 | `"preflight"` | whatever prefix the failing check permitted — a `policy-invalid` for an absent profile truthfully carries `profile_sha256: null` |
 | `"eligibility"` | prefix through the record lists |
@@ -251,7 +263,8 @@ four are determinate.
 A `"gates"`-stage refusal does carry its unique assignment — coverage
 succeeded; a gate outcome did not. The refusal member is named
 `refusal` in both variants (never `diff_coverage`), and its single
-closed code enum is: `"uncovered-path"`, `"ambiguous-assignment"`,
+closed code enum is: `"subject-unresolvable"`,
+`"chain-unresolvable"`, `"uncovered-path"`, `"ambiguous-assignment"`,
 `"inconsistent-chain"`, `"record-cycle"`, `"no-valid-execution"`,
 `"inadmissible-entry"`, `"structural"`, `"state-identical"`,
 `"trust-surface-change"`, `"policy-invalid"`, `"predecessor-stale"`,
@@ -262,7 +275,13 @@ changes a trust surface"; `policy-invalid` → "required policy, profile, or key
 or invalid at the base" (registry invalidity refuses under this code);
 a non-representable offending path reports `path: null` with the
 template unchanged — the I-JSON path contract never carries non-UTF-8
-bytes; `predecessor-stale` → "base is
+bytes; `subject-unresolvable` → "subject commit or tree cannot be
+resolved" (the common `subject_commit_git_oid` field carries the
+requested oid, which is input, not resolution); `chain-unresolvable` →
+"finalized chain state cannot be reconstructed" (an absent, malformed,
+or invalid-to-reconstruction chain — distinct from `predecessor-stale`,
+whose chain resolved and whose base is simply not the tip);
+`predecessor-stale` → "base is
 not the finalized chain tip"; `gate-extra` → "gate outside the
 profile". `ineligible_records`
 entries carry `reasons`: the **sorted array of every applicable reason
@@ -293,25 +312,31 @@ classification the profile did not grant; `diff_coverage`: exactly `"pass"` — 
 variant carries no refusal shapes, and `waived`/`not-run` exist in
 neither variant; `unprotected_changes`
 (sorted paths); `ineligible_records`: sorted array of
-`{store_name, reasons}` — `store_name` is the literal filename string
-relative to `.axiom/lineage/`, `.json` suffix included, whatever bytes
-it holds within the UTF-8 tree domain; the array sorts bytewise by
-`store_name`. (Eligible records remain digest-keyed — they passed the
-address check, so name and digest coincide; ineligible entries are
-name-keyed precisely because their names may not be digests.)
+`{store_name, reasons}` — `store_name` is the literal name string
+relative to `.axiom/lineage/`, suffix and any `/` separators included,
+whatever bytes it holds within the UTF-8 tree domain; the array sorts
+bytewise by `store_name`. (Eligible records remain digest-keyed — they
+passed the address check, so stem and digest coincide; ineligible
+entries are name-keyed precisely because their names may not be
+addresses.)
 `reasons` is the sorted array of every applicable code **whose
 prerequisites are satisfied**, from the closed enum with this
-prerequisite order: `address-mismatch` and `malformed-record` are
-always computable; `invalid-signature`, `wrong-lane`, `wrong-epoch`,
+prerequisite order: `address-mismatch`, `unrecognized-store-name`, and
+`malformed-record` are always computable — with
+`unrecognized-store-name` **exclusive**: a non-grammar name's contents
+are never evaluated, so it is that entry's sole reason; `invalid-signature`,
+`wrong-lane`, `wrong-epoch`,
 `duplicate-transition-paths`, and `unprotected-path-transition` apply
 only when the body parsed (never beside `malformed-record`). Entries
-are keyed by `store_name` — the literal filename string under
-`.axiom/lineage/` (total over every tree: a name that is not a valid
-lowercase-hex digest, or differs from the body's digest, is simply an
-`address-mismatch` entry under its literal name) — so a valid body
-added at its correct path *and* at an alias yields one eligible record
-plus one ineligible entry, with no identity collision and no
-unrepresentable key. Same shape in
+are keyed by `store_name` under the §2.6 classification, total over
+every tree: a name matching the §2.1 body grammar whose stem differs
+from the file's raw-byte digest is an `address-mismatch` entry; a name
+matching neither the body grammar nor the
+sidecar-of-a-newly-introduced-body pattern is an
+`unrecognized-store-name` entry — each under its literal name — so a
+valid body added at its correct address *and* at an alias yields one
+eligible record plus one ineligible entry, with no identity collision
+and no unrepresentable key. Same shape in
 pass and refusal variants; `dependency_pins_sha256`: the digest of a
 canonical dependency inventory, a body of schema
 `axiom/notary-dependency-inventory/v1` with the closed shape
@@ -330,8 +355,9 @@ waiver file is a refusal, not an empty hash. The refusal variant's `refusal` mem
 `{code, path | null, detail}` with the single code enum of §2.4
 (coverage and gate codes alike), `detail` a JSON string — and
 deterministic under simultaneous faults, with all three members fixed:
-the evaluation order is total — structural (§2.1 manifest rules in
-listed order), preflight (§4 in listed order), state-identical,
+the evaluation order is total — resolution (finalized-chain
+reconstruction, then subject resolution), structural (§2.1 manifest
+rules in listed order), preflight (§4 in listed order), state-identical,
 eligibility (§3.2 in listed order), assignment (§3.3 rules 1–4 in
 order), gates (missing, then extra, then unacceptable; within each,
 bytewise-least `gate_id`) — checks run in that total order **globally across all
@@ -346,6 +372,8 @@ path within it, `null` otherwise; `detail` is the fixed template string defined 
 `record-cycle` → "consumed records admit no execution order";
 `no-valid-execution` → "no topological order yields realizable trees";
 `inadmissible-entry` → "entry mode or type inadmissible";
+`subject-unresolvable` → "subject commit or tree cannot be resolved";
+`chain-unresolvable` → "finalized chain state cannot be reconstructed";
 `structural` → "tree or store structurally malformed";
 `state-identical` → "base and subject states are identical";
 `gate-missing` → "required gate absent";
@@ -458,7 +486,18 @@ every successor.) A **newly introduced** record that is malformed,
 misaddressed, or badly signed is an eligibility-stage ineligible
 record, enumerated with its reasons — never a structural refusal — so
 one bad new record cannot veto an otherwise covered candidate, now or
-later.
+later. **Every newly introduced store file is classified exactly
+once** by the §2.1 grammar: a name matching the body grammar with stem
+equal to its raw-byte digest enters the record pipeline (eligible, or
+ineligible for content reasons); a sidecar naming a newly introduced
+body is signature evidence, verified with that body and never
+separately enumerated (an absent or invalid required sidecar is the
+body's `invalid-signature` reason); everything else — a body-grammar
+name with a wrong stem (`address-mismatch`), or any other name: an
+orphan sidecar, a sidecar naming a base-present body, a nested name, a
+non-lineage role suffix, a non-hex or uppercase stem
+(`unrecognized-store-name`) — is an ineligible entry under its literal
+name, riding in as enumerated, inert history.
 Reports, receipts, genesis, and transition records publish per §7 and are
 never part of the subject tree.
 
@@ -775,21 +814,28 @@ verification reads it from here). The three typed scopes —
 registry entry: the external typed signer signs all three with the
 notary key, and the admin-approver's separate signature is what
 authorizes the administrative ones. **Role-key exclusions are enumerated pairs, nothing implicit** — and
-the governing principle is stated with them: **the `notary` SPKI is
+the governing principles are stated with them. **The `notary` SPKI is
 disjoint from every other role, without exception**, because any alias
 means a private key outside the typed signer can freshly sign the
-notary domain (domain separation prevents replay, not signing). The
+notary domain (domain separation prevents replay, not signing). **The
+`legacy_apply_root` is likewise disjoint from every registry role,
+without exception**: §9.15's freeze pins *which* key is the v5 root,
+never *when* its signatures were made, so the holder of an aliased
+private key could freshly sign v5 records over hand-edited bytes right
+up to the lane lock and have genesis bless them as `v5_attested` — the
+exact retroactive laundering this design exists to refuse. (The
+production signing broker already rejects an apply/corpus-release root
+collision, so the total exclusion restores deployed behavior rather
+than adding a constraint.) The
 forbidden collisions are exactly: `notary`×{every other role,
-`legacy_apply_root` included}; `producer`×{`review`, `admin-approver`,
+`legacy_apply_root` included}; `legacy_apply_root`×{every registry
+role}; `producer`×{`review`, `admin-approver`,
 `approver`, `corpus-release`}; `actor`×{`review`, `admin-approver`,
 `approver`, `corpus-release`}; `review`×`admin-approver`;
-`approver`×{`producer`, `actor`, `corpus-release`,
-`legacy_apply_root`}; plus the genesis-time
-`legacy_apply_root`×{`notary`, `admin-approver`, `review`, `approver`}
-refusals of §9.16. Any listed collision refuses the registry; the one
-deliberately permitted service pair is
-`corpus-release`×`legacy_apply_root` (both verification roots of
-retiring infrastructure). (The charter's separate-key requirement made
+`approver`×{`producer`, `actor`, `corpus-release`}. Any listed
+collision refuses the registry; there is **no permitted service
+pair** — every role, service roles included, holds its own key. (The
+charter's separate-key requirement made
 checkable; the cross-scope matrix alone cannot detect deliberate key
 reuse across scopes.) For every other scope,
 scope-to-registry resolution is the role table itself: a detached signature under a scope verifies
@@ -852,7 +898,14 @@ partition property against the manifest before signing):
   against the currently provisioned production value, witnessed), and
   the anti-reclassification claim is scoped to that precondition: given
   the independently frozen fingerprint, root substitution at genesis
-  cannot reclassify pre-epoch hand edits as attested. The organization
+  cannot reclassify pre-epoch hand edits as attested. One residual is
+  inherent to grandfathering and stated rather than claimed away: a
+  fresh v5 record signed under the *true* frozen root before the lane
+  lock is indistinguishable from a historical one, so `v5_attested`
+  trust is bounded by the legacy key's custody up to the lock — §5's
+  total `legacy_apply_root` exclusion keeps every registry-role holder
+  out of that window, and the lock closes it (a locked, pinned tip
+  admits no new store files). The organization
   variable supplying this root today is eliminated by §9.10;
 - `v5_attested`: sorted `[path, entry_sha256, record_sha256]` — paths
   whose blobs are vouched at genesis by a legacy record that passes the
@@ -941,16 +994,18 @@ separate repository is the capability boundary rulesets cannot provide
 inside the lane repo: a Contents-write App token is repository-scoped
 and can always manipulate qualified custom refs of the repository it
 holds, so single-ref confinement inside the lane repository is not
-implementable — whereas the publisher App's contents-write installation
-covers only the notary repository, and in the lane repository it holds
-a lane credential whose App installation holds `checks: write` and
+implementable — whereas the **chain App's** contents-write
+installation covers only the notary repository, and in the lane
+repository the publisher holds a credential from the **distinct lane
+App** (§9.7b: a separate registration with its own private key), whose
+installation holds `checks: write` and
 `contents: read` — sufficient for source-bound required checks, which
 branch protection binds by the creating App's id; no
 Commit-Status-path permission is taken, because an unused
 merge-authorizing permission is attack surface — with runtime tokens
 downscoped per operation. The lane repository's refs are
-physically outside the publisher's write capability. The chain branch's
-ruleset in the notary repository: only the publisher App may push; no
+physically outside both Apps' write capability. The chain branch's
+ruleset in the notary repository: only the chain App may push; no
 force pushes; no deletion; linear history. Its contents: content-addressed artifact files (reports,
 receipts, transitions, genesis, and void markers) plus `HEAD.json`
 (`{schema: "axiom/notary-head/v1", tip_sha256, tip_kind}`) as a
@@ -960,7 +1015,7 @@ target_sha256, target_kind, merged_tip_manifest_sha256, sequence}`) and
 `axiom/notary-void/v1` (`{schema, lane, epoch_sha256, target_sha256,
 target_kind, reason}`), each content-addressed like every other
 artifact. Marker authentication is structural: the branch accepts
-commits from the publisher App alone, linear history, no force pushes —
+commits from the chain App alone, linear history, no force pushes —
 so markers are exactly what the pinned publisher committed, in order.
 
 The chain state machine, exhaustively: an artifact is *pending* when its
@@ -1050,7 +1105,7 @@ equal what was verified":
    the signer signs the receipt (or transition). The publisher commits it
    to the chain branch as *pending* and sets the required status check on
    the candidate — a check whose required context is **bound to the
-   publisher App** in branch protection, so a same-named context from
+   lane App** in branch protection, so a same-named context from
    Actions or any other integration does not satisfy the requirement. A
    pending artifact authorizes exactly one thing: the merge of a head
    whose tree manifest is `T1` onto the finalized tip it names as base.
@@ -1151,7 +1206,7 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    signing for those scopes.
 7. The publisher split implemented: the chain on its protected branch
    with an App-restricted, no-force-push, no-deletion ruleset; the
-   required admission check bound to the publisher App (a same-named
+   required admission check bound to the lane App (a same-named
    context from any other source must not satisfy it); strict
    up-to-date-with-base merges (or verified merge-group heads) on the
    protected content branch; and the two-phase pending/finalize protocol
@@ -1198,12 +1253,15 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
     migrated from its organization variable into the registry's
     `corpus-release` entry — Job 1's toolchain verification must read
     it from the registry before any lane activates.
-16. Genesis-time equality refusals: `legacy_apply_root` equal to the
-    `notary`, `admin-approver`, `review`, or `approver` entries
-    refuses — the last matters concretely because legacy signed-apply
-    retirement is not a pilot precondition, and an aliased apply
-    authority could otherwise forge receipt approvals; the registry
-    validator enforces the full §5 matrix.
+16. Genesis-time equality refusals: `legacy_apply_root` equal to
+    **any** registry entry refuses — `approver` matters concretely
+    because legacy signed-apply retirement is not a pilot
+    precondition, so an aliased apply authority could forge receipt
+    approvals; `corpus-release` matters because an aliased service-key
+    holder could freshly sign v5 records over hand-edited bytes before
+    the lane lock and have genesis bless them (§5's window argument —
+    and the production broker already rejects this collision); the
+    registry validator enforces the full §5 matrix.
 
 ## 10. Negative-test floor
 
@@ -1338,7 +1396,10 @@ refused; duplicate profile gate ids and duplicate inventory
 ref_spec/image keys refused; `workflow_ref`/`ref` suffix mismatch
 refused; publisher lane-content write attempt failing (two-credential
 split, positive control); publisher job holding App-minting authority
-forbidden by audit; publisher identity attempting the notary signing
+forbidden by audit; one App registration serving both publisher
+credentials, a shared App private key, or a root installation granting
+repositories or permissions beyond its enumerated scope, each refused
+by the §9.7b audit; publisher identity attempting the notary signing
 operation refused; a non-publisher updating the chain branch, or
 non-linear history, rejected; void marker carrying a sequence refused;
 genesis finalization sequence not "1" refused; sequence "01" or
@@ -1376,7 +1437,8 @@ riding an ordinary candidate refused (trust surface); candidate
 workflow_sha diverging from approve's OIDC claim refused; wrapper
 lane or epoch diverging from candidate or chain refused;
 authorization.environment not derived from OIDC refused; untyped or
-empty lineage identity fields refused; simultaneous-fault refusal
+empty lineage identity fields refused; empty correction `reason`
+refused; simultaneous-fault refusal
 reporting the first rule, least path, and template detail (positive
 control); state-identical transition (empty delta) refused by signer
 and publisher; delete-and-recreate chain through a differing
@@ -1394,10 +1456,11 @@ validation refused; protected 100755 entry refused at base, subject,
 and inside a transition (domain-total wall); delete-then-recreate-
 executable across two finalized receipts refused by the same rule
 (positive control); **a table-driven collision suite over every forbidden §5 pair** —
-each pair a distinct refusal case, `notary`×`review` and
-`notary`×`admin-approver` included — while
-corpus-release/legacy_apply_root, the one permitted service pair, is
-accepted (positive control); finalization requested by rotated not-yet-finalized workflow
+the matrix now total over `notary` and `legacy_apply_root`: every
+pairing of each a distinct refusal case, `notary`×`review`,
+`notary`×`admin-approver`, and
+`corpus-release`×`legacy_apply_root` included — with an all-distinct
+registry accepted (positive control); finalization requested by rotated not-yet-finalized workflow
 code validated and executed by the broker, not the workflow (positive
 control); broker refusing finalization when the pending artifact,
 predecessor, or merged tree fails validation; clean-room chain
@@ -1413,21 +1476,33 @@ consumer pin refused; waiver bytes disagreeing with the base toolchain
 pin refused; equal-manifest transition carrying a forged nonempty
 delta refused; bad newly-introduced record enumerated ineligible while
 the candidate passes (positive control — structural scope);
-non-hex or uppercase store filename enumerated address-mismatch under
-its literal store_name (positive control — total keying);
+non-hex or uppercase store filename enumerated
+unrecognized-store-name under its literal store_name (positive
+control — total keying); a body-grammar name whose stem differs from
+its raw-byte digest enumerated address-mismatch; an honest body at
+`<digest>.json` accepted — the stem is the address, the suffix is
+grammar (positive control); an orphan sidecar, a sidecar naming a
+base-present body, a nested store name, and a non-lineage role suffix
+each enumerated unrecognized-store-name; the sidecar of an eligible
+newly-introduced body not separately enumerated (positive control);
 transition-path policy covering .axiom/notary accepted and covering
 .axiom/lineage refused (the opposite obligations); corpus-release root
 absent from the registry refused; invalid corpus-release signature
 refused; raw_key_id/SPKI pair inconsistent refused; legacy root equal
-to notary, admin-approver, review, or approver refused (each a
-distinct test); finalized receipt whose
+to any registry entry refused (each role a distinct test,
+corpus-release and producer included); finalized receipt whose
 referenced report is unpublished invalid to reconstruction;
 absent-profile preflight refusal carrying a truthful null digest
 (positive control);
 base-present invalid record inert — successor with an honest diff
-passes (positive control — no lane poison); refusal during repository
-or predecessor resolution carrying a truthful all-null established
-prefix (positive control); established-prefix violation refused;
+passes (positive control — no lane poison); chain-reconstruction
+failure refusing chain-unresolvable with a truthful all-null
+established prefix (positive control); absent subject commit refusing
+subject-unresolvable with the three chain fields established (the
+chain resolved first); malformed or invalid-to-reconstruction
+predecessor artifact refusing chain-unresolvable — distinct from
+predecessor-stale, which requires a resolved chain;
+established-prefix violation refused;
 wrong-address new record enumerated address-mismatch; malformed new
 record enumerated malformed-record; absent Job-1 artifact refused;
 reusable approve, publish, or finalizer job refused; unsorted or

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v13
+# Notary admission: design v14
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 13 folds design-review rounds 1–12
-(eighty-six blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 14 folds design-review rounds 1–13
+(eighty-nine blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -429,7 +429,11 @@ do not exist at this level. Over the protected subset:
    the next link's before-state; the final after-state equals the path's
    state in the subject (`(null, null)` for deletions). Mode-only changes
    need a covering transition like any other change.
-3. **Admissible entries.** Protected paths are regular blobs (100644 or
+3. **Admissible entries and the mode wall.** A protected path whose
+   mode differs between base and subject refuses outright — the charter
+   requirement-4 wall, encoded in the predicate itself, not only at
+   preflight; no lineage record covers a mode change in the pilot.
+   Protected paths are regular blobs (100644 or
    100755) wherever they exist — symlinks are inadmissible in the
    protected domain, and gitlinks are refused tree-wide by §2.1.
    File/directory replacements decompose into entry deletions and
@@ -483,18 +487,23 @@ each on a fresh ephemeral runner, none reusable:
 | `verify` (Job 1) | yes | `contents: read` only, no secrets, no environment | none |
 | `recompute` | no (pinned code) | `contents: read`, `actions: read` | none |
 | `approve` | no (pinned code) | `id-token: write` only — the control-plane lookups (`actions: read`) belong to the **signer's own credential**, not to any job | presents identity to the signer |
-| `publish` | no (pinned code) | the two §9.7b credentials, released only by its protected environment | none |
+| `publish` | no (pinned code) | the two §9.7b credentials, vended by the publisher-token broker against its OIDC | `id-token: write`; presents identity to the publisher-token broker |
 
 `publish` (and the finalizer below) run in a dedicated protected
 **`notary-publishing` environment** with its administrator bypass
 disallowed and audited — but environment rules bind reviewers and refs,
 not workflow identity, so the credentials themselves are not
 environment secrets at all: `publish` presents its own OIDC
-(`id-token: write`) and the **external broker vends the two publisher
-tokens** against the exact identity (repository, `workflow_ref` and
-`workflow_sha`, ref, run, attempt, environment) precisely as the signer
-authenticates `approve` — a revoked, rerun, or foreign workflow gets
-nothing. Minting authority never enters any job; the current
+(`id-token: write`) and a **separately deployed publisher-token
+broker** — holding no notary key, no signing operation, and nothing but
+the two App credentials — vends the two publisher tokens against the
+exact identity (repository, `workflow_ref` and `workflow_sha`, ref,
+run, attempt, environment), the same authentication discipline the
+signing broker applies to `approve`. The two brokers are distinct
+deployments by requirement: the signing broker is forbidden
+repository-write capability, and the publisher-token broker is
+forbidden signing capability. A revoked, rerun, or foreign workflow
+gets nothing. Minting authority never enters any job; the current
 publisher's in-job App minting is what this replaces. Finalization
 necessarily runs after the merge, in a separate named workflow
 (`notary-finalize.yml`) triggered by the protected content ref, under
@@ -582,8 +591,9 @@ repository-write credentials, and its caller allowlist is exact — the
 and `workflow_sha`, job, run, attempt, ref, and the `notary-signing`
 environment, with `id-token: write` allocated for the OIDC proof and
 `actions: read` for control-plane lookups and nothing further — the
-allowlisted caller is the `approve` job, the only job that presents
-OIDC. Job 1's
+allowlisted caller of the **signing** operation is the `approve` job;
+`publish` presents OIDC only to the separate publisher-token broker,
+never to the signer. Job 1's
 token is audited to `contents: read` with no other permissions, no
 secrets, and no environment. The trusted job's `GITHUB_TOKEN` is
 read-only and it references no secrets beyond the OIDC exchange. The
@@ -684,10 +694,10 @@ state's trust roots** (the old keys and policy authorize the handover, so
 a successor-controlled key cannot self-authorize its own installation);
 transitions (and genesis) follow the same digest-bound authorization
 pattern as receipts: the typed signer emits the **administrative
-candidate** (the exact genesis or transition body, unsigned), a
-protected reviewer holding a predecessor-state reviewer key signs its
-digest under `axiom/notary-admin-approval/v1` (a scope added to the
-§2.1 role table's semantics; for genesis, the reviewer keys are those
+candidate** (the exact genesis or transition body, unsigned), the
+holder of the predecessor-state **administrative key** — per the §2.1
+role table, never the correction-reviewer key — signs its digest under
+`axiom/notary-admin-approval/v1` (for genesis, the administrative key
 named by the bootstrap ceremony), and the signer signs only after
 verifying that approval signature over the exact digest — environment
 approval alone binds no bytes here either, and a swapped-body
@@ -870,9 +880,12 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    disallowed and audited (a bypassed approval carries no reviewer
    signature and refuses regardless, but the platform gate is
    configured off, not merely compensated for).
-2c. The `notary-publishing` environment created: the publisher and
-   finalizer credentials are environment secrets released only to the
-   pinned workflows on protected refs.
+2c. The `notary-publishing` environment created with its administrator
+   bypass disallowed and audited, and the **publisher-token broker
+   deployed** as a distinct service (no notary key, no signing
+   operation, only the two App credentials) vending against exact OIDC
+   identity — environment secrets are not the mechanism, because
+   environments gate reviewers and refs, not workflow identity.
 3. The dedicated `notary-signing` environment created (required
    reviewers, protected refs, no self-approval), holding no generation
    credentials and no write tokens; generation workflows migrated off
@@ -1086,9 +1099,11 @@ refused; activation consumer-spec differing from the genesis-bound
 template beyond the epoch substitution refused (same-file smuggling);
 replay over the whole tree instead of the protected projection would
 reject a valid candidate (positive control for the projection rule);
-publisher or finalizer credentials requested outside the
-notary-publishing environment, or from a wrong workflow or ref, refused
-by secret release; intermediate replay projection with a path both
+publisher or finalizer credentials requested from the publisher-token
+broker by a wrong workflow, ref, run, or environment vended nothing;
+publisher-token broker asked to sign, or signing broker asked for a
+write token, refused (capability separation of the two brokers);
+publishing-environment administrator bypass tested off; intermediate replay projection with a path both
 terminal and directory-prefix refused as no-valid-execution;
 noncanonical JCS bytes or wrong semantic-array order refused; genesis
 inventory containing a path outside the protected domain refused;

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v28
+# Notary admission: design v29
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 28 folds design-review rounds 1–27
-(one hundred thirty-four blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 29 folds design-review rounds 1–28
+(one hundred thirty-five blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -152,7 +152,9 @@ bytes — **the stem is the address; the `.json` suffix is grammar, not
 digest** — and a signature sidecar is named `<digest>.json.<role>.sig`
 with `<role>` one of the store's lineage scopes (`producer`, `actor`,
 `review`; chain artifacts live on the chain branch, never in the
-store). Each sidecar is canonical JSON:
+store, and carry their signatures under §7's chain-bundle grammar —
+the same filename pattern with the chain scopes as tokens). Each
+sidecar is canonical JSON:
 `{schema: "axiom/detached-signature/v1", body_sha256, scope,
 signer_spki_sha256, signature_base64}`. Every cross-scope verification
 must fail, legacy `apply_ed25519`/`eval_ed25519` included (§10 tests the
@@ -454,10 +456,11 @@ milestone one.
 approval_signature_sha256}` — the `approve` job's own OIDC
 `check_run_id`, and the digest of the detached
 `axiom/notary-approval/v1` signature file. Candidate fields are
-referenced by digest, never flattened, and the candidate body and
-approval-signature file **must be published on the chain branch beside
-the receipt** — a receipt whose candidate or approval file is
-unpublished is unverifiable and invalid to reconstruction. The reviewer
+referenced by digest, never flattened, and the receipt's §7 bundle —
+report body, candidate body, the approval sidecar over the candidate,
+and the notary sidecar over the receipt — **must be published on the
+chain branch with it, in one commit**; a receipt any of whose bundle
+files is unpublished is unverifiable and invalid to reconstruction. The reviewer
 approval signs the candidate digest; the signer assembles the wrapper
 **by derivation, never by input**: wrapper `lane` and `epoch_sha256`
 are copied from the candidate and verified equal to the chain's;
@@ -993,7 +996,10 @@ named by the bootstrap ceremony), and the signer signs only after
 verifying that approval signature over the exact digest — environment
 approval alone binds no bytes here either, and a swapped-body
 transition after platform approval refuses on the missing
-matching-digest signature; and transitions are void
+matching-digest signature. Both signatures — the admin-approval and
+the typed signer's own — publish as the artifact's §7 bundle
+sidecars, so authorization evidence is durable on the branch, not an
+ephemeral signing-time check; and transitions are void
 until finalized (§7), exactly like receipts. For merge gating, a pending
 transition plays the pending receipt's role for its own subject (§7): it
 is the merge-authorizing artifact for exactly its enumerated delta.
@@ -1024,7 +1030,26 @@ ruleset in the notary repository: only the chain App may push; no
 force pushes; no deletion; linear history. Its contents: content-addressed artifact files (reports,
 receipts, transitions, genesis, and void markers) plus `HEAD.json`
 (`{schema: "axiom/notary-head/v1", tip_sha256, tip_kind}`) as a
-convenience pointer. Two marker schemas complete the branch's contents:
+convenience pointer. **Chain files follow the §2.1 grammar** — bodies
+`<digest>.json` with the stem the SHA-256 of the raw bytes, detached
+signatures `<digest>.json.<scope>.sig` with the scope name as token —
+and every signed artifact publishes as a **closed bundle in one
+commit**: genesis = body + its `genesis`-scope sidecar (the typed
+signer's) + its `admin-approver` sidecar; transition = body +
+`transition` sidecar + `admin-approver` sidecar; receipt = report
+body + candidate body + the `approver` sidecar over the candidate +
+receipt body + the `notary` sidecar over the receipt. Reports,
+candidates, markers, and `HEAD.json` are exactly the unsigned files —
+reports and candidates are bound by digest from signed bodies, and
+marker authentication is structural (below); a sidecar naming a
+marker, an unknown scope token, or any other file pattern invalidates
+the branch to reconstruction. Exactly one sidecar per (body, scope):
+duplicates cannot coexist in a tree, and a later commit that adds,
+rewrites, or deletes any file of an already published bundle is
+mutation — append-only discipline identical to the lineage store's,
+and reconstruction refuses the branch at that commit. A partial
+bundle is never *pending* (the state machine below reads complete
+bundles), and the publisher refuses to commit one. Two marker schemas complete the branch's contents:
 `axiom/notary-finalization/v1` (`{schema, lane, epoch_sha256,
 target_sha256, target_kind, merged_tip_manifest_sha256, sequence}`) and
 `axiom/notary-void/v1` (`{schema, lane, epoch_sha256, target_sha256,
@@ -1033,8 +1058,9 @@ artifact. Marker authentication is structural: the branch accepts
 commits from the chain App alone, linear history, no force pushes —
 so markers are exactly what the pinned publisher committed, in order.
 
-The chain state machine, exhaustively: an artifact is *pending* when its
-body is on the branch with no marker naming it; *finalized* when exactly
+The chain state machine, exhaustively: an artifact is *pending* when
+its **complete bundle** is on the branch with no marker naming its
+body — an incomplete bundle never enters the state machine; *finalized* when exactly
 one finalization marker names it; *void* when a void marker names it.
 Finalized and void are terminal and mutually exclusive — the first
 marker in branch history wins, and any later marker naming the same
@@ -1510,13 +1536,26 @@ base-present body, a nested store name, and a non-lineage role suffix
 each enumerated unrecognized-store-name; the sidecar of an eligible
 newly-introduced body not separately enumerated (positive control);
 transition-path policy covering .axiom/notary accepted and covering
-.axiom/lineage refused (the opposite obligations); corpus-release root
+.axiom/lineage refused (the opposite obligations); transition-path
+policy omitting required .axiom/notary coverage refused as
+policy-invalid; corpus-release root
 absent from the registry refused; invalid corpus-release signature
 refused; raw_key_id/SPKI pair inconsistent refused for either legacy root;
+the §9.15 witnessed comparison failing — genesis-bound apply root
+differing from the independently frozen production fingerprint — 
+aborting the ceremony (a distinct case per legacy root: apply and
+eval each tested);
 either legacy root equal
 to any registry entry refused (each pairing a distinct test,
 corpus-release and producer included); finalized receipt whose
-referenced report is unpublished invalid to reconstruction;
+referenced report is unpublished invalid to reconstruction; a bundle
+missing its notary, admin-approver, or approver sidecar never pending
+and invalid to reconstruction (a distinct case per artifact kind); a
+later commit rewriting or deleting any published bundle file
+invalidating the branch at that commit (append-only discipline); a
+partial-bundle commit refused by the publisher; an unknown scope
+token, a sidecar naming a marker, or an unclassifiable chain file
+invalidating the branch to reconstruction;
 absent-profile preflight refusal carrying a truthful null digest
 (positive control);
 base-present invalid record inert — successor with an honest diff

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v21
+# Notary admission: design v22
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 21 folds design-review rounds 1–20
-(one hundred eighteen blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 22 folds design-review rounds 1–21
+(one hundred twenty-one blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -533,30 +533,34 @@ do not exist at this level. Over the protected subset:
    tree would falsely reject every nonempty candidate — cross-path cycles between records (X and Y each feeding the
    other on different paths) refuse as `record-cycle`, because no
    repository state ever contained what the subject cherry-picks.
-   Second, **correction predecessors have predicate meaning**: a consumed
-   correction event's `predecessor_record_sha256` must be null or equal
-   the digest of the immediately preceding consumed record in the same
-   path's chain; anything else refuses. It is lineage, verified — not
-   opaque metadata implementations may ignore.
+   Second, **correction predecessors have predicate meaning, scoped to
+   the current candidate**: a consumed correction event's
+   `predecessor_record_sha256` must be null or equal the digest of the
+   immediately preceding consumed record in the same path's chain
+   within this assignment; anything else refuses. A correction landing
+   in a later candidate than the record it amends uses null — the
+   historical relationship belongs in `reason`, since cross-receipt
+   pointers would force references to permanently ineligible records.
+   It is lineage, verified — not opaque metadata implementations may
+   ignore.
 2. **Blob-and-mode ground truth.** Each chain's first
    `(before_blob_sha256, before_mode)` equals the path's state at the
    base (`(null, null)` for additions); each link's after-state equals
    the next link's before-state; the final after-state equals the path's
    state in the subject (`(null, null)` for deletions). Mode-only changes
    need a covering transition like any other change.
-3. **Admissible entries and the mode wall, presence-aware.** For a
-   protected path **present at both endpoints**, differing modes refuse
-   outright; additions and deletions carry their single endpoint's mode
-   and are unaffected (the wall never fires on a null side). And the
-   wall is closed against laundering through intermediates: **every
-   non-null mode across a path's entire consumed chain must agree**
-   (per-transition preservation alone still admits an executable
-   intermediate through a delete-and-recreate pair), so any chain
-   passing through a differing mode refuses wherever it occurs.
-   This is the charter requirement-4 wall in the predicate itself;
-   relaxing it is the §11 charter-alignment decision. Protected paths
-   are regular blobs (100644 or
-   100755) wherever they exist — symlinks are inadmissible in the
+3. **Admissible entries and the mode wall, domain-total.** The pilot's
+   protected domain is **100644-only**: a protected entry with mode
+   `"100755"` — at the base, at the subject, or inside any transition —
+   refuses. This is stronger than an endpoint or chain rule and closes
+   every laundering shape at once, including delete-in-one-receipt,
+   recreate-executable-in-the-next: no admissible executable state
+   exists anywhere in the protected domain, so there is nothing to
+   launder toward. (Every rulespec file is a 100644 YAML file; the
+   restriction costs the pilot nothing.) Executable support, if ever
+   wanted, is the §11 charter-alignment decision and arrives with the
+   chain-state tombstone machinery a cross-receipt wall needs.
+   Protected paths are regular 100644 blobs wherever they exist — symlinks are inadmissible in the
    protected domain, and gitlinks are refused tree-wide by §2.1.
    File/directory replacements decompose into entry deletions and
    additions and are covered as such.
@@ -627,9 +631,19 @@ repository-write capability, and the publisher-token broker is
 forbidden signing capability. A revoked, rerun, or foreign workflow
 gets nothing. Minting authority never enters any job; the current
 publisher's in-job App minting is what this replaces. Finalization
-necessarily runs after the merge, in a separate named workflow
-(`notary-finalize.yml`) triggered by the protected content ref, under
-the same environment and credential binding.
+necessarily runs after the merge — but its trust does not ride any
+lane workflow file, because a workflow-rotation transition changes the
+very file GitHub would load post-merge, and the successor code is not
+yet finalized. So **finalization is a typed broker operation**: the
+`notary-finalize.yml` workflow (triggered by the protected content
+ref, in the publishing environment) merely *requests* finalization
+with its OIDC identity; the **publisher-token broker itself**
+re-derives the merged tip's manifest, validates the signed pending
+artifact, its chain predecessor, and the state-machine rules, and
+executes the CAS commit with its own credential. Even
+not-yet-finalized workflow code can only ask; it validates nothing and
+holds nothing, so squash rewrites and credential-bearing workflow
+rotations stay harmless.
 
 Job conclusions are read through the jobs-for-run endpoint (by job name
 and attempt), never self-asserted; the `approve` job's identity is
@@ -750,14 +764,18 @@ verification reads it from here). The three typed scopes —
 `genesis`, `transition`, and `notary` — all resolve to the **`notary`**
 registry entry: the external typed signer signs all three with the
 notary key, and the admin-approver's separate signature is what
-authorizes the administrative ones. **Role-key exclusions are pairwise and explicit**: an SPKI under
-`producer` or `actor` must not appear under any admission-side role
-(`review`, `admin-approver`, `approver`, `notary`); `review` and
-`admin-approver` must be disjoint (a correction reviewer must not hold
-rotation authority); and `approver` must be disjoint from every
-automation role. Any listed collision refuses the registry (the
-charter's separate-key requirement made checkable; the cross-scope
-matrix alone cannot detect deliberate key reuse across scopes). For every other scope,
+authorizes the administrative ones. **Role-key exclusions are enumerated pairs, nothing implicit** — the
+forbidden collisions are exactly: `producer`×{`review`,
+`admin-approver`, `approver`, `notary`, `corpus-release`};
+`actor`×{`review`, `admin-approver`, `approver`, `notary`,
+`corpus-release`}; `review`×`admin-approver`;
+`approver`×{`producer`, `actor`, `notary`, `corpus-release`}; plus the
+genesis-time `legacy_apply_root`×{`notary`, `admin-approver`,
+`review`, `approver`} refusals of §9.16. Any listed collision refuses
+the registry; unlisted pairs (e.g. `notary`×`corpus-release`, two
+service-held verification roots) are permitted. (The charter's
+separate-key requirement made checkable; the cross-scope matrix alone
+cannot detect deliberate key reuse across scopes.) For every other scope,
 scope-to-registry resolution is the role table itself: a detached signature under a scope verifies
 against the key bytes registered for that scope's role, never against
 the signature file's self-declared fingerprint (which is
@@ -984,7 +1002,12 @@ is closed by the audited freeze: genesis is valid only over the locked
 tip, and the activation transition chains from it before anything else
 may.
 
-**Verification does not trust the pointer.** The chain's truth is
+**Verification does not trust the pointer — and the branch carries its
+own preimages.** Genesis publishes the full policy, profile, and
+key-registry bodies (not digests alone) beside its body on the chain
+branch, and every transition that changes them publishes the new
+bodies likewise, so administrative approvals and historical keys
+verify from the branch alone after any number of rotations. The chain's truth is
 reconstructible by rule from the branch alone: the valid chain is the
 unique sequence of signed artifacts starting at genesis in which each
 artifact's base manifest equals its predecessor's subject manifest, each
@@ -1330,7 +1353,19 @@ byte-correct at genesis absent from the activation diff accepted
 (positive control — installed values, not diff membership);
 generation-side SPKI colliding with an admission-side role refused;
 registry key bytes failing base64, DER, Ed25519, or fingerprint
-validation refused; noncanonical decimal id ("01") refused; invalid
+validation refused; protected 100755 entry refused at base, subject,
+and inside a transition (domain-total wall); delete-then-recreate-
+executable across two finalized receipts refused by the same rule
+(positive control); approver/corpus-release collision refused per the
+enumerated pairs while notary/corpus-release is permitted (positive
+control); finalization requested by rotated not-yet-finalized workflow
+code validated and executed by the broker, not the workflow (positive
+control); broker refusing finalization when the pending artifact,
+predecessor, or merged tree fails validation; clean-room chain
+reconstruction succeeding from the branch alone after a key rotation
+(positive control — published preimages); cross-receipt correction
+with a null predecessor and the amended record named in reason
+accepted (positive control); noncanonical decimal id ("01") refused; invalid
 RFC 3339 emitted_at refused; registry notary entry differing from the
 consumer pin refused; waiver bytes disagreeing with the base toolchain
 pin refused; equal-manifest transition carrying a forged nonempty

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v31
+# Notary admission: design v32
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 31 folds design-review rounds 1–30
-(one hundred thirty-eight blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 32 folds design-review rounds 1–31
+(one hundred thirty-nine blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -1046,16 +1046,29 @@ transition = body + `transition` sidecar + `admin-approver` sidecar +
 after sides; deletions publish nothing); receipt =
 report body + candidate body + the `approver` sidecar over the
 candidate + receipt body + the `notary` sidecar over the receipt.
-**Preimages have their own opaque grammar**: `<digest>.raw`, the raw
+**Preimages have their own grammar — opaque at dispatch, semantic
+at use**: `<digest>.raw`, the raw
 lane-file bytes stored verbatim, `<digest>` the lowercase 64-hex
-SHA-256 of exactly those bytes — trust files are YAML, TOML, and
+SHA-256 of exactly those bytes. Trust files are YAML, TOML, and
 JSON, so preimages are exempt from the §2.1 body contract and are
-**never parsed**, whatever their bytes resemble (a `.raw` file whose
-content looks like a schema-carrying JSON body is still opaque bytes;
-the suffix alone selects the treatment, so no type precedence
-exists). This holds even for the JSON policy files: every preimage
+**never dispatched as chain artifacts**, whatever their bytes
+resemble (a `.raw` file whose
+content looks like a schema-carrying JSON body is still no body;
+the suffix alone selects the namespace, so no type precedence
+exists) — this holds even for the JSON policy files: every preimage
 lands under `.raw`, and the `.json` namespace holds chain-artifact
-bodies alone.
+bodies alone. Dispatch opacity is not semantic opacity: **once a
+preimage is digest-bound to a named trust path, its user decodes and
+validates the bytes under that trust file's own contract** — the key
+registry preimage under `axiom/notary-key-registry/v1` (mandatory:
+reconstruction recovers each state's key bytes from here, because a
+detached signature carries only a fingerprint and a fingerprint
+cannot verify a signature), the policy and profile preimages under
+their own schemas, and schema-less trust files (workflow YAML, the
+waiver file, the toolchain pin) by digest identity alone, their
+semantics living in lane enforcement. A bound preimage that fails
+its own contract fails the reconstruction or validation step that
+needed it.
 The unsigned files are closed by **digest-reachability, not by
 pattern**: every unsigned `.json` body on the branch must be
 digest-named by a signed body — the report by its candidate's
@@ -1592,8 +1605,13 @@ each accepted verbatim under `.raw` (positive controls — the honest
 waiver-file and toolchain-pin transitions are constructible); a raw
 preimage wrapped in JSON refused (digest no longer the delta's
 after-digest); a `.raw` file whose bytes resemble a schema-carrying
-JSON body accepted as opaque and never parsed (positive control — no
-type precedence); a `.raw` file digest-reachable from no
+JSON body never dispatched as a chain artifact (positive control —
+dispatch opacity); the registry preimage decoded and validated under
+its own schema at reconstruction, recovering the historical keys that
+verify a post-rotation signature (positive control — semantic use); a
+bound registry preimage failing its own schema validation failing
+reconstruction; a sidecar naming a `.raw` file invalidating the
+branch; a `.raw` file digest-reachable from no
 bootstrap_policies digest or delta after-digest invalidating the
 branch; a transition delta out of bytewise path order, or with a
 duplicate path, refused at parse; two honest constructions of one

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v9
+# Notary admission: design v10
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 9 folds design-review rounds 1–8
-(sixty-two blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 10 folds design-review rounds 1–9
+(sixty-eight blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -191,14 +191,26 @@ refusal has no unique assignment; a structural refusal has no manifest),
 so the report is **two closed schemas**, not one with impossible fields.
 
 `axiom/notary-report-refusal/v1`: `{schema, lane, epoch_sha256,
-subject_commit_git_oid, stage, refusal}` where `stage` is one of
-`"structural"`, `"preflight"`, `"eligibility"`, `"assignment"`,
-`"gates"`, and `refusal` is the coded object below; plus exactly the
-stage-established optional fields per a fixed table: manifests only from
-`"preflight"` onward, eligible-record lists only from `"eligibility"`
-onward, never an assignment (a refusal that could compute a unique
-assignment would not be a refusal). Refusal reports are diagnostics; no
-downstream artifact ever binds one.
+subject_commit_git_oid, stage, refusal}` plus stage-established fields
+per this normative table (present exactly when the stage is reached,
+null-less and closed at each stage):
+
+| `stage` | additional required fields |
+|---|---|
+| `"structural"` | none |
+| `"preflight"` | both tree manifests, base/chain fields, policy and profile digests |
+| `"eligibility"` | the preflight fields + `eligible_records`, `ineligible_records` |
+| `"assignment"` | the eligibility fields + `unused_eligible_records` |
+| `"gates"` | the assignment fields + `coverage_assignment`, `unprotected_changes`, `gates` |
+
+A `"gates"`-stage refusal does carry its unique assignment — coverage
+succeeded; a gate outcome did not — under refusal codes extended
+accordingly: the closed enum gains `"gate-unacceptable"` and
+`"gate-missing"` beside the coverage codes. `ineligible_records`
+entries carry `reasons`: the **sorted array of every applicable reason
+code**, so a multi-fault record has one deterministic representation.
+Refusal reports are diagnostics; no downstream artifact ever binds
+one.
 
 `axiom/notary-report-pass/v1` — the only variant the trusted side will
 reconcile — content-addressed output of the verification workflow.
@@ -307,7 +319,7 @@ never part of the subject tree.
 
 The policy is a committed file at the base
 (`.axiom/notary/path-policy.json`):
-`{schema: "axiom/notary-path-policy/v1", rules: [{action:
+`{schema: "axiom/notary-path-policy/v1", lane, rules: [{action:
 "include" | "exclude", prefix}]}`. A prefix matches path `p` iff
 `p == prefix` or `p` starts with `prefix + "/"` (component-wise; `rules`
 never matches `rules-evil/x`). Last matching rule wins; a path matching no
@@ -415,17 +427,25 @@ surfaces move only by transition record (§6.4).
 
 ## 5. Execution, trust boundary, and the external signer
 
-**One workflow run, two jobs.** Job 1 and the trusted job are jobs of
-the **same workflow run** — this topology is normative, because it is
-what makes workflow identity derivable: the trusted job's own OIDC token
-carries the `workflow_sha` that governed the entire run, covering Job 1
-without needing any per-job claim GitHub does not issue. The trusted job
-reads Job 1's conclusion through the jobs-for-run endpoint (by job name
-and attempt) rather than any self-asserted value, and its own identity
-is bound the only way OIDC permits: the token's `check_run_id` claim is
-reconciled through jobs-for-run to the expected trusted-job name and
-attempt — GitHub's claims carry no job name — and reusable execution is
-prohibited for the trusted job exactly as for Job 1.
+**One workflow run, four named jobs.** All jobs share the **same
+workflow run** — the topology is normative because it makes workflow
+identity derivable: any job's OIDC `workflow_sha` covers the whole run,
+and no per-job claim GitHub does not issue is ever needed. The jobs,
+each on a fresh ephemeral runner, none reusable:
+
+| Job | Runs candidate code | Token | OIDC use |
+|---|---|---|---|
+| `verify` (Job 1) | yes | `contents: read` only, no secrets, no environment | none |
+| `recompute` | no (pinned code) | `contents: read`, `actions: read` | none |
+| `approve` | no (pinned code) | none beyond `id-token: write` | presents identity to the signer |
+| `publish` | no (pinned code) | the two §9.7b credentials | none |
+
+Job conclusions are read through the jobs-for-run endpoint (by job name
+and attempt), never self-asserted; the `approve` job's identity is
+bound the only way OIDC permits — its token's `check_run_id` claim,
+reconciled through jobs-for-run to the expected job name and attempt
+(GitHub's claims carry no job name). The receipt's `job1.check_run_id`
+is the `verify` job's check run, recorded from that same lookup.
 
 **Job 1 — verify (secretless, candidate-executing).** Runs on a fresh
 ephemeral runner (GitHub-hosted or dedicated ephemeral pool) with no
@@ -472,17 +492,28 @@ trusted flow is therefore three stages: the **recomputation stage**
 (fresh runner, pinned code, unapproved) performs the reconciliation
 above and publishes the immutable, content-addressed **receipt
 candidate** — the completed reconciled body, unsigned; the **approval
-stage** is a separate job in the dedicated `notary-signing` environment
-whose input is the candidate digest, so the deployment review the
-humans approve names the exact bytes (required reviewers, no
-self-approval, an environment holding no generation credentials and no
-write tokens — unlike today's `production-signing`, which provisions
-generation workflows with the apply key, a model credential, and a
-write-capable token, and is structurally disqualified); the **signing
-step** is the external signer, which validates the approved job's OIDC
-identity, re-reads the candidate by digest, verifies the approved input
-digest matches, and signs. Approval is thereby digest-bound to a
-completed receipt; it never releases key material to a runner.
+stage** is the `approve` job in the dedicated `notary-signing`
+environment (required reviewers, no self-approval, **administrator
+bypass disallowed and audited** — GitHub's separate bypass setting must
+be off, and §10 tests the bypassed case; the environment holds no
+generation credentials and no write tokens, unlike today's
+`production-signing`, which provisions generation workflows with the
+apply key, a model credential, and a write-capable token, and is
+structurally disqualified). Platform approval alone cannot bind bytes —
+neither OIDC nor the jobs API authenticates job inputs — so the binding
+is cryptographic: **a protected reviewer signs the candidate digest**
+under its own scope, `axiom/notary-approval/v1` (a detached signature
+by a reviewer key from §8's ceremony, distinct from every automation
+key), and that signature is the durable, signer-verifiable approval
+evidence. The **signing step** is the external signer, which validates
+the `approve` job's OIDC identity, re-reads the candidate by digest,
+**verifies the reviewer approval signature over that exact digest**,
+and signs. An environment-bypassed job carries no reviewer signature
+and refuses. Approval is thereby digest-bound to a completed receipt by
+signature, not by platform semantics; key material never reaches a
+runner. (This resolves the §11 approval-wording decision in the
+stronger form: `authorization.approval_context` is the reviewer
+approval-signature reference.)
 
 Effective-permission constraints, not deployment assumptions (§9): the
 external signer's own deployment holds no model, generation, or
@@ -531,6 +562,10 @@ inventories forming an **exhaustive, disjoint, exactly-once partition of
 the protected paths** at genesis (the typed signer verifies the
 partition property against the manifest before signing):
 
+- `bootstrap_policies`: an object with exactly three members —
+  `{path_policy_sha256, transition_path_policy_sha256, profile_sha256}`
+  — the prospective policy bodies §7 binds (part of the closed genesis
+  schema, so the epoch digest is uniquely constructible);
 - `v5_attested`: sorted `[path, entry_sha256, record_sha256]` — paths
   whose blobs are vouched at genesis by a legacy record that passes the
   **current v5 authentication contract**: schema exactly
@@ -635,9 +670,17 @@ audited rather than claimed as CAS: before genesis signing, the lane's
 protected branch is **locked** (a lock ruleset barring all merges), the
 signer verifies via the API both that the lock is active and that
 `genesis_commit_git_oid` equals the locked tip, and the lock is
-retained until activation finalization — the post-sign pre-publication
-race cannot occur because nothing can merge while locked. A genesis
-attempt observing a moved tip or an absent lock refuses.
+retained until activation finalization. A locked branch is read-only —
+including to the activation merge — so the lock names its **sole,
+audited bypass**: the bootstrap administrative actor, whose one
+permitted action is merging the activation commit, listed in §9 as a
+security-critical authority. The guarantee does not rest on that
+actor's discipline: activation refuses unless the recomputed
+base→subject diff equals exactly the epoch pin plus the three
+genesis-bound policy files, so a bypass misused for any other merge
+produces an activation that cannot finalize and a bootstrap that
+voids. A genesis attempt observing a moved tip or an absent lock
+refuses.
 
 Genesis also **binds its prospective policies**: the body carries
 `bootstrap_policies` — the digests of the exact path-policy,
@@ -886,8 +929,11 @@ subject (voids, permanently); voided digest re-finalization attempt;
 finalization when the artifact's base is not the current finalized tip;
 chain-branch force-push and deletion rejected by ruleset; unauthorized
 chain rollback or void-marker erasure visible to reconstruction;
-`HEAD.json` diverging from chain reconstruction; publisher push outside
-the chain branch rejected; `HEAD.json` naming an unpublished or unsigned
+`HEAD.json` diverging from chain reconstruction; publisher writes outside the chain branch of the notary repository are
+not ruleset-preventable (contents-write is repository-scoped) and are
+harmless by construction — reconstruction reads only the chain branch —
+tested as: a non-chain ref in the notary repository is ignored by
+reconstruction; `HEAD.json` naming an unpublished or unsigned
 artifact; recomputation divergence in `eligible_records`,
 `corpus_release`, `waiver_set_sha256`, `dependency_pins_sha256`, or the
 `verifier` identity; malformed finalization or void marker;
@@ -929,7 +975,16 @@ duplicate-path case; absent, non-regular, or oversized waiver file
 refused; refusal report carrying an assignment or stage-unestablished
 fields refused; approval-stage input digest mismatching the receipt
 candidate refused; signing without a digest-bound approval refused;
-invalid OIDC signature, issuer, audience, or expiry refused.
+invalid OIDC signature, issuer, audience, or expiry refused; unknown
+stage, refusal-code, or ineligible-reason value refused; multi-fault
+ineligible record represented by its full sorted reason array (positive
+control); wrong `baseline_unattested` entry digest refused; genesis
+commit/tree-manifest mismatch refused; wrong or intervening first chain
+commits refused; premature lock removal or an unauthorized bootstrap
+bypass merge producing an activation that cannot finalize (voids);
+environment-admin approval bypass carrying no reviewer signature
+refused; reviewer approval signature over the wrong digest refused;
+`"gates"`-stage refusal carrying its assignment (positive control).
 
 ## 11. Decisions for sign-off
 

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v8
+# Notary admission: design v9
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 8 folds design-review rounds 1–7
-(fifty-eight blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 9 folds design-review rounds 1–8
+(sixty-two blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -184,9 +184,25 @@ are first-class and loud: the sanctioned response to a wrong encoding
 remains fix-the-encoder-and-re-encode, and a correction event is the
 recorded exception, never the quiet path.
 
-### 2.4 Verification report (Job 1, unsigned) — `axiom/notary-report/v1`
+### 2.4 Verification reports (Job 1, unsigned) — pass and refusal variants
 
-Content-addressed output of the verification workflow. Fields: `schema`,
+Refusals cannot carry fields their stage never established (an ambiguity
+refusal has no unique assignment; a structural refusal has no manifest),
+so the report is **two closed schemas**, not one with impossible fields.
+
+`axiom/notary-report-refusal/v1`: `{schema, lane, epoch_sha256,
+subject_commit_git_oid, stage, refusal}` where `stage` is one of
+`"structural"`, `"preflight"`, `"eligibility"`, `"assignment"`,
+`"gates"`, and `refusal` is the coded object below; plus exactly the
+stage-established optional fields per a fixed table: manifests only from
+`"preflight"` onward, eligible-record lists only from `"eligibility"`
+onward, never an assignment (a refusal that could compute a unique
+assignment would not be a refusal). Refusal reports are diagnostics; no
+downstream artifact ever binds one.
+
+`axiom/notary-report-pass/v1` — the only variant the trusted side will
+reconcile — content-addressed output of the verification workflow.
+Fields: `schema`,
 `lane`, `epoch_sha256`; `subject_commit_git_oid`,
 `subject_tree_manifest_sha256`; `base_commit_git_oid`,
 `base_tree_manifest_sha256`; `chain_predecessor_sha256`,
@@ -200,8 +216,9 @@ digests consumed for its chain, in chain order (the unique assignment of
 by `gate_id`, **one entry per gate id** (duplicates are a parse refusal),
 each `{gate_id, outcome}` — tiers are not report fields at all: a gate's
 tier comes from the digest-bound profile, so a report cannot strengthen a
-classification the profile did not grant; `diff_coverage`: `"pass"` or a typed
-refusal object (never `waived`, never `not-run`); `unprotected_changes`
+classification the profile did not grant; `diff_coverage`: exactly `"pass"` — the pass
+variant carries no refusal shapes, and `waived`/`not-run` exist in
+neither variant; `unprotected_changes`
 (sorted paths); `ineligible_records`: sorted array of `{record_sha256, reason}` with a
 closed reason enum (`"unprotected-path-transition"`,
 `"duplicate-transition-paths"`, `"wrong-lane"`, `"wrong-epoch"`,
@@ -447,14 +464,25 @@ trusted job running only pinned code on a fresh runner:
    exposes no arbitrary-byte operation for the genesis, transition, or
    notary scopes.
 
-**Human authorization** gates the signing step through the dedicated
-`notary-signing` environment (required reviewers, protected refs, no
-self-approval) — an environment that holds no generation credentials and
-no write tokens, unlike today's `production-signing`, which provisions
+**Human authorization approves a completed receipt, not a pipeline.**
+GitHub environment approval gates a job before it starts, so the
+recomputing job cannot be the approved job — reviewers would be
+approving work not yet run, which the charter explicitly forbids. The
+trusted flow is therefore three stages: the **recomputation stage**
+(fresh runner, pinned code, unapproved) performs the reconciliation
+above and publishes the immutable, content-addressed **receipt
+candidate** — the completed reconciled body, unsigned; the **approval
+stage** is a separate job in the dedicated `notary-signing` environment
+whose input is the candidate digest, so the deployment review the
+humans approve names the exact bytes (required reviewers, no
+self-approval, an environment holding no generation credentials and no
+write tokens — unlike today's `production-signing`, which provisions
 generation workflows with the apply key, a model credential, and a
-write-capable token and is structurally disqualified. Environment
-approval releases the *request* to the external signer; it never
-releases key material to a runner.
+write-capable token, and is structurally disqualified); the **signing
+step** is the external signer, which validates the approved job's OIDC
+identity, re-reads the candidate by digest, verifies the approved input
+digest matches, and signs. Approval is thereby digest-bound to a
+completed receipt; it never releases key material to a runner.
 
 Effective-permission constraints, not deployment assumptions (§9): the
 external signer's own deployment holds no model, generation, or
@@ -472,9 +500,11 @@ publisher is pinned candidate-free code that validates the signed
 receipt and the current finalized predecessor before ever emitting the
 required check.
 
-**Publisher — separate job.** Holds only a token whose write capability
-is confined to the notary ref by repository ruleset (App tokens scope to
-repositories, not refs); publishes per §7; holds no signing capability.
+**Publisher — separate job, two-keyed.** Holds two separately
+constrained credentials per §9.7b — a chain credential (contents-write
+on the notary repository alone) and a lane credential (checks-write and
+contents-read on the lane repository alone) — provisioned to it, never
+minted by it; publishes per §7; holds no signing capability.
 
 Trust roots for every step are committed at or digest-pinned to the
 protected base. Runtime organization variables are not trust anchors
@@ -598,21 +628,34 @@ Genesis bootstraps the branch: the branch's first two commits must be
 exactly the genesis body and its finalization marker, published by the
 same CAS branch creation — a competing genesis loses the atomic
 first-push and any later genesis body or marker is invalid by the
-second-genesis rule. **Bootstrap is explicitly acyclic and
-tip-frozen.** At genesis signing, the typed signer verifies by CAS that
-`genesis_commit_git_oid` is the lane's protected-ref tip at that
-moment; a tip that moved voids the genesis attempt and it reruns. The
-lane's epoch pin cannot live inside the genesis tree (that would be
-`epoch → tree → body → epoch`); it lands immediately after, in a
-**bootstrap activation transition** — the chain's second artifact,
-predecessor genesis, whose delta is exactly the consumer-spec epoch pin
-and the three policy files. Enforcement begins at activation
-finalization; between genesis and activation the lane accepts no
-ordinary candidates. The stale-genesis laundering path (genesis frozen
-at an old tip while the branch sits at a newer one, letting a later
-record cover the gap) is closed by the CAS: genesis is void unless it
-froze the actual tip, and the activation transition chains from it
-before anything else may.
+second-genesis rule. **Bootstrap is explicitly acyclic, policy-bound, and freeze-audited.**
+No writer in this design can atomically couple a lane read with a
+notary-repository branch creation, so the freeze is administrative and
+audited rather than claimed as CAS: before genesis signing, the lane's
+protected branch is **locked** (a lock ruleset barring all merges), the
+signer verifies via the API both that the lock is active and that
+`genesis_commit_git_oid` equals the locked tip, and the lock is
+retained until activation finalization — the post-sign pre-publication
+race cannot occur because nothing can merge while locked. A genesis
+attempt observing a moved tip or an absent lock refuses.
+
+Genesis also **binds its prospective policies**: the body carries
+`bootstrap_policies` — the digests of the exact path-policy,
+transition-path-policy, and profile bodies the lane will adopt — and
+the genesis partition of protected paths is computed under that bound
+path policy, so the policy defining genesis provenance is fixed at
+signing and cannot be selected afterward. The lane's epoch pin cannot
+live inside the genesis tree (that would be `epoch → tree → body →
+epoch`); it lands immediately after, in the **bootstrap activation
+transition** — the chain's second artifact, predecessor genesis, whose
+delta is exactly the consumer-spec epoch pin plus those three policy
+files, digest-identical to `bootstrap_policies`; its eligibility oracle
+is the genesis-bound transition-path policy. Enforcement begins at
+activation finalization; the lock spans the whole interval, so no
+ordinary candidate can slip between. The stale-genesis laundering path
+is closed by the audited freeze: genesis is valid only over the locked
+tip, and the activation transition chains from it before anything else
+may.
 
 **Verification does not trust the pointer.** The chain's truth is
 reconstructible by rule from the branch alone: the valid chain is the
@@ -862,18 +905,31 @@ kind, or tip manifest; marker sequence gap or repeat invalidating the
 branch; transition delta path unmatched by the transition-path policy;
 transition validated by the publisher under predecessor-state roots
 (positive control) and rejected when its signature or predecessor
-fails; empty subtree entry refused; genesis signing against a moved
-lane tip voided by CAS (stale-genesis laundering closed); ordinary
-candidate between genesis and activation refused; activation transition
-with any delta beyond the epoch pin and policy files refused; wrong
+fails; empty subtree entry refused; genesis attempt without an active
+lane lock, or against a tip that moved, refused (stale-genesis
+laundering closed); lane movement between genesis signing and
+publication impossible under the audited lock (positive control);
+ordinary candidate between genesis and activation refused; activation
+transition with any delta beyond the epoch pin and the three
+genesis-bound policy files refused; activation omitting the epoch pin
+or any policy file refused; activation installing a policy file whose
+digest differs from bootstrap_policies refused; genesis with absent
+bootstrap_policies refused; wrong
 `check_run_id` or a trusted job in a reusable or separate-run topology
 refused; duplicate profile gate ids and duplicate inventory
 ref_spec/image keys refused; `workflow_ref`/`ref` suffix mismatch
 refused; publisher lane-content write attempt failing (two-credential
 split, positive control); publisher job holding App-minting authority
-forbidden by audit; void marker carrying a sequence refused; genesis
-finalization sequence not "1" refused; fsck-dirty tree refused beyond
-the duplicate-path case; absent or non-regular waiver file refused.
+forbidden by audit; publisher identity attempting the notary signing
+operation refused; a non-publisher updating the chain branch, or
+non-linear history, rejected; void marker carrying a sequence refused;
+genesis finalization sequence not "1" refused; sequence "01" or
+non-decimal text refused; fsck-dirty tree refused beyond the
+duplicate-path case; absent, non-regular, or oversized waiver file
+refused; refusal report carrying an assignment or stage-unestablished
+fields refused; approval-stage input digest mismatching the receipt
+candidate refused; signing without a digest-bound approval refused;
+invalid OIDC signature, issuer, audience, or expiry refused.
 
 ## 11. Decisions for sign-off
 

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v22
+# Notary admission: design v23
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 22 folds design-review rounds 1–21
-(one hundred twenty-one blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 23 folds design-review rounds 1–22
+(one hundred twenty-six blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -234,9 +234,16 @@ refusals carry `coverage_assignment`, `unused_eligible_records`,
 | `"assignment"` | prefix through the record lists — **never** an assignment or unused partition (an ambiguity has neither) |
 | `"gates"` | the full prefix, plus the gates-stage extras below |
 
-The prefix property is the single rule; the table describes what it
-yields per stage and never overrides it — including for structural
-refusals, whose prefixes reflect how far establishment actually got. Only `"gates"`-stage refusals
+Formally the refusal report is a **discriminated union on `stage`**:
+the common shape (`schema`, `lane`, `epoch_sha256`,
+`subject_commit_git_oid`, `stage`, `refusal`, `established`) for every
+stage, and the `"gates"` variant alone extending it with
+`coverage_assignment`, `unused_eligible_records`,
+`unprotected_changes`, and `gates` — closed-world parsing accepts
+exactly the variant its discriminator names. The prefix property is
+the single rule for `established`; the table describes what it yields
+per stage and never overrides it — including for structural refusals,
+whose prefixes reflect how far establishment actually got. Only `"gates"`-stage refusals
 additionally carry `coverage_assignment`, `unused_eligible_records`,
 `unprotected_changes`, and `gates` — there coverage succeeded, so all
 four are determinate.
@@ -764,18 +771,24 @@ verification reads it from here). The three typed scopes —
 `genesis`, `transition`, and `notary` — all resolve to the **`notary`**
 registry entry: the external typed signer signs all three with the
 notary key, and the admin-approver's separate signature is what
-authorizes the administrative ones. **Role-key exclusions are enumerated pairs, nothing implicit** — the
-forbidden collisions are exactly: `producer`×{`review`,
-`admin-approver`, `approver`, `notary`, `corpus-release`};
-`actor`×{`review`, `admin-approver`, `approver`, `notary`,
-`corpus-release`}; `review`×`admin-approver`;
-`approver`×{`producer`, `actor`, `notary`, `corpus-release`}; plus the
-genesis-time `legacy_apply_root`×{`notary`, `admin-approver`,
-`review`, `approver`} refusals of §9.16. Any listed collision refuses
-the registry; unlisted pairs (e.g. `notary`×`corpus-release`, two
-service-held verification roots) are permitted. (The charter's
-separate-key requirement made checkable; the cross-scope matrix alone
-cannot detect deliberate key reuse across scopes.) For every other scope,
+authorizes the administrative ones. **Role-key exclusions are enumerated pairs, nothing implicit** — and
+the governing principle is stated with them: **the `notary` SPKI is
+disjoint from every other role, without exception**, because any alias
+means a private key outside the typed signer can freshly sign the
+notary domain (domain separation prevents replay, not signing). The
+forbidden collisions are exactly: `notary`×{every other role,
+`legacy_apply_root` included}; `producer`×{`review`, `admin-approver`,
+`approver`, `corpus-release`}; `actor`×{`review`, `admin-approver`,
+`approver`, `corpus-release`}; `review`×`admin-approver`;
+`approver`×{`producer`, `actor`, `corpus-release`,
+`legacy_apply_root`}; plus the genesis-time
+`legacy_apply_root`×{`notary`, `admin-approver`, `review`, `approver`}
+refusals of §9.16. Any listed collision refuses the registry; the one
+deliberately permitted service pair is
+`corpus-release`×`legacy_apply_root` (both verification roots of
+retiring infrastructure). (The charter's separate-key requirement made
+checkable; the cross-scope matrix alone cannot detect deliberate key
+reuse across scopes.) For every other scope,
 scope-to-registry resolution is the role table itself: a detached signature under a scope verifies
 against the key bytes registered for that scope's role, never against
 the signature file's self-declared fingerprint (which is
@@ -802,7 +815,11 @@ Produced only through the typed signer under administrative authorization
 (§6.4's authority). Its body binds: `schema`, `lane`,
 `genesis_commit_git_oid`, `genesis_tree_manifest_sha256`, and two frozen
 inventories forming an **exhaustive, disjoint, exactly-once partition of
-the protected paths** at genesis (the typed signer verifies the
+the protected paths** at genesis — where **every protected entry must be
+mode 100644**: the domain-total wall of §3.3 applies at genesis and
+activation exactly as in ordinary coverage, so a pre-epoch hand chmod
+cannot hide under a path/blob-only v5 record (current v5 applied_files
+bind no modes) and then poison every successor's base (the typed signer verifies the
 partition property against the manifest before signing):
 
 - `bootstrap_policies`: an object with exactly four members —
@@ -923,7 +940,11 @@ and can always manipulate qualified custom refs of the repository it
 holds, so single-ref confinement inside the lane repository is not
 implementable — whereas the publisher App's contents-write installation
 covers only the notary repository, and in the lane repository it holds
-checks-write and contents-read alone. The lane repository's refs are
+a lane credential whose App installation holds `checks: write`,
+`statuses: write`, and `contents: read` — GitHub's source-bound
+required check needs the statuses permission at the installation even
+when runs are created via the Checks API — with runtime tokens
+downscoped per operation. The lane repository's refs are
 physically outside the publisher's write capability. The chain branch's
 ruleset in the notary repository: only the publisher App may push; no
 force pushes; no deletion; linear history. Its contents: content-addressed artifact files (reports,
@@ -1038,9 +1059,10 @@ equal what was verified":
    rather than left green. The race sol named — two green pendings, the
    second merging onto a moved base — is closed before merge, not
    discovered after.
-3. **Finalize.** After the merge, the finalizer (publisher job,
-   triggered on the protected content ref) recomputes the merged tip's
-   tree manifest. Finalization requires all of: the merged tip manifest
+3. **Finalize.** After the merge, the finalize workflow *requests*
+   finalization with its OIDC identity, and the **publisher-token
+   broker** — per §5 the sole holder of the chain credential —
+   recomputes the merged tip's tree manifest. Finalization requires all of: the merged tip manifest
    equals the artifact's subject manifest; **the artifact's
    `chain_predecessor_sha256` and kind equal the current finalized tip
    exactly** — manifest-state agreement is not enough, because two
@@ -1116,7 +1138,10 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    `contents: read` with no secrets and no environment.
 5. **Compute isolation**: fresh ephemeral runners for the verification
    and trusted jobs.
-6. Trusted recomputation implemented (§5): every claim-bearing invariant
+6. Trusted recomputation implemented (§5): typed operations for
+   genesis, transition, receipt, **and finalization** (the last a
+   broker-side validate-and-CAS, never a vended credential); every
+   claim-bearing invariant
    re-derived from content-addressed inputs before signing; typed
    operations for genesis, transition, and receipt scopes; no raw-byte
    signing for those scopes.
@@ -1138,7 +1163,9 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    credentials** (two Apps, or two repository- and
    permission-downscoped installation tokens): a chain credential with
    contents-write on the notary repository alone, and a lane credential
-   with checks-write and contents-read on the lane repository alone.
+   with an installation holding `checks: write`, `statuses: write`,
+   and `contents: read` on the lane repository alone, runtime tokens
+   downscoped per operation.
    The publisher job holds no App-minting authority — tokens are
    provisioned to it, never minted by it. The publisher runs pinned
    candidate-free code and validates **every merge-authorizing
@@ -1167,8 +1194,11 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
     `corpus-release` entry — Job 1's toolchain verification must read
     it from the registry before any lane activates.
 16. Genesis-time equality refusals: `legacy_apply_root` equal to the
-    `notary`, `admin-approver`, or `review` entries refuses; the
-    registry validator enforces the §5 pairwise exclusions.
+    `notary`, `admin-approver`, `review`, or `approver` entries
+    refuses — the last matters concretely because legacy signed-apply
+    retirement is not a pilot precondition, and an aliased apply
+    authority could otherwise forge receipt approvals; the registry
+    validator enforces the full §5 matrix.
 
 ## 10. Negative-test floor
 
@@ -1241,8 +1271,9 @@ non-trust-surface path; nonexistent
 `record_sha256`; duplicate qualifying v5 records for one path; genesis
 carrying coverage; state-identical receipt (base manifest equals subject manifest)
 refused; mode-preserving transition rule refusing a
-100644→100755→100644 chain at its first link; protected addition and
-deletion unaffected by the mode wall (positive controls); post-epoch change vouched only by v5; v5
+100644→100755→100644 chain at its first link; protected 100644 addition and
+deletion admissible (positive controls — the domain-total wall refuses
+100755 anywhere, additions included); post-epoch change vouched only by v5; v5
 record whose blob differs from its frozen pair; transition whose
 recomputed diff differs from its enumerated delta (smuggled content);
 transition evaluated under successor roots (self-authorizing rotation);
@@ -1328,8 +1359,9 @@ refused; activation consumer-spec differing from the genesis-bound
 template beyond the epoch substitution refused (same-file smuggling);
 replay over the whole tree instead of the protected projection would
 reject a valid candidate (positive control for the projection rule);
-publisher or finalizer credentials requested from the publisher-token
-broker by a wrong workflow, ref, run, or environment vended nothing;
+a finalization request from a wrong workflow, ref, run, or
+environment refused by the broker (no finalizer credential is ever
+vended — finalization is a broker-side operation);
 publisher-token broker asked to sign, or signing broker asked for a
 write token, refused (capability separation of the two brokers);
 publishing-environment administrator bypass tested off; signature
@@ -1363,7 +1395,10 @@ code validated and executed by the broker, not the workflow (positive
 control); broker refusing finalization when the pending artifact,
 predecessor, or merged tree fails validation; clean-room chain
 reconstruction succeeding from the branch alone after a key rotation
-(positive control — published preimages); cross-receipt correction
+(positive control — published preimages); missing or wrong historical
+policy, profile, or registry preimage on the branch failing
+reconstruction; genesis or activation containing a 100755 protected
+entry refused; cross-receipt correction
 with a null predecessor and the amended record named in reason
 accepted (positive control); noncanonical decimal id ("01") refused; invalid
 RFC 3339 emitted_at refused; registry notary entry differing from the

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v18
+# Notary admission: design v19
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 18 folds design-review rounds 1–17
-(one hundred eight blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 19 folds design-review rounds 1–18
+(one hundred eleven blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -211,10 +211,20 @@ manifests and chain fields, then policy and profile digests, then
 record lists), each nullable with the **prefix property**: a non-null
 field implies every field before it is non-null, and a field is
 non-null exactly when its computation completed before the failing
-check. A refusal during repository or predecessor resolution therefore
-carries a truthful all-null prefix rather than impossible mandatory
-fields. The stage table below gives the maximum established set per
-stage:
+check. Its exact ordered members: `base_commit_git_oid`,
+`chain_predecessor_sha256`, `chain_predecessor_kind`,
+`base_tree_manifest_sha256`, `subject_tree_manifest_sha256`,
+`profile_sha256`, `path_policy_sha256`, `eligible_records`,
+`ineligible_records` — types as in the pass schema. A refusal during
+repository or predecessor resolution therefore carries a truthful
+all-null prefix rather than impossible mandatory fields. Stage
+maxima: `structural` and `preflight` refusals stop wherever the prefix
+stopped; `eligibility` and `assignment` refusals may establish through
+the record lists — **an assignment-stage refusal never carries an
+assignment or unused list** (an ambiguity refusal has neither a unique
+assignment nor a determinate unused partition); only `gates`-stage
+refusals carry `coverage_assignment`, `unused_eligible_records`,
+`unprotected_changes`, and `gates` (coverage succeeded there).
 
 | `stage` | additional required fields |
 |---|---|
@@ -234,8 +244,11 @@ closed code enum is: `"uncovered-path"`, `"ambiguous-assignment"`,
 `"gate-unacceptable"`, `"gate-missing"`, `"gate-extra"` — with
 templates for the added codes: `state-identical` → "base and subject
 states are identical"; `trust-surface-change` → "ordinary candidate
-changes a trust surface"; `policy-invalid` → "required policy or
-profile absent or invalid at the base"; `predecessor-stale` → "base is
+changes a trust surface"; `policy-invalid` → "required policy, profile, or key registry absent
+or invalid at the base" (registry invalidity refuses under this code);
+a non-representable offending path reports `path: null` with the
+template unchanged — the I-JSON path contract never carries non-UTF-8
+bytes; `predecessor-stale` → "base is
 not the finalized chain tip"; `gate-extra` → "gate outside the
 profile". `ineligible_records`
 entries carry `reasons`: the **sorted array of every applicable reason
@@ -266,11 +279,17 @@ classification the profile did not grant; `diff_coverage`: exactly `"pass"` — 
 variant carries no refusal shapes, and `waived`/`not-run` exist in
 neither variant; `unprotected_changes`
 (sorted paths); `ineligible_records`: sorted array of `{record_sha256, reasons}` —
-`reasons` is the sorted array of every applicable code from the closed
-enum (`"unprotected-path-transition"`, `"duplicate-transition-paths"`,
-`"wrong-lane"`, `"wrong-epoch"`, `"invalid-signature"`,
-`"malformed-record"`, `"address-mismatch"`), the same shape in pass and
-refusal variants; `dependency_pins_sha256`: the digest of a
+`reasons` is the sorted array of every applicable code **whose
+prerequisites are satisfied**, from the closed enum with this
+prerequisite order: `address-mismatch` and `malformed-record` are
+always computable; `invalid-signature`, `wrong-lane`, `wrong-epoch`,
+`duplicate-transition-paths`, and `unprotected-path-transition` apply
+only when the body parsed (never beside `malformed-record`). Entries
+are keyed by the **store-filename digest** (the name the file claims),
+not the body digest — so a valid body added at its correct path *and*
+at an alias yields one eligible record plus one ineligible
+`address-mismatch` entry, with no identity collision. Same shape in
+pass and refusal variants; `dependency_pins_sha256`: the digest of a
 canonical dependency inventory, a body of schema
 `axiom/notary-dependency-inventory/v1` with the closed shape
 `{schema, lane, actions: [[ref_spec, git_oid], …] sorted by ref_spec
@@ -291,8 +310,8 @@ deterministic under simultaneous faults, with all three members fixed:
 the evaluation order is total — structural (§2.1 manifest rules in
 listed order), preflight (§4 in listed order), state-identical,
 eligibility (§3.2 in listed order), assignment (§3.3 rules 1–4 in
-order), gates (missing before unacceptable, then bytewise-least
-`gate_id`) — checks run in that total order **globally across all
+order), gates (missing, then extra, then unacceptable; within each,
+bytewise-least `gate_id`) — checks run in that total order **globally across all
 paths before the next check** (every path's rule-1 existence check
 precedes any path's rule-2 chain validation, so `uncovered-path` on
 any path wins over `inconsistent-chain` on another); the reported
@@ -709,11 +728,14 @@ verification spec; a mismatch refuses). The three typed scopes —
 `genesis`, `transition`, and `notary` — all resolve to the **`notary`**
 registry entry: the external typed signer signs all three with the
 notary key, and the admin-approver's separate signature is what
-authorizes the administrative ones. **Generation-side and
-admission-side roles are disjoint**: an SPKI registered under
-`producer` or `actor` must not appear under `review`, `admin-approver`,
-`approver`, or `notary` (the charter's separate-key requirement made
-checkable; a collision refuses the registry). For every other scope,
+authorizes the administrative ones. **Role-key exclusions are pairwise and explicit**: an SPKI under
+`producer` or `actor` must not appear under any admission-side role
+(`review`, `admin-approver`, `approver`, `notary`); `review` and
+`admin-approver` must be disjoint (a correction reviewer must not hold
+rotation authority); and `approver` must be disjoint from every
+automation role. Any listed collision refuses the registry (the
+charter's separate-key requirement made checkable; the cross-scope
+matrix alone cannot detect deliberate key reuse across scopes). For every other scope,
 scope-to-registry resolution is the role table itself: a detached signature under a scope verifies
 against the key bytes registered for that scope's role, never against
 the signature file's self-declared fingerprint (which is
@@ -758,6 +780,15 @@ partition property against the manifest before signing):
   repository (all part of the closed genesis schema, so the epoch
   digest is uniquely constructible and the bindings are inside the
   schema, not beside it);
+- `legacy_apply_root`: `{raw_key_id, public_key_spki_der_base64}` —
+  the exact legacy apply public key that authenticates v5 records at
+  genesis, bound in the closed schema like every other root (the
+  conversion is normative: the raw Ed25519 key bytes wrap into a DER
+  SPKI, and `raw_key_id` is the legacy broker's key identifier for
+  cross-checking). The organization variable that supplies this root
+  today is eliminated by §9.10; a genesis validating v5 records against
+  any key other than this bound root refuses, so root substitution at
+  genesis cannot reclassify pre-epoch hand edits as attested;
 - `v5_attested`: sorted `[path, entry_sha256, record_sha256]` — paths
   whose blobs are vouched at genesis by a legacy record that passes the
   **current v5 authentication contract**: schema exactly
@@ -809,7 +840,10 @@ policy, repository-structure rules); the recomputed base→subject diff
 must equal `delta` exactly, every delta path must match the
 transition-path policy, and no delta path may be protected content — a
 protected-content or unclassified change smuggled into a transition
-refuses;
+refuses; and a path policy (or transition-path policy) whose rules
+would protect any `.axiom/lineage/` or `.axiom/notary/` path is itself
+invalid (`policy-invalid`) — the lineage store and trust files live
+outside the coverage domain by construction, not assertion;
 signatures and authorization are evaluated **under the predecessor
 state's trust roots** (the old keys and policy authorize the handover, so
 a successor-controlled key cannot self-authorize its own installation);
@@ -1271,7 +1305,15 @@ wrong-address new record enumerated address-mismatch; malformed new
 record enumerated malformed-record; absent Job-1 artifact refused;
 reusable approve, publish, or finalizer job refused; unsorted or
 duplicate key-registry role array refused; consumer-spec decoy at a
-non-named path binding nothing (positive control); intermediate replay projection with a path both
+non-named path binding nothing (positive control); v5 record validated
+against a key other than the genesis-bound legacy root refused (root
+substitution); alias occurrence ineligible with address-mismatch while
+the correct-path occurrence stays eligible (positive control);
+malformed body carrying only computable reasons (positive control);
+reusable verify job refused; duplicate prompt_sha256s refused; empty
+or wrong pinned artifact_name refused; review/admin-approver SPKI
+collision refused; approver/automation SPKI collision refused; policy
+protecting .axiom/lineage or .axiom/notary refused as policy-invalid; intermediate replay projection with a path both
 terminal and directory-prefix refused as no-valid-execution;
 noncanonical JCS bytes or wrong semantic-array order refused; genesis
 inventory containing a path outside the protected domain refused;

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v17
+# Notary admission: design v18
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 17 folds design-review rounds 1–16
-(one hundred three blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 18 folds design-review rounds 1–17
+(one hundred eight blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -204,9 +204,17 @@ refusal has no unique assignment; a structural refusal has no manifest),
 so the report is **two closed schemas**, not one with impossible fields.
 
 `axiom/notary-report-refusal/v1`: `{schema, lane, epoch_sha256,
-subject_commit_git_oid, stage, refusal}` plus stage-established fields
-per this normative table (present exactly when the stage is reached,
-null-less and closed at each stage):
+subject_commit_git_oid, stage, refusal, established}` — `established`
+is a closed object of the report's contextual fields in fixed
+dependency order (repository and predecessor resolution, then
+manifests and chain fields, then policy and profile digests, then
+record lists), each nullable with the **prefix property**: a non-null
+field implies every field before it is non-null, and a field is
+non-null exactly when its computation completed before the failing
+check. A refusal during repository or predecessor resolution therefore
+carries a truthful all-null prefix rather than impossible mandatory
+fields. The stage table below gives the maximum established set per
+stage:
 
 | `stage` | additional required fields |
 |---|---|
@@ -221,8 +229,15 @@ succeeded; a gate outcome did not. The refusal member is named
 `refusal` in both variants (never `diff_coverage`), and its single
 closed code enum is: `"uncovered-path"`, `"ambiguous-assignment"`,
 `"inconsistent-chain"`, `"record-cycle"`, `"no-valid-execution"`,
-`"inadmissible-entry"`, `"structural"`, `"gate-unacceptable"`,
-`"gate-missing"`. `ineligible_records`
+`"inadmissible-entry"`, `"structural"`, `"state-identical"`,
+`"trust-surface-change"`, `"policy-invalid"`, `"predecessor-stale"`,
+`"gate-unacceptable"`, `"gate-missing"`, `"gate-extra"` — with
+templates for the added codes: `state-identical` → "base and subject
+states are identical"; `trust-surface-change` → "ordinary candidate
+changes a trust surface"; `policy-invalid` → "required policy or
+profile absent or invalid at the base"; `predecessor-stale` → "base is
+not the finalized chain tip"; `gate-extra` → "gate outside the
+profile". `ineligible_records`
 entries carry `reasons`: the **sorted array of every applicable reason
 code**, so a multi-fault record has one deterministic representation.
 Refusal reports are diagnostics; no downstream artifact ever binds
@@ -253,8 +268,9 @@ neither variant; `unprotected_changes`
 (sorted paths); `ineligible_records`: sorted array of `{record_sha256, reasons}` —
 `reasons` is the sorted array of every applicable code from the closed
 enum (`"unprotected-path-transition"`, `"duplicate-transition-paths"`,
-`"wrong-lane"`, `"wrong-epoch"`, `"invalid-signature"`), the same shape
-in pass and refusal variants; `dependency_pins_sha256`: the digest of a
+`"wrong-lane"`, `"wrong-epoch"`, `"invalid-signature"`,
+`"malformed-record"`, `"address-mismatch"`), the same shape in pass and
+refusal variants; `dependency_pins_sha256`: the digest of a
 canonical dependency inventory, a body of schema
 `axiom/notary-dependency-inventory/v1` with the closed shape
 `{schema, lane, actions: [[ref_spec, git_oid], …] sorted by ref_spec
@@ -276,9 +292,12 @@ the evaluation order is total — structural (§2.1 manifest rules in
 listed order), preflight (§4 in listed order), state-identical,
 eligibility (§3.2 in listed order), assignment (§3.3 rules 1–4 in
 order), gates (missing before unacceptable, then bytewise-least
-`gate_id`) — the reported refusal is the first failing check; `path` is
-the bytewise-least affected path for path-scoped codes and `null`
-otherwise; `detail` is the fixed template string defined per code — normatively:
+`gate_id`) — checks run in that total order **globally across all
+paths before the next check** (every path's rule-1 existence check
+precedes any path's rule-2 chain validation, so `uncovered-path` on
+any path wins over `inconsistent-chain` on another); the reported
+refusal is the first failing check, `path` the bytewise-least affected
+path within it, `null` otherwise; `detail` is the fixed template string defined per code — normatively:
 `uncovered-path` → "no eligible transition covers this path";
 `ambiguous-assignment` → "more than one valid assignment";
 `inconsistent-chain` → "eligible transitions exist but no valid chain";
@@ -332,7 +351,11 @@ field set with `schema` replaced by the candidate's own identifier — every rec
 outcomes acceptable) — plus `report_sha256` (the reconciled proposal)
 and `job1`: `{workflow_ref, workflow_sha_git_oid, ref, run_id,
 run_attempt, check_run_id, conclusion, artifact_name, artifact_id,
-artifact_sha256}`. `workflow_ref` is the OIDC `workflow_ref` claim
+artifact_sha256}` — `conclusion` must be the literal `"success"`;
+`artifact_name` and `authorization.environment` are non-empty JSON
+strings validated against the pinned workflow's declared artifact name
+and the `notary-signing` environment name. `workflow_ref` is the OIDC
+`workflow_ref` claim
 string verbatim (its `@`-suffix must equal `ref` or the candidate
 refuses), and `job1.check_run_id` is **`verify`'s** check-run id from
 the jobs-for-run lookup — the `approve` job's own OIDC `check_run_id`
@@ -379,12 +402,17 @@ detached signatures beside it. The lineage directory is outside the
 protected-content coverage domain but inside the preflight's structural
 checks: schema-valid, authenticated, correctly content-addressed,
 append-only; deleting or mutating an existing record is a refusal.
-Structural checks govern **records present at the base** — the store's
-integrity as inherited; a **newly introduced** record that is
-malformed, misaddressed, or badly signed is not a structural refusal
-but an eligibility-stage ineligible record, enumerated with its
-reasons, so one bad new record cannot veto an otherwise covered
-candidate.
+Base-present records are **inert history**: the structural rule
+enforces append-only discipline alone (no deletion, no mutation) and
+never re-validates their contents — an invalid record that once rode
+in as ineligible sits harmless forever, since eligibility is the only
+door and it never reopens for base-present files. (Re-validating the
+inherited store would let one admitted bad record permanently poison
+every successor.) A **newly introduced** record that is malformed,
+misaddressed, or badly signed is an eligibility-stage ineligible
+record, enumerated with its reasons — never a structural refusal — so
+one bad new record cannot veto an otherwise covered candidate, now or
+later.
 Reports, receipts, genesis, and transition records publish per §7 and are
 never part of the subject tree.
 
@@ -723,9 +751,13 @@ partition property against the manifest before signing):
   bootstrap breaks the predecessor-roots recursion by binding its own
   root set, exactly as it binds its policies);
 - `activation_spec_template_sha256`: the §7 epoch-placeholder template
-  digest (both fields are part of the closed genesis schema, so the
-  epoch digest is uniquely constructible and the same-file-smuggling
-  protection is inside the schema, not beside it);
+  digest; `consumer_spec_path`: the lane path of the operative consumer
+  verification spec file — the fifth bootstrap path is named, not
+  guessed, so a digest-matching decoy elsewhere binds nothing; and
+  `notary_repository`: the `owner/repo` string of the dedicated chain
+  repository (all part of the closed genesis schema, so the epoch
+  digest is uniquely constructible and the bindings are inside the
+  schema, not beside it);
 - `v5_attested`: sorted `[path, entry_sha256, record_sha256]` — paths
   whose blobs are vouched at genesis by a legacy record that passes the
   **current v5 authentication contract**: schema exactly
@@ -1038,6 +1070,9 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
     dual-era operation.
 13. Retirement of lane signed-apply legs (#1195) is a cutover exit
     criterion, not a pilot precondition.
+14. Golden-regeneration QA retained and audited — the charter keeps it
+    as the distributional defense, §1 relies on it as a mitigation, and
+    its removal fails this precondition.
 
 ## 10. Negative-test floor
 
@@ -1160,9 +1195,10 @@ lane lock, or against a tip that moved, refused (stale-genesis
 laundering closed); lane movement between genesis signing and
 publication impossible under the audited lock (positive control);
 ordinary candidate between genesis and activation refused; activation
-transition with any delta beyond the epoch pin and the three
-genesis-bound policy files refused; activation omitting the epoch pin
-or any policy file refused; activation installing a policy file whose
+transition changing any path outside the five named bootstrap paths
+refused; activation leaving any bootstrap path's installed bytes
+unequal to its genesis-bound digest refused (installed values, not
+diff membership); activation installing a policy file whose
 digest differs from bootstrap_policies refused; genesis with absent
 bootstrap_policies refused; wrong
 `check_run_id` or a trusted job in a reusable or separate-run topology
@@ -1226,7 +1262,16 @@ RFC 3339 emitted_at refused; registry notary entry differing from the
 consumer pin refused; waiver bytes disagreeing with the base toolchain
 pin refused; equal-manifest transition carrying a forged nonempty
 delta refused; bad newly-introduced record enumerated ineligible while
-the candidate passes (positive control — structural scope); intermediate replay projection with a path both
+the candidate passes (positive control — structural scope);
+base-present invalid record inert — successor with an honest diff
+passes (positive control — no lane poison); refusal during repository
+or predecessor resolution carrying a truthful all-null established
+prefix (positive control); established-prefix violation refused;
+wrong-address new record enumerated address-mismatch; malformed new
+record enumerated malformed-record; absent Job-1 artifact refused;
+reusable approve, publish, or finalizer job refused; unsorted or
+duplicate key-registry role array refused; consumer-spec decoy at a
+non-named path binding nothing (positive control); intermediate replay projection with a path both
 terminal and directory-prefix refused as no-valid-execution;
 noncanonical JCS bytes or wrong semantic-array order refused; genesis
 inventory containing a path outside the protected domain refused;

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v7
+# Notary admission: design v8
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 7 folds design-review rounds 1–6
-(fifty-one blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 8 folds design-review rounds 1–7
+(fifty-eight blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -17,10 +17,10 @@ The notary signs one narrow claim:
 > `T1`), reached from predecessor state `T0` recorded by chain predecessor
 > `C` (a receipt, a transition record, or genesis): under the verifier
 > profile and protected-path policy committed at the base, every
-> protected-content tree-entry change from `T0` to `T1` is covered by the
-> unique valid assignment over the eligible lineage set; every gate the
-> profile requires is declared with an outcome the profile accepts;
-> unprotected tree-entry changes are enumerated in `R`; and the protected
+> protected-content terminal-entry change from `T0` to `T1` is covered
+> by the unique valid assignment over the eligible lineage set; every
+> gate the profile requires is declared with an outcome the profile
+> accepts; unprotected terminal-entry changes are enumerated in `R`; and the protected
 > signing policy authorized this acceptance.
 
 Two classes of statement inside that claim have different evidentiary
@@ -109,10 +109,14 @@ refusal; terminal modes outside {"100644", "100755", "120000"} are a
 refusal, and "120000" only outside the protected domain. Within these
 rules the manifest function is total and exact: two trees with equal
 manifests are terminal-entry-identical. Structural malformation refuses:
-input trees must be fsck-clean, and a duplicate flattened terminal path
-— which Git itself treats as an fsck error but can technically encode —
+input trees must be fsck-clean; a duplicate flattened terminal path —
+which Git itself treats as an fsck error but can technically encode —
 is a manifest refusal, so per-path endpoints are always singular and
-manifest set-difference is exact.
+manifest set-difference is exact; and **any directory entry resolving to
+the empty tree is a refusal** — an empty subtree is a real tree-entry
+change the terminal manifest cannot see, and refusing it keeps the
+claim's terminal-entry wording and the manifest's blindness aligned
+rather than quietly divergent.
 
 **Signature envelope.** Signing uses the existing broker frame verbatim:
 
@@ -204,15 +208,18 @@ closed reason enum (`"unprotected-path-transition"`,
 `"invalid-signature"`); `dependency_pins_sha256`: the digest of a
 canonical dependency inventory, a body of schema
 `axiom/notary-dependency-inventory/v1` with the closed shape
-`{schema, lane, actions: [[ref_spec, git_oid], …] sorted by ref_spec,
-containers: [[image, digest_sha256], …] sorted by image,
-python_lock_sha256, verifier: {repo, git_oid}}`, where
+`{schema, lane, actions: [[ref_spec, git_oid], …] sorted by ref_spec
+with strictly unique ref_spec keys,
+containers: [[image, digest_sha256], …] sorted by image with strictly
+unique image keys, python_lock_sha256, verifier: {repo, git_oid}}`, where
 `python_lock_sha256` is SHA-256 over the raw bytes of `uv.lock` at
 `verifier.git_oid` in `verifier.repo`; `verifier`: `{repo, git_oid}`,
 the repository-qualified identity of the verifier code that ran.
-`waiver_set_sha256` adopts the existing toolchain contract: SHA-256 over
-the raw bytes of the repository-root `known-validation-gaps.yaml` at the
-base (absent file hashes the empty byte string). The `diff_coverage` refusal object is itself closed:
+`waiver_set_sha256` adopts the existing toolchain contract exactly:
+SHA-256 over the raw bytes of the repository-root
+`known-validation-gaps.yaml` at the base, which current mechanics
+require to be a present, bounded regular file — an absent or non-regular
+waiver file is a refusal, not an empty hash. The `diff_coverage` refusal object is itself closed:
 `{code, path | null, detail}` with a closed code enum
 (`"uncovered-path"`, `"ambiguous-assignment"`, `"inconsistent-chain"`,
 `"record-cycle"`, `"inadmissible-entry"`, `"structural"`).
@@ -220,8 +227,9 @@ base (absent file hashes the empty byte string). The `diff_coverage` refusal obj
 The profile is likewise a closed committed schema at a normative path:
 `.axiom/notary/profile.json`, schema `axiom/notary-profile/v1`, fields
 `{schema, lane, required_gates, oracle_policy}` with `required_gates`
-sorted by `gate_id`, each `{gate_id, acceptable_outcomes, tier}` where
-`acceptable_outcomes` is a sorted string array, and `oracle_policy`
+sorted by `gate_id` and **strictly unique per gate_id**, each
+`{gate_id, acceptable_outcomes, tier}` where `acceptable_outcomes` is a
+sorted string array, and `oracle_policy`
 exactly one of `"fail-closed"` or `"reduced-tier"` — so `profile_sha256`
 has exactly one preimage. Every committed policy body (`path-policy`,
 `transition-path-policy`, `profile`) carries `schema` and `lane` like
@@ -245,8 +253,12 @@ closed schema, enumerated: `schema`, `lane`, `epoch_sha256`;
 `dependency_pins_sha256`, `verifier` — each independently
 recomputed by the trusted side, never copied on trust; `gates` as
 declared (deduplicated, profile-complete, outcomes acceptable); `job1`:
-`{workflow_path, workflow_sha_git_oid, ref, run_id, run_attempt,
-conclusion, artifact_name, artifact_id, artifact_sha256}` — **run-scoped
+`{workflow_ref, workflow_sha_git_oid, ref, run_id, run_attempt,
+check_run_id, conclusion, artifact_name, artifact_id, artifact_sha256}`
+— `workflow_ref` is the OIDC `workflow_ref` claim string verbatim (one
+authoritative source and grammar; its `@`-suffix must equal `ref` or the
+receipt refuses), and `check_run_id` is the trusted job's own OIDC
+`check_run_id` claim — **run-scoped
 provenance, stated as such**: GitHub artifacts carry no producing-job or
 attempt identity, so the receipt claims only that the named artifact
 with this digest existed in this run, which the pilot requires to
@@ -392,7 +404,11 @@ what makes workflow identity derivable: the trusted job's own OIDC token
 carries the `workflow_sha` that governed the entire run, covering Job 1
 without needing any per-job claim GitHub does not issue. The trusted job
 reads Job 1's conclusion through the jobs-for-run endpoint (by job name
-and attempt) rather than any self-asserted value.
+and attempt) rather than any self-asserted value, and its own identity
+is bound the only way OIDC permits: the token's `check_run_id` claim is
+reconciled through jobs-for-run to the expected trusted-job name and
+attempt — GitHub's claims carry no job name — and reusable execution is
+prohibited for the trusted job exactly as for Job 1.
 
 **Job 1 — verify (secretless, candidate-executing).** Runs on a fresh
 ephemeral runner (GitHub-hosted or dedicated ephemeral pool) with no
@@ -582,7 +598,21 @@ Genesis bootstraps the branch: the branch's first two commits must be
 exactly the genesis body and its finalization marker, published by the
 same CAS branch creation — a competing genesis loses the atomic
 first-push and any later genesis body or marker is invalid by the
-second-genesis rule.
+second-genesis rule. **Bootstrap is explicitly acyclic and
+tip-frozen.** At genesis signing, the typed signer verifies by CAS that
+`genesis_commit_git_oid` is the lane's protected-ref tip at that
+moment; a tip that moved voids the genesis attempt and it reruns. The
+lane's epoch pin cannot live inside the genesis tree (that would be
+`epoch → tree → body → epoch`); it lands immediately after, in a
+**bootstrap activation transition** — the chain's second artifact,
+predecessor genesis, whose delta is exactly the consumer-spec epoch pin
+and the three policy files. Enforcement begins at activation
+finalization; between genesis and activation the lane accepts no
+ordinary candidates. The stale-genesis laundering path (genesis frozen
+at an old tip while the branch sits at a newer one, letting a later
+record cover the gap) is closed by the CAS: genesis is void unless it
+froze the actual tip, and the activation transition chains from it
+before anything else may.
 
 **Verification does not trust the pointer.** The chain's truth is
 reconstructible by rule from the branch alone: the valid chain is the
@@ -625,9 +655,12 @@ equal what was verified":
    distinct signed statements and only one may enter the chain; and the
    marker's `lane`, `epoch_sha256`, `target_kind`, and
    `merged_tip_manifest_sha256` validate against the artifact. On
-   success the finalization marker commits with the next `sequence` (a
-   strictly increasing decimal-string counter over all markers on the
-   chain; a gap or repeat invalidates the branch to reconstruction) and
+   success the finalization marker commits with the next `sequence` — a
+   finalization-only counter: canonical decimal string, no leading
+   zeros, genesis's finalization is `"1"`, each subsequent finalization
+   exactly one greater; a gap or repeat invalidates the branch to
+   reconstruction; void markers carry no sequence and order by branch
+   history and
    `HEAD.json` advances — compare-and-swap via the atomic branch
    update. **All other pending artifacts naming the superseded tip as
    predecessor are voided in the same publisher pass** (same-state
@@ -666,9 +699,11 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    any environment involved in notary authorization (#1194 re-scoped).
 4. **External signer with identity binding**: the notary key held only
    by the external typed signer; OIDC-claim validation of the requesting
-   repository, workflow path and `workflow_sha`, job, run, attempt, ref,
-   and `notary-signing` environment, against an exact allowlist;
-   reusable workflows prohibited for Job 1; `id-token: write` and
+   repository, `workflow_ref` and `workflow_sha`, `check_run_id`
+   (reconciled via jobs-for-run to the expected trusted-job name and
+   attempt), run, attempt, ref, and `notary-signing` environment,
+   against an exact allowlist; reusable workflows prohibited for Job 1
+   and the trusted job; `id-token: write` and
    `actions: read` allocated explicitly and nothing further; no raw
    notary key material on any runner; Job 1's token audited to
    `contents: read` with no secrets and no environment.
@@ -688,11 +723,17 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
 7a. Effective-permission constraints audited per §5: signer deployment
    credentials, exact caller allowlist, Job-1 and trusted-job token
    audits, and publisher signing denial.
-7b. Publisher write confinement is physical: the publisher App's
-   contents-write installation covers only the dedicated notary
-   repository (chain branch ruleset: App-only, no force push, no
-   deletion, linear history); in the lane repository it holds
-   checks-write and contents-read only. The publisher runs pinned
+7b. Publisher write confinement is physical and two-keyed: because App
+   installation permissions span the repositories an installation
+   covers, one App cannot hold contents-write on the notary repository
+   without holding it wherever else it is installed with that
+   permission — so the publisher uses **two separately constrained
+   credentials** (two Apps, or two repository- and
+   permission-downscoped installation tokens): a chain credential with
+   contents-write on the notary repository alone, and a lane credential
+   with checks-write and contents-read on the lane repository alone.
+   The publisher job holds no App-minting authority — tokens are
+   provisioned to it, never minted by it. The publisher runs pinned
    candidate-free code and validates **every merge-authorizing
    artifact** — receipt or transition alike — signature, typed fields,
    and current finalized predecessor under predecessor-state roots,
@@ -821,7 +862,18 @@ kind, or tip manifest; marker sequence gap or repeat invalidating the
 branch; transition delta path unmatched by the transition-path policy;
 transition validated by the publisher under predecessor-state roots
 (positive control) and rejected when its signature or predecessor
-fails.
+fails; empty subtree entry refused; genesis signing against a moved
+lane tip voided by CAS (stale-genesis laundering closed); ordinary
+candidate between genesis and activation refused; activation transition
+with any delta beyond the epoch pin and policy files refused; wrong
+`check_run_id` or a trusted job in a reusable or separate-run topology
+refused; duplicate profile gate ids and duplicate inventory
+ref_spec/image keys refused; `workflow_ref`/`ref` suffix mismatch
+refused; publisher lane-content write attempt failing (two-credential
+split, positive control); publisher job holding App-minting authority
+forbidden by audit; void marker carrying a sequence refused; genesis
+finalization sequence not "1" refused; fsck-dirty tree refused beyond
+the duplicate-path case; absent or non-regular waiver file refused.
 
 ## 11. Decisions for sign-off
 

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v23
+# Notary admission: design v24
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 23 folds design-review rounds 1–22
-(one hundred twenty-six blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 24 folds design-review rounds 1–23
+(one hundred twenty-seven blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -395,9 +395,11 @@ outcomes acceptable) — plus `report_sha256` (the reconciled proposal)
 and `job1`: `{workflow_ref, workflow_sha_git_oid, ref, run_id,
 run_attempt, check_run_id, conclusion, artifact_name, artifact_id,
 artifact_sha256}` — `conclusion` must be the literal `"success"`;
-`artifact_name` and `authorization.environment` are non-empty JSON
-strings validated against the pinned workflow's declared artifact name
-and the `notary-signing` environment name. `workflow_ref` is the OIDC
+`artifact_name` is a non-empty JSON string validated against the
+pinned workflow's declared artifact name. (`authorization.environment`
+— a wrapper field, not a candidate field — is likewise a non-empty
+string validated against the `notary-signing` environment name where
+§2.5 defines the wrapper.) `workflow_ref` is the OIDC
 `workflow_ref` claim
 string verbatim (its `@`-suffix must equal `ref` or the candidate
 refuses), and `job1.check_run_id` is **`verify`'s** check-run id from
@@ -940,10 +942,11 @@ and can always manipulate qualified custom refs of the repository it
 holds, so single-ref confinement inside the lane repository is not
 implementable — whereas the publisher App's contents-write installation
 covers only the notary repository, and in the lane repository it holds
-a lane credential whose App installation holds `checks: write`,
-`statuses: write`, and `contents: read` — GitHub's source-bound
-required check needs the statuses permission at the installation even
-when runs are created via the Checks API — with runtime tokens
+a lane credential whose App installation holds `checks: write` and
+`contents: read` — sufficient for source-bound required checks, which
+branch protection binds by the creating App's id; no
+Commit-Status-path permission is taken, because an unused
+merge-authorizing permission is attack surface — with runtime tokens
 downscoped per operation. The lane repository's refs are
 physically outside the publisher's write capability. The chain branch's
 ruleset in the notary repository: only the publisher App may push; no
@@ -1163,8 +1166,9 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    credentials** (two Apps, or two repository- and
    permission-downscoped installation tokens): a chain credential with
    contents-write on the notary repository alone, and a lane credential
-   with an installation holding `checks: write`, `statuses: write`,
-   and `contents: read` on the lane repository alone, runtime tokens
+   with an installation holding `checks: write` and `contents: read`
+   on the lane repository alone (no Commit-Status permission — branch
+   protection binds the required check by App id), runtime tokens
    downscoped per operation.
    The publisher job holds no App-minting authority — tokens are
    provisioned to it, never minted by it. The publisher runs pinned
@@ -1388,9 +1392,9 @@ registry key bytes failing base64, DER, Ed25519, or fingerprint
 validation refused; protected 100755 entry refused at base, subject,
 and inside a transition (domain-total wall); delete-then-recreate-
 executable across two finalized receipts refused by the same rule
-(positive control); approver/corpus-release collision refused per the
-enumerated pairs while notary/corpus-release is permitted (positive
-control); finalization requested by rotated not-yet-finalized workflow
+(positive control); approver/corpus-release and notary/corpus-release collisions refused
+per the enumerated pairs, while corpus-release/legacy_apply_root — the
+one permitted service pair — is accepted (positive control); finalization requested by rotated not-yet-finalized workflow
 code validated and executed by the broker, not the workflow (positive
 control); broker refusing finalization when the pending artifact,
 predecessor, or merged tree fails validation; clean-room chain
@@ -1412,7 +1416,8 @@ transition-path policy covering .axiom/notary accepted and covering
 .axiom/lineage refused (the opposite obligations); corpus-release root
 absent from the registry refused; invalid corpus-release signature
 refused; raw_key_id/SPKI pair inconsistent refused; legacy root equal
-to notary, admin-approver, or review refused; finalized receipt whose
+to notary, admin-approver, review, or approver refused (each a
+distinct test); finalized receipt whose
 referenced report is unpublished invalid to reconstruction;
 absent-profile preflight refusal carrying a truthful null digest
 (positive control);

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v30
+# Notary admission: design v31
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 30 folds design-review rounds 1–29
-(one hundred thirty-six blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 31 folds design-review rounds 1–30
+(one hundred thirty-eight blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -98,7 +98,7 @@ field, missing field, wrong type, or duplicate key is a parse refusal.
 | `workflow_sha_git_oid` | the commit the workflow file was loaded from: **context-derived at candidate time** (`github.workflow_sha` in the `recompute` job), then **authenticated by equality** to `approve`'s OIDC `workflow_sha` claim at signing — one run, one workflow, so the equality is exact; reusable workflows are prohibited; never the run's `head_sha` |
 | Entry modes | six-character octal strings: `"100644"` and `"100755"` (the pilot admits no symlinks anywhere — charter requirement 4 rejects symlink deltas, and refusing the mode tree-wide is the total form) |
 | Paths | UTF-8 strings; sorting is bytewise over the UTF-8 encoding |
-| Semantic arrays | **one comparator everywhere**: elements order bytewise over the UTF-8 encoding of the element's sort key, which each array names — `gates` by `gate_id`, `required_gates` by `gate_id`, `acceptable_outcomes` and `reasons` by their string value, `eligible_records`/`unused_eligible_records` by digest, `ineligible_records` by `store_name`, `coverage_assignment` by `path`, dependency `actions` by `ref_spec`, `containers` by `image`, inventories by `path`; set-valued arrays are strictly unique on their key (JCS canonicalizes objects, not arrays — this row is what makes array bytes deterministic) |
+| Semantic arrays | **one comparator everywhere**: elements order bytewise over the UTF-8 encoding of the element's sort key, which each array names — `gates` by `gate_id`, `required_gates` by `gate_id`, `acceptable_outcomes` and `reasons` by their string value, `eligible_records`/`unused_eligible_records` by digest, `ineligible_records` by `store_name`, `coverage_assignment` by `path`, transition `delta` by `path`, dependency `actions` by `ref_spec`, `containers` by `image`, inventories by `path`; set-valued arrays are strictly unique on their key (JCS canonicalizes objects, not arrays — this row is what makes array bytes deterministic) |
 
 **Tree manifests.** A tree manifest is the recursively flattened list of
 **terminal entries** (blobs and symlinks; directories appear only through
@@ -957,10 +957,12 @@ the preflight refuses them — so the transition record exists to advance
 the chain across them. Closed schema: `schema`, `lane`, `epoch_sha256`,
 `chain_predecessor_sha256`, `chain_predecessor_kind`,
 `base_tree_manifest_sha256`, `subject_tree_manifest_sha256`,
-`subject_commit_git_oid`, `delta`: sorted array of
+`subject_commit_git_oid`, `delta`: array of
 `{path, before_entry_sha256 | null, before_mode | null,
 after_entry_sha256 | null, after_mode | null}` restricted to
-trust-surface paths, and `reason`.
+trust-surface paths — sorted bytewise by `path` under §2.1's one
+comparator, paths strictly unique, so any two honest constructions of
+one delta produce identical body bytes and one digest — and `reason`.
 
 Rules: a transition whose delta is empty, or whose base manifest
 equals its subject manifest, refuses — the state-identical ban of §1
@@ -1036,21 +1038,35 @@ signatures `<digest>.json.<role>.sig` with the **§2.1 role name as
 the token** (role names are `/`-free; scope strings are not) — and
 every signed artifact publishes as a **closed bundle in one commit**:
 genesis = body + its `genesis`-role sidecar (the typed signer's) +
-its `admin-approver` sidecar + **the four preimage bodies its
+its `admin-approver` sidecar + **the four preimages its
 `bootstrap_policies` digests name** (path policy, transition-path
 policy, profile, key registry — the §7 preimage rule below);
 transition = body + `transition` sidecar + `admin-approver` sidecar +
-**the new body of every trust file its delta changes**; receipt =
+**the raw preimage of every trust file its delta changes** (non-null
+after sides; deletions publish nothing); receipt =
 report body + candidate body + the `approver` sidecar over the
 candidate + receipt body + the `notary` sidecar over the receipt.
+**Preimages have their own opaque grammar**: `<digest>.raw`, the raw
+lane-file bytes stored verbatim, `<digest>` the lowercase 64-hex
+SHA-256 of exactly those bytes — trust files are YAML, TOML, and
+JSON, so preimages are exempt from the §2.1 body contract and are
+**never parsed**, whatever their bytes resemble (a `.raw` file whose
+content looks like a schema-carrying JSON body is still opaque bytes;
+the suffix alone selects the treatment, so no type precedence
+exists). This holds even for the JSON policy files: every preimage
+lands under `.raw`, and the `.json` namespace holds chain-artifact
+bodies alone.
 The unsigned files are closed by **digest-reachability, not by
-pattern**: every unsigned body on the branch must be digest-named by
-a signed body — the report by its candidate's `report_sha256`, the
-candidate by its receipt's `candidate_sha256`, preimages by
-`bootstrap_policies` or a transition delta's after-digests — while
-markers (structurally authenticated, below) and `HEAD.json` are the
+pattern**: every unsigned `.json` body on the branch must be
+digest-named by a signed body — the report by its candidate's
+`report_sha256`, the candidate by its receipt's `candidate_sha256` —
+and every `.raw` preimage by a `bootstrap_policies` digest or a
+transition delta's after-digest, while
+markers (structurally authenticated, below) and the literal
+`HEAD.json` are the
 two named exceptions; an unsigned file reachable from no signed
-artifact, a sidecar naming a marker, an unknown role token, or any
+artifact, a sidecar naming a marker or a `.raw` file, an unknown role
+token, or any
 other file pattern invalidates the branch to reconstruction. Exactly
 one sidecar per (body, role):
 duplicates cannot coexist in a tree, and a later commit that adds,
@@ -1135,9 +1151,11 @@ may.
 
 **Verification does not trust the pointer — and the branch carries its
 own preimages.** Genesis publishes the full policy, profile, and
-key-registry bodies (not digests alone) beside its body on the chain
-branch, and every transition that changes them publishes the new
-bodies likewise, so administrative approvals and historical keys
+key-registry preimages (raw bytes under the `.raw` grammar, not
+digests alone) beside its body on the chain
+branch, and every transition that changes a trust file publishes the
+new raw preimage likewise, so administrative approvals and historical
+keys
 verify from the branch alone after any number of rotations. The chain's truth is
 reconstructible by rule from the branch alone: the valid chain is the
 unique sequence of signed artifacts starting at genesis in which each
@@ -1566,9 +1584,21 @@ missing its typed-signer sidecar (`genesis`, `transition`, or
 `notary` per artifact kind) or its `admin-approver` or `approver`
 sidecar never pending
 and invalid to reconstruction (a distinct case per artifact kind and
-missing file); a genesis bundle missing any bootstrap preimage body,
-and a transition bundle missing a changed trust file's new body, each
-never pending (distinct cases); a
+missing file); a genesis bundle missing any bootstrap preimage,
+and a transition bundle missing a changed trust file's raw preimage,
+each
+never pending (distinct cases); a YAML and a TOML trust-file preimage
+each accepted verbatim under `.raw` (positive controls — the honest
+waiver-file and toolchain-pin transitions are constructible); a raw
+preimage wrapped in JSON refused (digest no longer the delta's
+after-digest); a `.raw` file whose bytes resemble a schema-carrying
+JSON body accepted as opaque and never parsed (positive control — no
+type precedence); a `.raw` file digest-reachable from no
+bootstrap_policies digest or delta after-digest invalidating the
+branch; a transition delta out of bytewise path order, or with a
+duplicate path, refused at parse; two honest constructions of one
+two-path transition producing identical body bytes and one digest
+(permutation-invariance positive control); a
 later commit rewriting or deleting any published bundle file
 invalidating the branch at that commit (append-only discipline); a
 partial-bundle commit refused by the publisher; an unknown role

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v27
+# Notary admission: design v28
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 27 folds design-review rounds 1–26
-(one hundred thirty-three blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 28 folds design-review rounds 1–27
+(one hundred thirty-four blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -193,9 +193,9 @@ ground truth.
 
 ### 2.3 Correction event — `axiom/lineage-correction/v1`
 
-Signed by the actor (role `actor`) and countersigned by a protected
-reviewer key distinct from the actor's (role `review`, per the §2.1 role
-table). Fields: `schema`, `lane`, `epoch_sha256`; `actor` and
+Signed by the actor (role `actor`) and countersigned by the
+protected correction-review key, distinct from the actor's (role
+`review`, per the §2.1 role table). Fields: `schema`, `lane`, `epoch_sha256`; `actor` and
 `reason` — non-empty JSON strings; `predecessor_record_sha256 | null`;
 `transitions` as §2.2. The
 countersignature validates lineage; it never authorizes merge. Corrections
@@ -756,8 +756,10 @@ structurally disqualified). Platform approval alone cannot bind bytes —
 neither OIDC nor the jobs API authenticates job inputs — so the binding
 is cryptographic: **a protected reviewer signs the candidate digest**
 under its own scope, `axiom/notary-approval/v1` (a detached signature
-by a reviewer key from §8's ceremony, distinct from every automation
-key), and that signature is the durable, signer-verifiable approval
+by the receipt-approver key — role `approver` — from §8's ceremony:
+its own key, disjoint under §5's total rule from every other role's,
+the correction-review key included), and that signature is the
+durable, signer-verifiable approval
 evidence. The **signing step** is the external signer, which validates
 the `approve` job's OIDC identity, re-reads the candidate by digest,
 **verifies the reviewer approval signature over that exact digest**,
@@ -814,9 +816,14 @@ verification reads it from here). The three typed scopes —
 registry entry: the external typed signer signs all three with the
 notary key, and the admin-approver's separate signature is what
 authorizes the administrative ones. **Role-key separation is total, not enumerated**: the SPKI sets of
-all roles — the seven registry roles and `legacy_apply_root` — are
+all roles — the seven registry roles and both retained legacy roots,
+`legacy_apply_root` and `legacy_eval_root` — are
 **pairwise disjoint**, and any SPKI appearing under two roles refuses
-the registry. Four consecutive review rounds each found a pair a
+the registry. The eval root belongs in the universe for the same
+reason the apply root does: §9.13 keeps signed-leg retirement a
+cutover exit criterion, not a pilot precondition, so both legacy
+authorities stay active through dual-era operation, and the registry
+cannot police a key it does not bind — genesis binds both. Four consecutive review rounds each found a pair a
 sparse forbidden-pair matrix had missed, so the contract is the
 universal rule, with no permitted alias left for an implementer to
 weigh. Two consequences carry their rationale by name. A `notary`
@@ -830,8 +837,10 @@ have genesis bless them as `v5_attested` — and the production signing
 broker already rejects an apply/corpus-release root collision, so
 totality restores deployed behavior rather than adding a constraint.
 The same shape covers every other pair — an `admin-approver` alias of
-`approver`, for one, would escalate ordinary reviewer compromise into
-authority over trust-surface rotation. Whether one person may hold two
+`approver` would escalate ordinary reviewer compromise into
+authority over trust-surface rotation, and an `admin-approver` alias
+of `legacy_eval_root` would let the eval custodian sign
+administrative approvals for trust-surface transitions. Whether one person may hold two
 roles' keys is §8 custody policy; the registry contract is about keys:
 no SPKI serves two roles. (The charter's separate-key requirement made
 checkable; the cross-scope matrix alone cannot detect deliberate key
@@ -905,6 +914,14 @@ partition property against the manifest before signing):
   out of that window, and the lock closes it (a locked, pinned tip
   admits no new store files). The organization
   variable supplying this root today is eliminated by §9.10;
+- `legacy_eval_root`: `{raw_key_id, public_key_spki_der_base64}` —
+  the current external eval-signing root, same shape, formula, and
+  mutual-consistency refusal as `legacy_apply_root`. It is bound
+  **solely to extend §5's disjointness wall**: it authenticates
+  nothing at genesis (v5 vouching uses the apply root alone), but an
+  unbound active authority could alias an admission role undetected.
+  Frozen per §9.15 exactly like the apply root; its organization
+  variable is likewise eliminated by §9.10;
 - `v5_attested`: sorted `[path, entry_sha256, record_sha256]` — paths
   whose blobs are vouched at genesis by a legacy record that passes the
   **current v5 authentication contract**: schema exactly
@@ -1154,8 +1171,12 @@ Before the typed signer holds any notary-scope key: generate
 committed code (consumer verification specs pin the SPKI), storage and
 rotation procedure (rotation is a §6.4 transition evaluated under
 predecessor roots), revocation and recovery. The producer, actor,
-reviewer, and administrative keys get the same treatment under their own
-scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
+correction-review, receipt-approver, and administrative keys get the
+same treatment under their own scopes — **five distinct keys**: §5's
+total rule forbids the correction-review and receipt-approver roles
+from sharing one "reviewer" key, so the ceremony mints and custodies
+each separately. §10's pairwise cross-scope matrix is part of ceremony
+acceptance.
 
 ## 9. Preconditions (nothing admission-capable merges before these)
 
@@ -1245,20 +1266,23 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
 14. Golden-regeneration QA retained and audited — the charter keeps it
     as the distributional defense, §1 relies on it as a mitigation, and
     its removal fails this precondition.
-15. The legacy apply root's fingerprint frozen independently before
-    genesis (sign-off packet record, compared witnessed against the
-    production value at ceremony time), and the corpus-release root
+15. The legacy apply and eval roots' fingerprints frozen
+    independently before genesis (sign-off packet records, compared
+    witnessed against the production values at ceremony time), and the corpus-release root
     migrated from its organization variable into the registry's
     `corpus-release` entry — Job 1's toolchain verification must read
     it from the registry before any lane activates.
-16. Genesis-time equality refusals: `legacy_apply_root` equal to
-    **any** registry entry refuses — `approver` matters concretely
+16. Genesis-time equality refusals: **either legacy root** equal to
+    any registry entry — or to the other legacy root — refuses;
+    for `legacy_apply_root`, `approver` matters concretely
     because legacy signed-apply retirement is not a pilot
     precondition, so an aliased apply authority could forge receipt
     approvals; `corpus-release` matters because an aliased service-key
     holder could freshly sign v5 records over hand-edited bytes before
     the lane lock and have genesis bless them (§5's window argument —
-    and the production broker already rejects this collision); the
+    and the production broker already rejects this collision); for
+    `legacy_eval_root`, an aliased eval authority could sign
+    administrative approvals (round 27's counterexample); the
     registry validator enforces §5's total pairwise disjointness.
 
 ## 10. Negative-test floor
@@ -1455,9 +1479,10 @@ and inside a transition (domain-total wall); delete-then-recreate-
 executable across two finalized receipts refused by the same rule
 (positive control); **a table-driven collision suite over every unordered role pair** —
 §5's separation is total, so the table is the full pairwise matrix
-over the seven registry roles plus `legacy_apply_root`: all
-twenty-eight pairs distinct refusal cases (`notary`×`review`,
-`admin-approver`×`approver`, and `corpus-release`×`legacy_apply_root`
+over the seven registry roles plus both legacy roots: all
+thirty-six pairs distinct refusal cases (`notary`×`review`,
+`admin-approver`×`approver`, `corpus-release`×`legacy_apply_root`,
+and `legacy_eval_root`×`admin-approver` — round 27's counterexample —
 included) — with an all-distinct registry accepted (positive
 control); finalization requested by rotated not-yet-finalized workflow
 code validated and executed by the broker, not the workflow (positive
@@ -1487,8 +1512,9 @@ newly-introduced body not separately enumerated (positive control);
 transition-path policy covering .axiom/notary accepted and covering
 .axiom/lineage refused (the opposite obligations); corpus-release root
 absent from the registry refused; invalid corpus-release signature
-refused; raw_key_id/SPKI pair inconsistent refused; legacy root equal
-to any registry entry refused (each role a distinct test,
+refused; raw_key_id/SPKI pair inconsistent refused for either legacy root;
+either legacy root equal
+to any registry entry refused (each pairing a distinct test,
 corpus-release and producer included); finalized receipt whose
 referenced report is unpublished invalid to reconstruction;
 absent-profile preflight refusal carrying a truthful null digest
@@ -1549,9 +1575,11 @@ control).
   digest-bound reviewer evidence, or records "the protected signing
   policy authorized this receipt" (honest for plain environment
   approval; the stronger form needs an explicit approval artifact).
-- Custody model for the producer, actor, reviewer, and administrative
-  keys (the notary key is fixed by §5/§8); reviewer custody is the open
-  question deferred from the rulespec-nz custody ruling.
+- Custody model for the producer, actor, correction-review,
+  receipt-approver, and administrative keys (the notary key is fixed
+  by §5/§8) — the two review-side roles hold distinct keys under §5's
+  total rule, so each needs its own custodian answer; reviewer custody
+  is the open question deferred from the rulespec-nz custody ruling.
 - Charter alignment on modes: whether covered executable-mode
   transitions become admissible post-pilot (charter requirement 4
   amendment) or the wall stays permanent.

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v20
+# Notary admission: design v21
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 20 folds design-review rounds 1–19
-(one hundred sixteen blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 21 folds design-review rounds 1–20
+(one hundred eighteen blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -98,7 +98,7 @@ field, missing field, wrong type, or duplicate key is a parse refusal.
 | `workflow_sha_git_oid` | the commit the workflow file was loaded from: **context-derived at candidate time** (`github.workflow_sha` in the `recompute` job), then **authenticated by equality** to `approve`'s OIDC `workflow_sha` claim at signing — one run, one workflow, so the equality is exact; reusable workflows are prohibited; never the run's `head_sha` |
 | Entry modes | six-character octal strings: `"100644"` and `"100755"` (the pilot admits no symlinks anywhere — charter requirement 4 rejects symlink deltas, and refusing the mode tree-wide is the total form) |
 | Paths | UTF-8 strings; sorting is bytewise over the UTF-8 encoding |
-| Semantic arrays | **one comparator everywhere**: elements order bytewise over the UTF-8 encoding of the element's sort key, which each array names — `gates` by `gate_id`, `required_gates` by `gate_id`, `acceptable_outcomes` and `reasons` by their string value, `eligible_records`/`unused_eligible_records` by digest, `ineligible_records` by `record_sha256`, `coverage_assignment` by `path`, dependency `actions` by `ref_spec`, `containers` by `image`, inventories by `path`; set-valued arrays are strictly unique on their key (JCS canonicalizes objects, not arrays — this row is what makes array bytes deterministic) |
+| Semantic arrays | **one comparator everywhere**: elements order bytewise over the UTF-8 encoding of the element's sort key, which each array names — `gates` by `gate_id`, `required_gates` by `gate_id`, `acceptable_outcomes` and `reasons` by their string value, `eligible_records`/`unused_eligible_records` by digest, `ineligible_records` by `store_name`, `coverage_assignment` by `path`, dependency `actions` by `ref_spec`, `containers` by `image`, inventories by `path`; set-valued arrays are strictly unique on their key (JCS canonicalizes objects, not arrays — this row is what makes array bytes deterministic) |
 
 **Tree manifests.** A tree manifest is the recursively flattened list of
 **terminal entries** (blobs and symlinks; directories appear only through
@@ -228,14 +228,15 @@ refusals carry `coverage_assignment`, `unused_eligible_records`,
 
 | `stage` | `established` content |
 |---|---|
-| `"structural"` | the all-null prefix (nothing established) |
+| `"structural"` | the actual completed prefix — a late structural failure (an empty subtree found while building the subject manifest, after resolution and the base manifest succeeded) truthfully carries the resolved predecessor and base fields; manifests establish in fixed order, **base first, then subject**, so identical faults establish identical prefixes |
 | `"preflight"` | whatever prefix the failing check permitted — a `policy-invalid` for an absent profile truthfully carries `profile_sha256: null` |
 | `"eligibility"` | prefix through the record lists |
 | `"assignment"` | prefix through the record lists — **never** an assignment or unused partition (an ambiguity has neither) |
 | `"gates"` | the full prefix, plus the gates-stage extras below |
 
 The prefix property is the single rule; the table describes what it
-yields per stage and never overrides it. Only `"gates"`-stage refusals
+yields per stage and never overrides it — including for structural
+refusals, whose prefixes reflect how far establishment actually got. Only `"gates"`-stage refusals
 additionally carry `coverage_assignment`, `unused_eligible_records`,
 `unprotected_changes`, and `gates` — there coverage succeeded, so all
 four are determinate.
@@ -284,7 +285,13 @@ tier comes from the digest-bound profile, so a report cannot strengthen a
 classification the profile did not grant; `diff_coverage`: exactly `"pass"` — the pass
 variant carries no refusal shapes, and `waived`/`not-run` exist in
 neither variant; `unprotected_changes`
-(sorted paths); `ineligible_records`: sorted array of `{record_sha256, reasons}` —
+(sorted paths); `ineligible_records`: sorted array of
+`{store_name, reasons}` — `store_name` is the literal filename string
+relative to `.axiom/lineage/`, `.json` suffix included, whatever bytes
+it holds within the UTF-8 tree domain; the array sorts bytewise by
+`store_name`. (Eligible records remain digest-keyed — they passed the
+address check, so name and digest coincide; ineligible entries are
+name-keyed precisely because their names may not be digests.)
 `reasons` is the sorted array of every applicable code **whose
 prerequisites are satisfied**, from the closed enum with this
 prerequisite order: `address-mismatch` and `malformed-record` are
@@ -360,10 +367,11 @@ has exactly one preimage. Every committed policy body (`path-policy`,
 any other body.
 
 The report is a *proposal*. Refusal reports are diagnostic artifacts, and
-even a pass report authorizes nothing: every claim-bearing field is
-recomputed by the trusted side (§5) before signing, so a candidate-forged
-report — pass verdict, trimmed unprotected list, invented assignment —
-fails reconciliation rather than getting signed.
+even a pass report authorizes nothing: every **recomputed invariant**
+is re-derived by the trusted side (§5) before signing — gates alone are
+validated declarations, per §1's stated residual — so a
+candidate-forged report (pass verdict, trimmed unprotected list,
+invented assignment) fails reconciliation rather than getting signed.
 
 ### 2.5 Notary receipt (signed) — `axiom/notary-receipt/v1`
 
@@ -394,8 +402,9 @@ The `job1` block is **run-scoped provenance, stated as such**: GitHub
 artifacts carry no producing-job or attempt identity, so it claims only
 that the named artifact with this digest existed in this run, which the
 pilot requires to contain exactly one artifact of that name. The
-narrowing is safe because no claim-bearing field depends on the
-artifact — the trusted side recomputes them all — and gate declarations
+narrowing is safe because no recomputed invariant depends on the
+artifact — the trusted side re-derives them all, and gate declarations
+carry §1's residual by construction — and gate declarations
 attribute to the proposing run as a whole: a different job in the
 candidate's own run forging them is the same trust domain and the same
 accepted residual as the candidate weakening its gates. An OIDC-bound
@@ -1350,6 +1359,10 @@ against a key other than the genesis-bound legacy root refused (root
 substitution); alias occurrence ineligible with address-mismatch while
 the correct-path occurrence stays eligible (positive control);
 malformed body carrying only computable reasons (positive control);
+late structural failure carrying the resolved base prefix (positive
+control); reconciliation rejecting an omitted or spurious
+ineligible_records occurrence, or an omitted or extra applicable
+reason;
 reusable verify job refused; duplicate prompt_sha256s refused; empty
 or wrong pinned artifact_name refused; review/admin-approver SPKI
 collision refused; approver/automation SPKI collision refused; policy

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v16
+# Notary admission: design v17
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 16 folds design-review rounds 1–15
-(ninety-nine blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 17 folds design-review rounds 1–16
+(one hundred three blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -278,10 +278,26 @@ eligibility (§3.2 in listed order), assignment (§3.3 rules 1–4 in
 order), gates (missing before unacceptable, then bytewise-least
 `gate_id`) — the reported refusal is the first failing check; `path` is
 the bytewise-least affected path for path-scoped codes and `null`
-otherwise; `detail` is the fixed template string defined per code (no
-free text), so identical faults produce identical bytes. The
+otherwise; `detail` is the fixed template string defined per code — normatively:
+`uncovered-path` → "no eligible transition covers this path";
+`ambiguous-assignment` → "more than one valid assignment";
+`inconsistent-chain` → "eligible transitions exist but no valid chain";
+`record-cycle` → "consumed records admit no execution order";
+`no-valid-execution` → "no topological order yields realizable trees";
+`inadmissible-entry` → "entry mode or type inadmissible";
+`structural` → "tree or store structurally malformed";
+`state-identical` → "base and subject states are identical";
+`gate-missing` → "required gate absent";
+`gate-unacceptable` → "gate outcome outside the acceptable set" —
+so identical faults produce identical bytes. Code selection between
+`uncovered-path` and `inconsistent-chain` is fixed: `uncovered-path`
+when no eligible transition names the path at all,
+`inconsistent-chain` when transitions name it but no valid chain
+exists. The preflight order is the closed list: repository resolution,
+chain-predecessor admissibility, policy and profile presence, registry
+validity, trust-surface refusals in §4's listed sentence order. The
 state-identical refusal carries code `"state-identical"`, stage
-`"preflight"`, added to the closed enum. There is no `diff_coverage` refusal
+`"preflight"`. There is no `diff_coverage` refusal
 object anywhere; the pass variant's `diff_coverage` is the literal
 `"pass"` and nothing else.
 
@@ -363,6 +379,12 @@ detached signatures beside it. The lineage directory is outside the
 protected-content coverage domain but inside the preflight's structural
 checks: schema-valid, authenticated, correctly content-addressed,
 append-only; deleting or mutating an existing record is a refusal.
+Structural checks govern **records present at the base** — the store's
+integrity as inherited; a **newly introduced** record that is
+malformed, misaddressed, or badly signed is not a structural refusal
+but an eligibility-stage ineligible record, enumerated with its
+reasons, so one bad new record cannot veto an otherwise covered
+candidate.
 Reports, receipts, genesis, and transition records publish per §7 and are
 never part of the subject tree.
 
@@ -386,10 +408,15 @@ manifest the system accepts.
 Records present under `.axiom/lineage/` in the subject tree and absent at
 the base — introduced by this candidate — carrying this `lane` and
 `epoch_sha256`, with valid signatures per the role table. The sorted
-digest list is bound into report and receipt. Replay is dead: a record
-merged by an earlier candidate is present at the base and ineligible ever
-after; cross-lane and cross-epoch records refuse on their bindings; stale
-records refuse in replay (§3.3).
+digest list is bound into report and receipt. Replay of **previously
+published** records is dead: one merged by an earlier candidate is
+present at the base and ineligible ever after; cross-lane and
+cross-epoch records refuse on their bindings; records whose
+before-digests no longer match the base refuse in replay (§3.3). A
+never-published record stockpiled from an abandoned attempt can be
+introduced later if its endpoints recur — within the coverage claim
+(the bytes are authentically lineage-attested); event-to-attempt
+freshness binding is named future work, not claimed.
 
 ### 3.3 The predicate, deterministic and total
 
@@ -643,13 +670,23 @@ Trust roots for every step resolve through one normative committed
 registry: `.axiom/notary/keys.json` at the base, schema
 `axiom/notary-key-registry/v1` — a closed object mapping each role to
 its sorted (by `spki_sha256`), strictly unique array of
-`{spki_sha256, public_key_pem_base64}` entries: **the key bytes
-themselves**, because a fingerprint alone cannot verify an Ed25519
-signature. Registry role names are exactly the §2.1 role-table roles —
+`{spki_sha256, public_key_spki_der_base64}` entries: **the key bytes
+themselves** (standard base64 with padding, RFC 4648 §4, of the DER
+SubjectPublicKeyInfo; decoding must yield a valid Ed25519 SPKI whose
+SHA-256 equals the beside fingerprint, else the registry refuses) —
+because a fingerprint alone cannot verify a signature. Registry role names are exactly the §2.1 role-table roles —
 `producer`, `actor`, `review`, `admin-approver`, `approver` — plus
 `notary` (whose entry mirrors the SPKI pinned in the lane's consumer
-verification spec; a mismatch refuses). Scope-to-registry resolution
-is the role table itself: a detached signature under a scope verifies
+verification spec; a mismatch refuses). The three typed scopes —
+`genesis`, `transition`, and `notary` — all resolve to the **`notary`**
+registry entry: the external typed signer signs all three with the
+notary key, and the admin-approver's separate signature is what
+authorizes the administrative ones. **Generation-side and
+admission-side roles are disjoint**: an SPKI registered under
+`producer` or `actor` must not appear under `review`, `admin-approver`,
+`approver`, or `notary` (the charter's separate-key requirement made
+checkable; a collision refuses the registry). For every other scope,
+scope-to-registry resolution is the role table itself: a detached signature under a scope verifies
 against the key bytes registered for that scope's role, never against
 the signature file's self-declared fingerprint (which is
 cross-checked, not trusted). The registry is a §4 trust surface: it
@@ -812,10 +849,14 @@ audited bypass**: the bootstrap administrative actor, whose one
 permitted action is merging the activation commit, listed in §9 as a
 security-critical authority. The guarantee does not rest on that
 actor's discipline: activation refuses unless the recomputed
-base→subject diff equals exactly the epoch pin plus the three
-genesis-bound policy files, so a bypass misused for any other merge
-produces an activation that cannot finalize and a bootstrap that
-voids. A genesis attempt observing a moved tip or an absent lock
+base→subject state installs exactly the five bootstrap paths — the
+epoch-pinned consumer spec, the three policies, the key registry —
+**defined by final installed values, not by diff membership**: each
+path's subject bytes must equal its genesis-bound digest (with the
+epoch substitution for the spec), whether or not the path already held
+those bytes at genesis, and no other path may change. A bypass misused
+for any other merge produces an activation that cannot finalize and a
+bootstrap that voids. A genesis attempt observing a moved tip or an absent lock
 refuses.
 
 Genesis also **binds its prospective policies and the activation
@@ -836,9 +877,10 @@ afterward. The lane's epoch pin cannot
 live inside the genesis tree (that would be `epoch → tree → body →
 epoch`); it lands immediately after, in the **bootstrap activation
 transition** — the chain's second artifact, predecessor genesis, whose
-delta is exactly the consumer-spec epoch pin plus those four bound
-files (the three policies and the key registry), digest-identical to
-`bootstrap_policies`; its eligibility oracle
+delta installs the five bootstrap paths by final value — each
+byte-equal to its genesis-bound digest (epoch substituted in the spec),
+paths already correct at genesis permitted to be absent from the diff,
+no other path changing; its eligibility oracle
 is the genesis-bound transition-path policy. Enforcement begins at
 activation finalization; the lock spans the whole interval, so no
 ordinary candidate can slip between. The stale-genesis laundering path
@@ -1173,7 +1215,18 @@ intermediate mode refused (chain-wide agreement); registry entry whose
 key bytes hash to a different spki_sha256 refused; scope resolved to
 the wrong registry role refused; genesis over a locked tip whose
 ceremony key is absent from the genesis-bound prospective registry
-refused; activation delta missing the key registry refused; intermediate replay projection with a path both
+refused; activation leaving any bootstrap path's installed bytes
+unequal to its genesis-bound digest refused; bootstrap path already
+byte-correct at genesis absent from the activation diff accepted
+(positive control — installed values, not diff membership);
+generation-side SPKI colliding with an admission-side role refused;
+registry key bytes failing base64, DER, Ed25519, or fingerprint
+validation refused; noncanonical decimal id ("01") refused; invalid
+RFC 3339 emitted_at refused; registry notary entry differing from the
+consumer pin refused; waiver bytes disagreeing with the base toolchain
+pin refused; equal-manifest transition carrying a forged nonempty
+delta refused; bad newly-introduced record enumerated ineligible while
+the candidate passes (positive control — structural scope); intermediate replay projection with a path both
 terminal and directory-prefix refused as no-valid-execution;
 noncanonical JCS bytes or wrong semantic-array order refused; genesis
 inventory containing a path outside the protected domain refused;

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v10
+# Notary admission: design v11
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 10 folds design-review rounds 1–9
-(sixty-eight blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 11 folds design-review rounds 1–10
+(seventy-five blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -136,6 +136,7 @@ body's schema:
 | review | `axiom/lineage-correction-review/v1` | correction event (same body digest) |
 | genesis | `axiom/notary-genesis/v1` | genesis |
 | transition | `axiom/notary-transition/v1` | transition record |
+| approver | `axiom/notary-approval/v1` | receipt candidate (its body digest) |
 | notary | `axiom/notary-receipt/v1` | notary receipt |
 
 Signatures are detached files beside the body (`<digest>.json`,
@@ -231,10 +232,11 @@ tier comes from the digest-bound profile, so a report cannot strengthen a
 classification the profile did not grant; `diff_coverage`: exactly `"pass"` — the pass
 variant carries no refusal shapes, and `waived`/`not-run` exist in
 neither variant; `unprotected_changes`
-(sorted paths); `ineligible_records`: sorted array of `{record_sha256, reason}` with a
-closed reason enum (`"unprotected-path-transition"`,
-`"duplicate-transition-paths"`, `"wrong-lane"`, `"wrong-epoch"`,
-`"invalid-signature"`); `dependency_pins_sha256`: the digest of a
+(sorted paths); `ineligible_records`: sorted array of `{record_sha256, reasons}` —
+`reasons` is the sorted array of every applicable code from the closed
+enum (`"unprotected-path-transition"`, `"duplicate-transition-paths"`,
+`"wrong-lane"`, `"wrong-epoch"`, `"invalid-signature"`), the same shape
+in pass and refusal variants; `dependency_pins_sha256`: the digest of a
 canonical dependency inventory, a body of schema
 `axiom/notary-dependency-inventory/v1` with the closed shape
 `{schema, lane, actions: [[ref_spec, git_oid], …] sorted by ref_spec
@@ -298,9 +300,17 @@ proposing run" as a whole: a different job in the candidate's own run
 forging them is the same trust domain and the same accepted residual as
 the candidate weakening its gates. An OIDC-bound upload attestation
 tightening this to job-level is future work, out of milestone one;
-`authorization`: `{environment, approval_context}` (§11 wording
-decision). Genesis and transitions are distinct schemas; a receipt cannot
-claim their role.
+`authorization`: `{environment, approve_check_run_id,
+approval_signature_sha256}` — the `approve` job's own OIDC
+`check_run_id`, and the digest of the detached
+`axiom/notary-approval/v1` signature file (published beside the receipt
+on the chain branch). The receipt is assembled by the signer as
+**candidate plus authorization**: the recomputation stage produces the
+candidate (`axiom/notary-receipt-candidate/v1` — exactly the recomputed
+and `job1` fields, no authorization, so nothing circular); the reviewer
+approval signs the candidate digest; the final receipt binds
+`candidate_sha256` and the authorization block. Genesis and transitions
+are distinct schemas; a receipt cannot claim their role.
 
 ### 2.6 Storage
 
@@ -370,9 +380,15 @@ do not exist at this level. Over the protected subset:
    dependency graph (an edge from record X to record Y wherever, in some
    path's chain, a transition of Y consumes the state a transition of X
    produced); the graph must be acyclic, and applying whole records in a
-   topological order from the base must find every transition's
-   before-state current when its record applies and terminate at the
-   subject — cross-path cycles between records (X and Y each feeding the
+   topological order must replay **the protected-state projection**:
+   starting from the base's protected entries, every transition's
+   before-state must be current when its record applies, and the
+   replayed projection must terminate at the subject's protected
+   entries. Unprotected entries — including the candidate's own new
+   lineage files, which every ordinary candidate necessarily adds — are
+   outside the replay and accounted separately (`unprotected_changes`
+   and the §2.6/§3.2 lineage checks); a replay defined over the whole
+   tree would falsely reject every nonempty candidate — cross-path cycles between records (X and Y each feeding the
    other on different paths) refuse as `record-cycle`, because no
    repository state ever contained what the subject cherry-picks.
    Second, **correction predecessors have predicate meaning**: a consumed
@@ -438,7 +454,17 @@ each on a fresh ephemeral runner, none reusable:
 | `verify` (Job 1) | yes | `contents: read` only, no secrets, no environment | none |
 | `recompute` | no (pinned code) | `contents: read`, `actions: read` | none |
 | `approve` | no (pinned code) | none beyond `id-token: write` | presents identity to the signer |
-| `publish` | no (pinned code) | the two §9.7b credentials | none |
+| `publish` | no (pinned code) | the two §9.7b credentials, released only by its protected environment | none |
+
+`publish` (and the finalizer below) run in a dedicated protected
+**`notary-publishing` environment**: the merge-authorizing credentials
+are environment secrets released only to jobs on the pinned workflows
+and protected refs — "provisioned, never minted" is enforced by the
+platform's secret-release gate, exactly the mechanism the current
+signed-apply publisher already uses, not by convention. Finalization
+necessarily runs after the merge, in a separate named workflow
+(`notary-finalize.yml`) triggered by the protected content ref, under
+the same environment and credential binding.
 
 Job conclusions are read through the jobs-for-run endpoint (by job name
 and attempt), never self-asserted; the `approve` job's identity is
@@ -518,10 +544,12 @@ approval-signature reference.)
 Effective-permission constraints, not deployment assumptions (§9): the
 external signer's own deployment holds no model, generation, or
 repository-write credentials, and its caller allowlist is exact — the
-trusted recomputation job alone, identified by repository, workflow path
+`approve` job alone, identified by repository, workflow path
 and `workflow_sha`, job, run, attempt, ref, and the `notary-signing`
 environment, with `id-token: write` allocated for the OIDC proof and
-`actions: read` for control-plane lookups and nothing further. Job 1's
+`actions: read` for control-plane lookups and nothing further — the
+allowlisted caller is the `approve` job, the only job that presents
+OIDC. Job 1's
 token is audited to `contents: read` with no other permissions, no
 secrets, and no environment. The trusted job's `GITHUB_TOKEN` is
 read-only and it references no secrets beyond the OIDC exchange. The
@@ -682,12 +710,21 @@ produces an activation that cannot finalize and a bootstrap that
 voids. A genesis attempt observing a moved tip or an absent lock
 refuses.
 
-Genesis also **binds its prospective policies**: the body carries
-`bootstrap_policies` — the digests of the exact path-policy,
-transition-path-policy, and profile bodies the lane will adopt — and
-the genesis partition of protected paths is computed under that bound
-path policy, so the policy defining genesis provenance is fixed at
-signing and cannot be selected afterward. The lane's epoch pin cannot
+Genesis also **binds its prospective policies and the activation
+bytes**: the body carries `bootstrap_policies` — the digests of the
+exact path-policy, transition-path-policy, and profile bodies the lane
+will adopt — and `activation_spec_template_sha256`, the digest of the
+prospective consumer-spec file with the epoch value replaced by the
+fixed placeholder token
+`"0000000000000000000000000000000000000000000000000000000000000000"`
+(the epoch cannot be bound literally: it is the genesis digest itself).
+Activation's spec file must equal that template with the placeholder
+substituted by the actual epoch — byte-exact, mechanically checkable —
+so no other field of the consumer-spec file (a notary SPKI, an anchor
+pin) can ride the activation delta. The genesis partition of protected
+paths is computed under the bound path policy, so the policy defining
+genesis provenance is fixed at signing and cannot be selected
+afterward. The lane's epoch pin cannot
 live inside the genesis tree (that would be `epoch → tree → body →
 epoch`); it lands immediately after, in the **bootstrap activation
 transition** — the chain's second artifact, predecessor genesis, whose
@@ -779,6 +816,17 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    cross-family review plus **Max's named sign-off**, with every §11
    decision closed.
 2. The reviewers-semantics resolution in §4 accepted.
+2a. The bootstrap authority named and audited: the single administrative
+   actor holding the lane-lock bypass, its custody, its one permitted
+   action (merging the activation commit), and its removal at
+   activation finalization — a security-critical, single-use authority.
+2b. The `notary-signing` environment's administrator-bypass setting
+   disallowed and audited (a bypassed approval carries no reviewer
+   signature and refuses regardless, but the platform gate is
+   configured off, not merely compensated for).
+2c. The `notary-publishing` environment created: the publisher and
+   finalizer credentials are environment secrets released only to the
+   pinned workflows on protected refs.
 3. The dedicated `notary-signing` environment created (required
    reviewers, protected refs, no self-approval), holding no generation
    credentials and no write tokens; generation workflows migrated off
@@ -984,7 +1032,20 @@ commits refused; premature lock removal or an unauthorized bootstrap
 bypass merge producing an activation that cannot finalize (voids);
 environment-admin approval bypass carrying no reviewer signature
 refused; reviewer approval signature over the wrong digest refused;
-`"gates"`-stage refusal carrying its assignment (positive control).
+`"gates"`-stage refusal carrying its assignment (positive control);
+approval signature invalid, by the wrong key, or under the wrong scope
+refused; approval signature over a different candidate digest refused;
+receipt whose candidate_sha256 mismatches the recomputed candidate
+refused; activation consumer-spec differing from the genesis-bound
+template beyond the epoch substitution refused (same-file smuggling);
+replay over the whole tree instead of the protected projection would
+reject a valid candidate (positive control for the projection rule);
+publisher or finalizer credentials requested outside the
+notary-publishing environment refused by secret release; well-typed but
+invalid path-policy action or profile oracle_policy refused; Actions
+artifact_id mismatch refused; multi-fault ineligible record carrying
+one deterministic sorted reasons array in the pass variant (positive
+control).
 
 ## 11. Decisions for sign-off
 

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v15
+# Notary admission: design v16
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 15 folds design-review rounds 1–14
-(ninety-five blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 16 folds design-review rounds 1–15
+(ninety-nine blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -91,11 +91,11 @@ field, missing field, wrong type, or duplicate key is a parse refusal.
 | Git object id (`*_git_oid`, incl. `workflow_sha_git_oid`) | 40-char lowercase hex string (SHA-1 object format in the pilot) |
 | Ed25519 signature | `signature_base64`: standard base64 with padding (RFC 4648 §4) |
 | `signer_spki_sha256` | SHA-256 of the DER-encoded SubjectPublicKeyInfo, hex as above |
-| `run_id`, `run_attempt` | JSON strings (decimal), never numbers |
+| `run_id`, `run_attempt`, `check_run_id`, `approve_check_run_id`, `artifact_id` | JSON strings, canonical decimal, no leading zeros, never numbers |
 | `chain_predecessor_kind` | exactly one of `"genesis"`, `"receipt"`, `"transition"` |
 | `tier` (profile only) | exactly one of `"public"`, `"restricted"`, `"ci-attested"` — never a report or receipt field; consumers read tiers from the profile the receipt binds |
 | `ref` | the fully qualified Git ref string (`refs/...`) |
-| `workflow_sha_git_oid` | the commit the workflow file was loaded from, taken from the **trusted job's own OIDC `workflow_sha` claim** — normative because Job 1 and the trusted job run in the same workflow run (§5), so one authenticated claim covers both; reusable workflows are prohibited for this workflow; never the run's `head_sha`, which the workflow-run REST object reports instead of the loading commit |
+| `workflow_sha_git_oid` | the commit the workflow file was loaded from: **context-derived at candidate time** (`github.workflow_sha` in the `recompute` job), then **authenticated by equality** to `approve`'s OIDC `workflow_sha` claim at signing — one run, one workflow, so the equality is exact; reusable workflows are prohibited; never the run's `head_sha` |
 | Entry modes | six-character octal strings: `"100644"` and `"100755"` (the pilot admits no symlinks anywhere — charter requirement 4 rejects symlink deltas, and refusing the mode tree-wide is the total form) |
 | Paths | UTF-8 strings; sorting is bytewise over the UTF-8 encoding |
 | Semantic arrays | **one comparator everywhere**: elements order bytewise over the UTF-8 encoding of the element's sort key, which each array names — `gates` by `gate_id`, `required_gates` by `gate_id`, `acceptable_outcomes` and `reasons` by their string value, `eligible_records`/`unused_eligible_records` by digest, `ineligible_records` by `record_sha256`, `coverage_assignment` by `path`, dependency `actions` by `ref_spec`, `containers` by `image`, inventories by `path`; set-valued arrays are strictly unique on their key (JCS canonicalizes objects, not arrays — this row is what makes array bytes deterministic) |
@@ -271,9 +271,17 @@ require to be a present, bounded regular file — an absent or non-regular
 waiver file is a refusal, not an empty hash. The refusal variant's `refusal` member is itself closed:
 `{code, path | null, detail}` with the single code enum of §2.4
 (coverage and gate codes alike), `detail` a JSON string — and
-deterministic under simultaneous faults: the reported refusal is the
-first failing rule in §3.3's evaluation order, and within that rule the
-bytewise-least affected path. There is no `diff_coverage` refusal
+deterministic under simultaneous faults, with all three members fixed:
+the evaluation order is total — structural (§2.1 manifest rules in
+listed order), preflight (§4 in listed order), state-identical,
+eligibility (§3.2 in listed order), assignment (§3.3 rules 1–4 in
+order), gates (missing before unacceptable, then bytewise-least
+`gate_id`) — the reported refusal is the first failing check; `path` is
+the bytewise-least affected path for path-scoped codes and `null`
+otherwise; `detail` is the fixed template string defined per code (no
+free text), so identical faults produce identical bytes. The
+state-identical refusal carries code `"state-identical"`, stage
+`"preflight"`, added to the closed enum. There is no `diff_coverage` refusal
 object anywhere; the pass variant's `diff_coverage` is the literal
 `"pass"` and nothing else.
 
@@ -301,7 +309,7 @@ two layers, candidate and wrapper, each a closed schema.
 
 **The candidate** (`axiom/notary-receipt-candidate/v1`) is produced by
 the `recompute` job and carries exactly: the full §2.4 pass-report
-field set — every recomputed field including `diff_coverage` (exactly
+field set with `schema` replaced by the candidate's own identifier — every recomputed field including `diff_coverage` (exactly
 `"pass"`), `eligible_records`, `unused_eligible_records`,
 `ineligible_records`, `coverage_assignment`, `unprotected_changes`, and
 `gates` (validated declarations: deduplicated, profile-complete,
@@ -449,9 +457,10 @@ do not exist at this level. Over the protected subset:
    outright; additions and deletions carry their single endpoint's mode
    and are unaffected (the wall never fires on a null side). And the
    wall is closed against laundering through intermediates: **every
-   consumed transition must preserve mode** (`before_mode ==
-   after_mode` whenever both are non-null), so a 100644→100755→100644
-   chain refuses at its first link regardless of matching endpoints.
+   non-null mode across a path's entire consumed chain must agree**
+   (per-transition preservation alone still admits an executable
+   intermediate through a delete-and-recreate pair), so any chain
+   passing through a differing mode refuses wherever it occurs.
    This is the charter requirement-4 wall in the predicate itself;
    relaxing it is the §11 charter-alignment decision. Protected paths
    are regular blobs (100644 or
@@ -632,14 +641,19 @@ minted by it; publishes per §7; holds no signing capability.
 
 Trust roots for every step resolve through one normative committed
 registry: `.axiom/notary/keys.json` at the base, schema
-`axiom/notary-key-registry/v1` — a closed object mapping each role
-(`producer`, `actor`, `correction-reviewer`, `admin-approver`,
-`approver`) to its sorted, strictly unique array of authorized SPKI
-sha256 values (the notary key's SPKI is additionally pinned in the
-lane's consumer verification spec). Detached signatures validate
-against the registry entry for their role — never against a signature
-file's self-declared fingerprint — and the registry is a §4 trust
-surface: it moves only by transition, which is what key rotation is.
+`axiom/notary-key-registry/v1` — a closed object mapping each role to
+its sorted (by `spki_sha256`), strictly unique array of
+`{spki_sha256, public_key_pem_base64}` entries: **the key bytes
+themselves**, because a fingerprint alone cannot verify an Ed25519
+signature. Registry role names are exactly the §2.1 role-table roles —
+`producer`, `actor`, `review`, `admin-approver`, `approver` — plus
+`notary` (whose entry mirrors the SPKI pinned in the lane's consumer
+verification spec; a mismatch refuses). Scope-to-registry resolution
+is the role table itself: a detached signature under a scope verifies
+against the key bytes registered for that scope's role, never against
+the signature file's self-declared fingerprint (which is
+cross-checked, not trusted). The registry is a §4 trust surface: it
+moves only by transition, which is what key rotation is.
 Runtime organization variables are not trust anchors anywhere in the
 notary path.
 
@@ -664,9 +678,13 @@ inventories forming an **exhaustive, disjoint, exactly-once partition of
 the protected paths** at genesis (the typed signer verifies the
 partition property against the manifest before signing):
 
-- `bootstrap_policies`: an object with exactly three members —
-  `{path_policy_sha256, transition_path_policy_sha256, profile_sha256}`
-  — the prospective policy bodies §7 binds;
+- `bootstrap_policies`: an object with exactly four members —
+  `{path_policy_sha256, transition_path_policy_sha256, profile_sha256,
+  key_registry_sha256}` — the prospective policy and registry bodies §7
+  binds; the ceremony's administrative key must be authorized by that
+  prospective registry, verified by the typed signer at genesis (the
+  bootstrap breaks the predecessor-roots recursion by binding its own
+  root set, exactly as it binds its policies);
 - `activation_spec_template_sha256`: the §7 epoch-placeholder template
   digest (both fields are part of the closed genesis schema, so the
   epoch digest is uniquely constructible and the same-file-smuggling
@@ -708,7 +726,11 @@ the chain across them. Closed schema: `schema`, `lane`, `epoch_sha256`,
 after_entry_sha256 | null, after_mode | null}` restricted to
 trust-surface paths, and `reason`.
 
-Rules: transition eligibility has a deterministic oracle — a committed
+Rules: a transition whose delta is empty, or whose base manifest
+equals its subject manifest, refuses — the state-identical ban of §1
+covers transitions and receipts alike, and the signer and publisher
+both enforce it; transition eligibility has a deterministic oracle — a
+committed
 `.axiom/notary/transition-path-policy.json` (same rule shape and
 semantics as the path policy, schema
 `axiom/notary-transition-path-policy/v1`), evaluated under the
@@ -814,8 +836,9 @@ afterward. The lane's epoch pin cannot
 live inside the genesis tree (that would be `epoch → tree → body →
 epoch`); it lands immediately after, in the **bootstrap activation
 transition** — the chain's second artifact, predecessor genesis, whose
-delta is exactly the consumer-spec epoch pin plus those three policy
-files, digest-identical to `bootstrap_policies`; its eligibility oracle
+delta is exactly the consumer-spec epoch pin plus those four bound
+files (the three policies and the key registry), digest-identical to
+`bootstrap_policies`; its eligibility oracle
 is the genesis-bound transition-path policy. Enforcement begins at
 activation finalization; the lock spans the whole interval, so no
 ordinary candidate can slip between. The stale-genesis laundering path
@@ -1143,7 +1166,14 @@ workflow_sha diverging from approve's OIDC claim refused; wrapper
 lane or epoch diverging from candidate or chain refused;
 authorization.environment not derived from OIDC refused; untyped or
 empty lineage identity fields refused; simultaneous-fault refusal
-reporting the first rule and least path (positive control); intermediate replay projection with a path both
+reporting the first rule, least path, and template detail (positive
+control); state-identical transition (empty delta) refused by signer
+and publisher; delete-and-recreate chain through a differing
+intermediate mode refused (chain-wide agreement); registry entry whose
+key bytes hash to a different spki_sha256 refused; scope resolved to
+the wrong registry role refused; genesis over a locked tip whose
+ceremony key is absent from the genesis-bound prospective registry
+refused; activation delta missing the key registry refused; intermediate replay projection with a path both
 terminal and directory-prefix refused as no-valid-execution;
 noncanonical JCS bytes or wrong semantic-array order refused; genesis
 inventory containing a path outside the protected domain refused;

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v11
+# Notary admission: design v12
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 11 folds design-review rounds 1–10
-(seventy-five blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 12 folds design-review rounds 1–11
+(eighty blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -95,6 +95,7 @@ field, missing field, wrong type, or duplicate key is a parse refusal.
 | `workflow_sha_git_oid` | the commit the workflow file was loaded from, taken from the **trusted job's own OIDC `workflow_sha` claim** — normative because Job 1 and the trusted job run in the same workflow run (§5), so one authenticated claim covers both; reusable workflows are prohibited for this workflow; never the run's `head_sha`, which the workflow-run REST object reports instead of the loading commit |
 | Entry modes | six-character octal strings: `"100644"`, `"100755"`, `"120000"` |
 | Paths | UTF-8 strings; sorting is bytewise over the UTF-8 encoding |
+| Semantic arrays | **one comparator everywhere**: elements order bytewise over the UTF-8 encoding of the element's sort key, which each array names — `gates` by `gate_id`, `required_gates` by `gate_id`, `acceptable_outcomes` and `reasons` by their string value, `eligible_records`/`unused_eligible_records` by digest, `ineligible_records` by `record_sha256`, `coverage_assignment` by `path`, dependency `actions` by `ref_spec`, `containers` by `image`, inventories by `path`; set-valued arrays are strictly unique on their key (JCS canonicalizes objects, not arrays — this row is what makes array bytes deterministic) |
 
 **Tree manifests.** A tree manifest is the recursively flattened list of
 **terminal entries** (blobs and symlinks; directories appear only through
@@ -205,9 +206,12 @@ null-less and closed at each stage):
 | `"gates"` | the assignment fields + `coverage_assignment`, `unprotected_changes`, `gates` |
 
 A `"gates"`-stage refusal does carry its unique assignment — coverage
-succeeded; a gate outcome did not — under refusal codes extended
-accordingly: the closed enum gains `"gate-unacceptable"` and
-`"gate-missing"` beside the coverage codes. `ineligible_records`
+succeeded; a gate outcome did not. The refusal member is named
+`refusal` in both variants (never `diff_coverage`), and its single
+closed code enum is: `"uncovered-path"`, `"ambiguous-assignment"`,
+`"inconsistent-chain"`, `"record-cycle"`, `"no-valid-execution"`,
+`"inadmissible-entry"`, `"structural"`, `"gate-unacceptable"`,
+`"gate-missing"`. `ineligible_records`
 entries carry `reasons`: the **sorted array of every applicable reason
 code**, so a multi-fault record has one deterministic representation.
 Refusal reports are diagnostics; no downstream artifact ever binds
@@ -220,7 +224,10 @@ Fields: `schema`,
 `subject_tree_manifest_sha256`; `base_commit_git_oid`,
 `base_tree_manifest_sha256`; `chain_predecessor_sha256`,
 `chain_predecessor_kind`; `profile_sha256`, `path_policy_sha256`;
-`corpus_release` `{name, content_sha256}`; `waiver_set_sha256`;
+`corpus_release` `{name, content_sha256}` — derived normatively from
+the repository-root `.axiom/toolchain.toml` at the **base** per the
+existing toolchain contract, with `.axiom/toolchain.toml` itself a §4
+trust surface (transition-only); `waiver_set_sha256`;
 `eligible_records` and `unused_eligible_records` (sorted digest arrays);
 `coverage_assignment`: array sorted bytewise by path of
 `{path, record_sha256s}` — for each changed protected path, the record
@@ -304,12 +311,20 @@ tightening this to job-level is future work, out of milestone one;
 approval_signature_sha256}` — the `approve` job's own OIDC
 `check_run_id`, and the digest of the detached
 `axiom/notary-approval/v1` signature file (published beside the receipt
-on the chain branch). The receipt is assembled by the signer as
-**candidate plus authorization**: the recomputation stage produces the
-candidate (`axiom/notary-receipt-candidate/v1` — exactly the recomputed
-and `job1` fields, no authorization, so nothing circular); the reviewer
-approval signs the candidate digest; the final receipt binds
-`candidate_sha256` and the authorization block. Genesis and transitions
+on the chain branch). The final receipt's closed schema is exactly
+`{schema, lane, epoch_sha256, candidate_sha256, authorization}` — the
+candidate's fields are referenced by digest, never flattened, and the
+candidate body **must be published on the chain branch beside the
+receipt** (a receipt whose candidate is unpublished is unverifiable and
+invalid to reconstruction). The candidate
+(`axiom/notary-receipt-candidate/v1`) carries every §2.4-recomputed
+field plus `job1`, in the pass-report shapes, and no authorization —
+nothing circular. To remove the earlier ambiguity in one sentence:
+`job1.check_run_id` inside the candidate is **`verify`'s** check run id
+from jobs-for-run; the `approve` job's own OIDC `check_run_id` appears
+only in `authorization.approve_check_run_id`. The reviewer approval
+signs the candidate digest; the signer assembles and signs the final
+receipt. Genesis and transitions
 are distinct schemas; a receipt cannot claim their role.
 
 ### 2.6 Storage
@@ -384,7 +399,14 @@ do not exist at this level. Over the protected subset:
    starting from the base's protected entries, every transition's
    before-state must be current when its record applies, and the
    replayed projection must terminate at the subject's protected
-   entries. Unprotected entries — including the candidate's own new
+   entries, and **every intermediate projection must be realizable as a
+   Git tree** — prefix-free, no path simultaneously a terminal entry
+   and a directory prefix of another. Acceptance is existential and
+   therefore deterministic as a predicate: the assignment passes iff
+   **some** topological order yields all-realizable intermediates with
+   every endpoint current; if none does, the refusal is
+   `no-valid-execution`, a sibling of `record-cycle`. Unprotected
+   entries — including the candidate's own new
    lineage files, which every ordinary candidate necessarily adds — are
    outside the replay and accounted separately (`unprotected_changes`
    and the §2.6/§3.2 lineage checks); a replay defined over the whole
@@ -453,15 +475,17 @@ each on a fresh ephemeral runner, none reusable:
 |---|---|---|---|
 | `verify` (Job 1) | yes | `contents: read` only, no secrets, no environment | none |
 | `recompute` | no (pinned code) | `contents: read`, `actions: read` | none |
-| `approve` | no (pinned code) | none beyond `id-token: write` | presents identity to the signer |
+| `approve` | no (pinned code) | `id-token: write` only — the control-plane lookups (`actions: read`) belong to the **signer's own credential**, not to any job | presents identity to the signer |
 | `publish` | no (pinned code) | the two §9.7b credentials, released only by its protected environment | none |
 
 `publish` (and the finalizer below) run in a dedicated protected
 **`notary-publishing` environment**: the merge-authorizing credentials
 are environment secrets released only to jobs on the pinned workflows
 and protected refs — "provisioned, never minted" is enforced by the
-platform's secret-release gate, exactly the mechanism the current
-signed-apply publisher already uses, not by convention. Finalization
+platform's secret-release gate — borrowing the environment-gating
+mechanism the current signed-apply publisher uses for its secrets,
+while removing what that publisher still does wrong: it mints its App
+token in-job, and here minting authority never enters any job. Finalization
 necessarily runs after the merge, in a separate named workflow
 (`notary-finalize.yml`) triggered by the protected content ref, under
 the same environment and credential binding.
@@ -592,8 +616,11 @@ partition property against the manifest before signing):
 
 - `bootstrap_policies`: an object with exactly three members —
   `{path_policy_sha256, transition_path_policy_sha256, profile_sha256}`
-  — the prospective policy bodies §7 binds (part of the closed genesis
-  schema, so the epoch digest is uniquely constructible);
+  — the prospective policy bodies §7 binds;
+- `activation_spec_template_sha256`: the §7 epoch-placeholder template
+  digest (both fields are part of the closed genesis schema, so the
+  epoch digest is uniquely constructible and the same-file-smuggling
+  protection is inside the schema, not beside it);
 - `v5_attested`: sorted `[path, entry_sha256, record_sha256]` — paths
   whose blobs are vouched at genesis by a legacy record that passes the
   **current v5 authentication contract**: schema exactly
@@ -645,8 +672,17 @@ refuses;
 signatures and authorization are evaluated **under the predecessor
 state's trust roots** (the old keys and policy authorize the handover, so
 a successor-controlled key cannot self-authorize its own installation);
-transitions are produced only through the typed signer under the
-`notary-signing` environment's human approval; and transitions are void
+transitions (and genesis) follow the same digest-bound authorization
+pattern as receipts: the typed signer emits the **administrative
+candidate** (the exact genesis or transition body, unsigned), a
+protected reviewer holding a predecessor-state reviewer key signs its
+digest under `axiom/notary-admin-approval/v1` (a scope added to the
+§2.1 role table's semantics; for genesis, the reviewer keys are those
+named by the bootstrap ceremony), and the signer signs only after
+verifying that approval signature over the exact digest — environment
+approval alone binds no bytes here either, and a swapped-body
+transition after platform approval refuses on the missing
+matching-digest signature; and transitions are void
 until finalized (§7), exactly like receipts. For merge gating, a pending
 transition plays the pending receipt's role for its own subject (§7): it
 is the merge-authorizing artifact for exactly its enumerated delta.
@@ -1041,7 +1077,17 @@ template beyond the epoch substitution refused (same-file smuggling);
 replay over the whole tree instead of the protected projection would
 reject a valid candidate (positive control for the projection rule);
 publisher or finalizer credentials requested outside the
-notary-publishing environment refused by secret release; well-typed but
+notary-publishing environment, or from a wrong workflow or ref, refused
+by secret release; intermediate replay projection with a path both
+terminal and directory-prefix refused as no-valid-execution;
+noncanonical JCS bytes or wrong semantic-array order refused; genesis
+inventory containing a path outside the protected domain refused;
+genesis or transition lacking a matching-digest administrative approval
+signature refused (swapped-body-after-platform-approval); path policy
+attempting to protect `.axiom/lineage` refused; bootstrap bypass
+authority retained after activation finalization failing the §9.2a
+audit; administrator bypass of the required lane check tested;
+receipt with unpublished candidate invalid to reconstruction; well-typed but
 invalid path-policy action or profile oracle_policy refused; Actions
 artifact_id mismatch refused; multi-fault ineligible record carrying
 one deterministic sorted reasons array in the pass variant (positive

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v24
+# Notary admission: design v25
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 24 folds design-review rounds 1–23
-(one hundred twenty-seven blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 25 folds design-review rounds 1–24
+(one hundred twenty-nine blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -749,7 +749,8 @@ receipt and the current finalized predecessor before ever emitting the
 required check.
 
 **Publisher — separate job, two-keyed.** Holds two separately
-constrained credentials per §9.7b — a chain credential (contents-write
+constrained credentials per §9.7b, from **two distinct App
+registrations** — a chain credential (contents-write
 on the notary repository alone) and a lane credential (checks-write and
 contents-read on the lane repository alone) — provisioned to it, never
 minted by it; publishes per §7; holds no signing capability.
@@ -1158,14 +1159,14 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
 7a. Effective-permission constraints audited per §5: signer deployment
    credentials, exact caller allowlist, Job-1 and trusted-job token
    audits, and publisher signing denial.
-7b. Publisher write confinement is physical and two-keyed: because App
-   installation permissions span the repositories an installation
-   covers, one App cannot hold contents-write on the notary repository
-   without holding it wherever else it is installed with that
-   permission — so the publisher uses **two separately constrained
-   credentials** (two Apps, or two repository- and
-   permission-downscoped installation tokens): a chain credential with
-   contents-write on the notary repository alone, and a lane credential
+7b. Publisher write confinement is physical and two-keyed: **two
+   distinct App registrations with separate private keys and disjoint
+   installation permissions** — token downscoping is not an
+   alternative, because the App credential that mints a downscoped
+   token can equally mint an undownscoped one across everything its
+   installation grants, and the audit therefore covers the **root App
+   permissions**, not only delivered tokens: a chain App with
+   contents-write on the notary repository alone, and a lane App
    with an installation holding `checks: write` and `contents: read`
    on the lane repository alone (no Commit-Status permission — branch
    protection binds the required check by App id), runtime tokens
@@ -1392,9 +1393,11 @@ registry key bytes failing base64, DER, Ed25519, or fingerprint
 validation refused; protected 100755 entry refused at base, subject,
 and inside a transition (domain-total wall); delete-then-recreate-
 executable across two finalized receipts refused by the same rule
-(positive control); approver/corpus-release and notary/corpus-release collisions refused
-per the enumerated pairs, while corpus-release/legacy_apply_root — the
-one permitted service pair — is accepted (positive control); finalization requested by rotated not-yet-finalized workflow
+(positive control); **a table-driven collision suite over every forbidden §5 pair** —
+each pair a distinct refusal case, `notary`×`review` and
+`notary`×`admin-approver` included — while
+corpus-release/legacy_apply_root, the one permitted service pair, is
+accepted (positive control); finalization requested by rotated not-yet-finalized workflow
 code validated and executed by the broker, not the workflow (positive
 control); broker refusing finalization when the pending artifact,
 predecessor, or merged tree fails validation; clean-room chain

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v12
+# Notary admission: design v13
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 12 folds design-review rounds 1–11
-(eighty blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 13 folds design-review rounds 1–12
+(eighty-six blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -93,7 +93,7 @@ field, missing field, wrong type, or duplicate key is a parse refusal.
 | `tier` (profile only) | exactly one of `"public"`, `"restricted"`, `"ci-attested"` — never a report or receipt field; consumers read tiers from the profile the receipt binds |
 | `ref` | the fully qualified Git ref string (`refs/...`) |
 | `workflow_sha_git_oid` | the commit the workflow file was loaded from, taken from the **trusted job's own OIDC `workflow_sha` claim** — normative because Job 1 and the trusted job run in the same workflow run (§5), so one authenticated claim covers both; reusable workflows are prohibited for this workflow; never the run's `head_sha`, which the workflow-run REST object reports instead of the loading commit |
-| Entry modes | six-character octal strings: `"100644"`, `"100755"`, `"120000"` |
+| Entry modes | six-character octal strings: `"100644"` and `"100755"` (the pilot admits no symlinks anywhere — charter requirement 4 rejects symlink deltas, and refusing the mode tree-wide is the total form) |
 | Paths | UTF-8 strings; sorting is bytewise over the UTF-8 encoding |
 | Semantic arrays | **one comparator everywhere**: elements order bytewise over the UTF-8 encoding of the element's sort key, which each array names — `gates` by `gate_id`, `required_gates` by `gate_id`, `acceptable_outcomes` and `reasons` by their string value, `eligible_records`/`unused_eligible_records` by digest, `ineligible_records` by `record_sha256`, `coverage_assignment` by `path`, dependency `actions` by `ref_spec`, `containers` by `image`, inventories by `path`; set-valued arrays are strictly unique on their key (JCS canonicalizes objects, not arrays — this row is what makes array bytes deterministic) |
 
@@ -106,8 +106,9 @@ the raw target bytes of the symlink blob, whatever they are. Pilot
 totality rules, applied to **whole trees** at verification, genesis, and
 finalization — not merely to diffs: a gitlink (mode 160000) anywhere in
 the tree is a refusal; a non-UTF-8 path anywhere in the tree is a
-refusal; terminal modes outside {"100644", "100755", "120000"} are a
-refusal, and "120000" only outside the protected domain. Within these
+refusal; terminal modes outside {"100644", "100755"} are a refusal —
+symlinks refuse tree-wide in the pilot, per charter requirement 4.
+Within these
 rules the manifest function is total and exact: two trees with equal
 manifests are terminal-entry-identical. Structural malformation refuses:
 input trees must be fsck-clean; a duplicate flattened terminal path —
@@ -138,6 +139,7 @@ body's schema:
 | genesis | `axiom/notary-genesis/v1` | genesis |
 | transition | `axiom/notary-transition/v1` | transition record |
 | approver | `axiom/notary-approval/v1` | receipt candidate (its body digest) |
+| admin-approver | `axiom/notary-admin-approval/v1` | genesis or transition administrative candidate (its body digest); signed by the **administrative** key of §8, never the correction-reviewer key — approving trust-root rotation is a wider power than validating a correction |
 | notary | `axiom/notary-receipt/v1` | notary receipt |
 
 Signatures are detached files beside the body (`<digest>.json`,
@@ -168,8 +170,11 @@ Signed by the producer key (non-authorizing). Fields: `schema`, `lane`,
 ```
 
 Modes are `"100644"` or `"100755"`, `null` exactly when the corresponding
-blob digest is `null`. A mode-only change is a real transition (equal blob
-digests, differing modes). `patch_note_sha256` is **opaque audit
+blob digest is `null`. A mode-only change is a transition shape the
+schema can carry, but **the pilot refuses protected-path mode changes
+outright** — charter requirement 4 rejects executable-mode deltas at
+preflight, and the pilot honors that wall rather than admitting covered
+mode transitions; relaxing it is the §11 charter-alignment decision. `patch_note_sha256` is **opaque audit
 metadata**: a producer-chosen digest of whatever diff rendering the
 runtime archived. It is never verified, carries no algorithm contract, and
 no refusal depends on it — endpoint blob digests and modes are the sole
@@ -257,10 +262,11 @@ the repository-qualified identity of the verifier code that ran.
 SHA-256 over the raw bytes of the repository-root
 `known-validation-gaps.yaml` at the base, which current mechanics
 require to be a present, bounded regular file — an absent or non-regular
-waiver file is a refusal, not an empty hash. The `diff_coverage` refusal object is itself closed:
-`{code, path | null, detail}` with a closed code enum
-(`"uncovered-path"`, `"ambiguous-assignment"`, `"inconsistent-chain"`,
-`"record-cycle"`, `"inadmissible-entry"`, `"structural"`).
+waiver file is a refusal, not an empty hash. The refusal variant's `refusal` member is itself closed:
+`{code, path | null, detail}` with the single code enum of §2.4
+(coverage and gate codes alike) — there is no `diff_coverage` refusal
+object anywhere; the pass variant's `diff_coverage` is the literal
+`"pass"` and nothing else.
 
 The profile is likewise a closed committed schema at a normative path:
 `.axiom/notary/profile.json`, schema `axiom/notary-profile/v1`, fields
@@ -281,51 +287,50 @@ fails reconciliation rather than getting signed.
 
 ### 2.5 Notary receipt (signed) — `axiom/notary-receipt/v1`
 
-The only artifact that, once finalized (§7), authorizes admission. Its
-closed schema, enumerated: `schema`, `lane`, `epoch_sha256`;
-`report_sha256`; `subject_commit_git_oid`, `subject_tree_manifest_sha256`,
-`base_commit_git_oid`, `base_tree_manifest_sha256`,
-`chain_predecessor_sha256`, `chain_predecessor_kind`, `profile_sha256`,
-`path_policy_sha256`, `corpus_release`, `waiver_set_sha256`,
-`eligible_records`, `coverage_assignment`, `unprotected_changes`,
-`dependency_pins_sha256`, `verifier` — each independently
-recomputed by the trusted side, never copied on trust; `gates` as
-declared (deduplicated, profile-complete, outcomes acceptable); `job1`:
-`{workflow_ref, workflow_sha_git_oid, ref, run_id, run_attempt,
-check_run_id, conclusion, artifact_name, artifact_id, artifact_sha256}`
-— `workflow_ref` is the OIDC `workflow_ref` claim string verbatim (one
-authoritative source and grammar; its `@`-suffix must equal `ref` or the
-receipt refuses), and `check_run_id` is the trusted job's own OIDC
-`check_run_id` claim — **run-scoped
-provenance, stated as such**: GitHub artifacts carry no producing-job or
-attempt identity, so the receipt claims only that the named artifact
-with this digest existed in this run, which the pilot requires to
-contain exactly one artifact of that name. This narrowing is safe
-because no claim-bearing field depends on the artifact — the trusted
-side recomputes them all — and gate declarations are attributed to "the
-proposing run" as a whole: a different job in the candidate's own run
-forging them is the same trust domain and the same accepted residual as
-the candidate weakening its gates. An OIDC-bound upload attestation
-tightening this to job-level is future work, out of milestone one;
+The only artifact that, once finalized (§7), authorizes admission — in
+two layers, candidate and wrapper, each a closed schema.
+
+**The candidate** (`axiom/notary-receipt-candidate/v1`) is produced by
+the `recompute` job and carries exactly: the full §2.4 pass-report
+field set — every recomputed field including `diff_coverage` (exactly
+`"pass"`), `eligible_records`, `unused_eligible_records`,
+`ineligible_records`, `coverage_assignment`, `unprotected_changes`, and
+`gates` (validated declarations: deduplicated, profile-complete,
+outcomes acceptable) — plus `report_sha256` (the reconciled proposal)
+and `job1`: `{workflow_ref, workflow_sha_git_oid, ref, run_id,
+run_attempt, check_run_id, conclusion, artifact_name, artifact_id,
+artifact_sha256}`. `workflow_ref` is the OIDC `workflow_ref` claim
+string verbatim (its `@`-suffix must equal `ref` or the candidate
+refuses), and `job1.check_run_id` is **`verify`'s** check-run id from
+the jobs-for-run lookup — the `approve` job's own OIDC `check_run_id`
+appears only in the wrapper's authorization block, never here. The
+candidate contains no authorization — nothing circular.
+
+The `job1` block is **run-scoped provenance, stated as such**: GitHub
+artifacts carry no producing-job or attempt identity, so it claims only
+that the named artifact with this digest existed in this run, which the
+pilot requires to contain exactly one artifact of that name. The
+narrowing is safe because no claim-bearing field depends on the
+artifact — the trusted side recomputes them all — and gate declarations
+attribute to the proposing run as a whole: a different job in the
+candidate's own run forging them is the same trust domain and the same
+accepted residual as the candidate weakening its gates. An OIDC-bound
+upload attestation tightening this to job-level is future work, out of
+milestone one.
+
+**The final receipt** (`axiom/notary-receipt/v1`) is exactly
+`{schema, lane, epoch_sha256, candidate_sha256, authorization}` with
 `authorization`: `{environment, approve_check_run_id,
 approval_signature_sha256}` — the `approve` job's own OIDC
 `check_run_id`, and the digest of the detached
-`axiom/notary-approval/v1` signature file (published beside the receipt
-on the chain branch). The final receipt's closed schema is exactly
-`{schema, lane, epoch_sha256, candidate_sha256, authorization}` — the
-candidate's fields are referenced by digest, never flattened, and the
-candidate body **must be published on the chain branch beside the
-receipt** (a receipt whose candidate is unpublished is unverifiable and
-invalid to reconstruction). The candidate
-(`axiom/notary-receipt-candidate/v1`) carries every §2.4-recomputed
-field plus `job1`, in the pass-report shapes, and no authorization —
-nothing circular. To remove the earlier ambiguity in one sentence:
-`job1.check_run_id` inside the candidate is **`verify`'s** check run id
-from jobs-for-run; the `approve` job's own OIDC `check_run_id` appears
-only in `authorization.approve_check_run_id`. The reviewer approval
-signs the candidate digest; the signer assembles and signs the final
-receipt. Genesis and transitions
-are distinct schemas; a receipt cannot claim their role.
+`axiom/notary-approval/v1` signature file. Candidate fields are
+referenced by digest, never flattened, and the candidate body and
+approval-signature file **must be published on the chain branch beside
+the receipt** — a receipt whose candidate or approval file is
+unpublished is unverifiable and invalid to reconstruction. The reviewer
+approval signs the candidate digest; the signer assembles and signs the
+wrapper. Genesis and transitions are distinct schemas; a receipt cannot
+claim their role.
 
 ### 2.6 Storage
 
@@ -429,7 +434,9 @@ do not exist at this level. Over the protected subset:
    protected domain, and gitlinks are refused tree-wide by §2.1.
    File/directory replacements decompose into entry deletions and
    additions and are covered as such.
-4. **Binary verdict.** `diff_coverage` is `"pass"` or a typed refusal.
+4. **Binary verdict.** The predicate outcome is `"pass"` (the pass
+   variant's `diff_coverage` literal) or a typed refusal (the refusal
+   variant's `refusal` member).
    From the enforcement epoch there is no `waived` and no `not-run`. This
    is deliberately stricter than consumer-side declaration completeness.
 
@@ -479,13 +486,16 @@ each on a fresh ephemeral runner, none reusable:
 | `publish` | no (pinned code) | the two §9.7b credentials, released only by its protected environment | none |
 
 `publish` (and the finalizer below) run in a dedicated protected
-**`notary-publishing` environment**: the merge-authorizing credentials
-are environment secrets released only to jobs on the pinned workflows
-and protected refs — "provisioned, never minted" is enforced by the
-platform's secret-release gate — borrowing the environment-gating
-mechanism the current signed-apply publisher uses for its secrets,
-while removing what that publisher still does wrong: it mints its App
-token in-job, and here minting authority never enters any job. Finalization
+**`notary-publishing` environment** with its administrator bypass
+disallowed and audited — but environment rules bind reviewers and refs,
+not workflow identity, so the credentials themselves are not
+environment secrets at all: `publish` presents its own OIDC
+(`id-token: write`) and the **external broker vends the two publisher
+tokens** against the exact identity (repository, `workflow_ref` and
+`workflow_sha`, ref, run, attempt, environment) precisely as the signer
+authenticates `approve` — a revoked, rerun, or foreign workflow gets
+nothing. Minting authority never enters any job; the current
+publisher's in-job App minting is what this replaces. Finalization
 necessarily runs after the merge, in a separate named workflow
 (`notary-finalize.yml`) triggered by the protected content ref, under
 the same environment and credential binding.
@@ -562,8 +572,8 @@ and signs. An environment-bypassed job carries no reviewer signature
 and refuses. Approval is thereby digest-bound to a completed receipt by
 signature, not by platform semantics; key material never reaches a
 runner. (This resolves the §11 approval-wording decision in the
-stronger form: `authorization.approval_context` is the reviewer
-approval-signature reference.)
+stronger form: `authorization.approval_signature_sha256` is the
+reviewer approval-signature reference.)
 
 Effective-permission constraints, not deployment assumptions (§9): the
 external signer's own deployment holds no model, generation, or
@@ -940,9 +950,8 @@ cross-scope matrix including legacy operations.
 
 **Manifests and totality:** gitlink anywhere in the tree; non-UTF-8 path
 anywhere in the tree (changed or unchanged); inadmissible terminal mode;
-symlink inside the protected domain; symlink with non-UTF-8 target bytes
-outside the protected domain manifests correctly (positive control —
-targets hash as raw bytes); manifest sort-order violation; two trees
+symlink inside the protected domain; any symlink anywhere refused (charter requirement 4, tree-wide in the
+pilot); manifest sort-order violation; two trees
 differing only by a gitlink refused rather than treated as
 manifest-equal.
 
@@ -951,7 +960,8 @@ wrong lane; wrong epoch; mode present on a null side; mode outside the
 admissible set.
 
 **Eligibility and coverage:** record present at the base (replay);
-uncovered protected change; uncovered mode-only change; overlapping
+uncovered protected change; protected mode-only change refused
+(charter wall); overlapping
 chains; transition against an unchanged path; forked, cyclic, or
 discontinuous chain; wrong starting or terminal blob/mode; malformed
 null-sides; partial record consumption; duplicate transition paths
@@ -1087,7 +1097,12 @@ signature refused (swapped-body-after-platform-approval); path policy
 attempting to protect `.axiom/lineage` refused; bootstrap bypass
 authority retained after activation finalization failing the §9.2a
 audit; administrator bypass of the required lane check tested;
-receipt with unpublished candidate invalid to reconstruction; well-typed but
+receipt with unpublished candidate or approval file invalid to
+reconstruction; sorted-but-duplicate entries refused in each set-valued
+array (acceptable_outcomes, eligible_records, unused_eligible_records,
+ineligible_records, reasons); protected-path mode change refused
+(charter wall, pilot); publisher token request from a revoked or rerun
+workflow identity vended nothing; well-typed but
 invalid path-policy action or profile oracle_policy refused; Actions
 artifact_id mismatch refused; multi-fault ineligible record carrying
 one deterministic sorted reasons array in the pass variant (positive
@@ -1099,7 +1114,8 @@ control).
   extend the path policy to composition outputs.
 - Licensed or unavailable oracles: fail closed, or visibly reduced-tier
   receipt.
-- Approval wording: `authorization.approval_context` binds durable
+- Approval wording — resolved in §5's stronger form:
+  `authorization.approval_signature_sha256` binds durable
   digest-bound reviewer evidence, or records "the protected signing
   policy authorized this receipt" (honest for plain environment
   approval; the stronger form needs an explicit approval artifact).

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v14
+# Notary admission: design v15
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 14 folds design-review rounds 1–13
-(eighty-nine blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 15 folds design-review rounds 1–14
+(ninety-five blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -37,11 +37,14 @@ unchanged in kind from today, and the receipt words them as declarations
 facts.
 
 Admission is a statement about the *delta*: the changes since the chain
-predecessor are covered. It never upgrades the provenance of older bytes.
-Pre-epoch content remains exactly what the genesis inventories say —
-v5-attested or unattested baseline — no matter how many receipts later sit
-above it; an empty-delta receipt admits nothing and changes no provenance
-status.
+predecessor are covered. It never upgrades the provenance of older
+bytes. Pre-epoch content remains exactly what the genesis inventories
+say — v5-attested or unattested baseline — no matter how many receipts
+later sit above it. **State-identical chain advances are forbidden**: a
+receipt whose base manifest equals its subject manifest refuses at
+verification — a no-op receipt admits nothing, and permitting one opens
+a stale-green race in which a no-op finalization voids a concurrently
+verified sibling after its merge window.
 
 The notary does not claim content was model-generated, and never will.
 Lineage records say where bytes came from; the notary says the recomputed
@@ -158,10 +161,12 @@ reviewer tooling).
 
 ### 2.2 Generation event — `axiom/lineage-generation/v1`
 
-Signed by the producer key (non-authorizing). Fields: `schema`, `lane`,
-`epoch_sha256`, `runtime_identity`, `model`, `cli_version`, `cli_sha256`,
-`prompt_sha256s`, `emitted_at` (informational, unverified), and
-`transitions`, sorted bytewise by path:
+Signed by the producer key (non-authorizing). Fields: `schema`,
+`lane`, `epoch_sha256`; `runtime_identity`, `model`, `cli_version` —
+non-empty JSON strings; `cli_sha256` — a digest; `prompt_sha256s` — a
+sorted, strictly unique digest array; `emitted_at` — an RFC 3339 UTC
+string, informational and unverified; and `transitions`, sorted
+bytewise by path:
 
 ```
 {path, before_blob_sha256 | null, before_mode | null,
@@ -184,8 +189,9 @@ ground truth.
 
 Signed by the actor (role `actor`) and countersigned by a protected
 reviewer key distinct from the actor's (role `review`, per the §2.1 role
-table). Fields: `schema`, `lane`, `epoch_sha256`, `actor`, `reason`,
-`predecessor_record_sha256 | null`, `transitions` as §2.2. The
+table). Fields: `schema`, `lane`, `epoch_sha256`; `actor` and
+`reason` — non-empty JSON strings; `predecessor_record_sha256 | null`;
+`transitions` as §2.2. The
 countersignature validates lineage; it never authorizes merge. Corrections
 are first-class and loud: the sanctioned response to a wrong encoding
 remains fix-the-encoder-and-re-encode, and a correction event is the
@@ -264,7 +270,10 @@ SHA-256 over the raw bytes of the repository-root
 require to be a present, bounded regular file — an absent or non-regular
 waiver file is a refusal, not an empty hash. The refusal variant's `refusal` member is itself closed:
 `{code, path | null, detail}` with the single code enum of §2.4
-(coverage and gate codes alike) — there is no `diff_coverage` refusal
+(coverage and gate codes alike), `detail` a JSON string — and
+deterministic under simultaneous faults: the reported refusal is the
+first failing rule in §3.3's evaluation order, and within that rule the
+bytewise-least affected path. There is no `diff_coverage` refusal
 object anywhere; the pass variant's `diff_coverage` is the literal
 `"pass"` and nothing else.
 
@@ -328,9 +337,15 @@ referenced by digest, never flattened, and the candidate body and
 approval-signature file **must be published on the chain branch beside
 the receipt** — a receipt whose candidate or approval file is
 unpublished is unverifiable and invalid to reconstruction. The reviewer
-approval signs the candidate digest; the signer assembles and signs the
-wrapper. Genesis and transitions are distinct schemas; a receipt cannot
-claim their role.
+approval signs the candidate digest; the signer assembles the wrapper
+**by derivation, never by input**: wrapper `lane` and `epoch_sha256`
+are copied from the candidate and verified equal to the chain's;
+`authorization.environment` is taken from `approve`'s authenticated
+OIDC claims, not from any caller value. The publisher and
+reconstruction re-verify candidate/wrapper/chain lane and epoch
+equality; a valid candidate for one lane or epoch cannot be wrapped
+into another. Genesis and transitions are distinct schemas; a receipt
+cannot claim their role.
 
 ### 2.6 Storage
 
@@ -429,11 +444,17 @@ do not exist at this level. Over the protected subset:
    the next link's before-state; the final after-state equals the path's
    state in the subject (`(null, null)` for deletions). Mode-only changes
    need a covering transition like any other change.
-3. **Admissible entries and the mode wall.** A protected path whose
-   mode differs between base and subject refuses outright — the charter
-   requirement-4 wall, encoded in the predicate itself, not only at
-   preflight; no lineage record covers a mode change in the pilot.
-   Protected paths are regular blobs (100644 or
+3. **Admissible entries and the mode wall, presence-aware.** For a
+   protected path **present at both endpoints**, differing modes refuse
+   outright; additions and deletions carry their single endpoint's mode
+   and are unaffected (the wall never fires on a null side). And the
+   wall is closed against laundering through intermediates: **every
+   consumed transition must preserve mode** (`before_mode ==
+   after_mode` whenever both are non-null), so a 100644→100755→100644
+   chain refuses at its first link regardless of matching endpoints.
+   This is the charter requirement-4 wall in the predicate itself;
+   relaxing it is the §11 charter-alignment decision. Protected paths
+   are regular blobs (100644 or
    100755) wherever they exist — symlinks are inadmissible in the
    protected domain, and gitlinks are refused tree-wide by §2.1.
    File/directory replacements decompose into entry deletions and
@@ -485,7 +506,7 @@ each on a fresh ephemeral runner, none reusable:
 | Job | Runs candidate code | Token | OIDC use |
 |---|---|---|---|
 | `verify` (Job 1) | yes | `contents: read` only, no secrets, no environment | none |
-| `recompute` | no (pinned code) | `contents: read`, `actions: read` | none |
+| `recompute` | no (pinned code) | `contents: read`, `actions: read` | reads `github.workflow_sha` from the run context — the authorized candidate-time source; the signer later compares it against `approve`'s OIDC `workflow_sha` claim and refuses on mismatch |
 | `approve` | no (pinned code) | `id-token: write` only — the control-plane lookups (`actions: read`) belong to the **signer's own credential**, not to any job | presents identity to the signer |
 | `publish` | no (pinned code) | the two §9.7b credentials, vended by the publisher-token broker against its OIDC | `id-token: write`; presents identity to the publisher-token broker |
 
@@ -609,9 +630,18 @@ on the notary repository alone) and a lane credential (checks-write and
 contents-read on the lane repository alone) — provisioned to it, never
 minted by it; publishes per §7; holds no signing capability.
 
-Trust roots for every step are committed at or digest-pinned to the
-protected base. Runtime organization variables are not trust anchors
-anywhere in the notary path.
+Trust roots for every step resolve through one normative committed
+registry: `.axiom/notary/keys.json` at the base, schema
+`axiom/notary-key-registry/v1` — a closed object mapping each role
+(`producer`, `actor`, `correction-reviewer`, `admin-approver`,
+`approver`) to its sorted, strictly unique array of authorized SPKI
+sha256 values (the notary key's SPKI is additionally pinned in the
+lane's consumer verification spec). Detached signatures validate
+against the registry entry for their role — never against a signature
+file's self-declared fingerprint — and the registry is a §4 trust
+surface: it moves only by transition, which is what key rotation is.
+Runtime organization variables are not trust anchors anywhere in the
+notary path.
 
 ## 6. Admission chain, epoch, genesis, and transitions
 
@@ -1013,8 +1043,10 @@ invalid signature, wrong encoder identity, wrong waiver binding,
 path/blob disagreement); transition whose enumerated delta contains a
 non-trust-surface path; nonexistent
 `record_sha256`; duplicate qualifying v5 records for one path; genesis
-carrying coverage; empty-delta first receipt leaving baseline provenance
-unchanged (positive control); post-epoch change vouched only by v5; v5
+carrying coverage; state-identical receipt (base manifest equals subject manifest)
+refused; mode-preserving transition rule refusing a
+100644→100755→100644 chain at its first link; protected addition and
+deletion unaffected by the mode wall (positive controls); post-epoch change vouched only by v5; v5
 record whose blob differs from its frozen pair; transition whose
 recomputed diff differs from its enumerated delta (smuggled content);
 transition evaluated under successor roots (self-authorizing rotation);
@@ -1103,7 +1135,15 @@ publisher or finalizer credentials requested from the publisher-token
 broker by a wrong workflow, ref, run, or environment vended nothing;
 publisher-token broker asked to sign, or signing broker asked for a
 write token, refused (capability separation of the two brokers);
-publishing-environment administrator bypass tested off; intermediate replay projection with a path both
+publishing-environment administrator bypass tested off; signature
+validated against a self-declared fingerprint instead of the registry
+refused; key absent from the registry role refused; registry change
+riding an ordinary candidate refused (trust surface); candidate
+workflow_sha diverging from approve's OIDC claim refused; wrapper
+lane or epoch diverging from candidate or chain refused;
+authorization.environment not derived from OIDC refused; untyped or
+empty lineage identity fields refused; simultaneous-fault refusal
+reporting the first rule and least path (positive control); intermediate replay projection with a path both
 terminal and directory-prefix refused as no-valid-execution;
 noncanonical JCS bytes or wrong semantic-array order refused; genesis
 inventory containing a path outside the protected domain refused;
@@ -1137,6 +1177,9 @@ control).
 - Custody model for the producer, actor, reviewer, and administrative
   keys (the notary key is fixed by §5/§8); reviewer custody is the open
   question deferred from the rulespec-nz custody ruling.
+- Charter alignment on modes: whether covered executable-mode
+  transitions become admissible post-pilot (charter requirement 4
+  amendment) or the wall stays permanent.
 - Newly protected paths: when a transition expands the path policy, the
   newly covered paths' current entries are inventoried in the transition
   body and carry "transition-initialized" provenance (administrative,

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v29
+# Notary admission: design v30
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 29 folds design-review rounds 1–28
-(one hundred thirty-five blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 30 folds design-review rounds 1–29
+(one hundred thirty-six blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -153,7 +153,7 @@ digest** — and a signature sidecar is named `<digest>.json.<role>.sig`
 with `<role>` one of the store's lineage scopes (`producer`, `actor`,
 `review`; chain artifacts live on the chain branch, never in the
 store, and carry their signatures under §7's chain-bundle grammar —
-the same filename pattern with the chain scopes as tokens). Each
+the same filename pattern with the chain **role names** as tokens). Each
 sidecar is canonical JSON:
 `{schema: "axiom/detached-signature/v1", body_sha256, scope,
 signer_spki_sha256, signature_base64}`. Every cross-scope verification
@@ -1032,18 +1032,27 @@ receipts, transitions, genesis, and void markers) plus `HEAD.json`
 (`{schema: "axiom/notary-head/v1", tip_sha256, tip_kind}`) as a
 convenience pointer. **Chain files follow the §2.1 grammar** — bodies
 `<digest>.json` with the stem the SHA-256 of the raw bytes, detached
-signatures `<digest>.json.<scope>.sig` with the scope name as token —
-and every signed artifact publishes as a **closed bundle in one
-commit**: genesis = body + its `genesis`-scope sidecar (the typed
-signer's) + its `admin-approver` sidecar; transition = body +
-`transition` sidecar + `admin-approver` sidecar; receipt = report
-body + candidate body + the `approver` sidecar over the candidate +
-receipt body + the `notary` sidecar over the receipt. Reports,
-candidates, markers, and `HEAD.json` are exactly the unsigned files —
-reports and candidates are bound by digest from signed bodies, and
-marker authentication is structural (below); a sidecar naming a
-marker, an unknown scope token, or any other file pattern invalidates
-the branch to reconstruction. Exactly one sidecar per (body, scope):
+signatures `<digest>.json.<role>.sig` with the **§2.1 role name as
+the token** (role names are `/`-free; scope strings are not) — and
+every signed artifact publishes as a **closed bundle in one commit**:
+genesis = body + its `genesis`-role sidecar (the typed signer's) +
+its `admin-approver` sidecar + **the four preimage bodies its
+`bootstrap_policies` digests name** (path policy, transition-path
+policy, profile, key registry — the §7 preimage rule below);
+transition = body + `transition` sidecar + `admin-approver` sidecar +
+**the new body of every trust file its delta changes**; receipt =
+report body + candidate body + the `approver` sidecar over the
+candidate + receipt body + the `notary` sidecar over the receipt.
+The unsigned files are closed by **digest-reachability, not by
+pattern**: every unsigned body on the branch must be digest-named by
+a signed body — the report by its candidate's `report_sha256`, the
+candidate by its receipt's `candidate_sha256`, preimages by
+`bootstrap_policies` or a transition delta's after-digests — while
+markers (structurally authenticated, below) and `HEAD.json` are the
+two named exceptions; an unsigned file reachable from no signed
+artifact, a sidecar naming a marker, an unknown role token, or any
+other file pattern invalidates the branch to reconstruction. Exactly
+one sidecar per (body, role):
 duplicates cannot coexist in a tree, and a later commit that adds,
 rewrites, or deletes any file of an already published bundle is
 mutation — append-only discipline identical to the lineage store's,
@@ -1068,7 +1077,8 @@ target is invalid, rejected by reconstruction. A finalization whose
 target was never pending on the branch, whose `target_kind` mismatches,
 or whose base does not equal the then-current finalized tip is invalid.
 Genesis bootstraps the branch: the branch's first two commits must be
-exactly the genesis body and its finalization marker, published by the
+exactly the complete genesis bundle and its finalization marker,
+published by the
 same CAS branch creation — a competing genesis loses the atomic
 first-push and any later genesis body or marker is invalid by the
 second-genesis rule. **Bootstrap is explicitly acyclic, policy-bound, and freeze-audited.**
@@ -1468,6 +1478,9 @@ refused; reviewer approval signature over the wrong digest refused;
 `"gates"`-stage refusal carrying its assignment (positive control);
 approval signature invalid, by the wrong key, or under the wrong scope
 refused; approval signature over a different candidate digest refused;
+a published, valid approval sidecar whose raw-file SHA-256 differs
+from `authorization.approval_signature_sha256` refused
+(wrapper/reference reconciliation);
 receipt whose candidate_sha256 mismatches the recomputed candidate
 refused; activation consumer-spec differing from the genesis-bound
 template beyond the epoch substitution refused (same-file smuggling);
@@ -1549,12 +1562,18 @@ either legacy root equal
 to any registry entry refused (each pairing a distinct test,
 corpus-release and producer included); finalized receipt whose
 referenced report is unpublished invalid to reconstruction; a bundle
-missing its notary, admin-approver, or approver sidecar never pending
-and invalid to reconstruction (a distinct case per artifact kind); a
+missing its typed-signer sidecar (`genesis`, `transition`, or
+`notary` per artifact kind) or its `admin-approver` or `approver`
+sidecar never pending
+and invalid to reconstruction (a distinct case per artifact kind and
+missing file); a genesis bundle missing any bootstrap preimage body,
+and a transition bundle missing a changed trust file's new body, each
+never pending (distinct cases); a
 later commit rewriting or deleting any published bundle file
 invalidating the branch at that commit (append-only discipline); a
-partial-bundle commit refused by the publisher; an unknown scope
-token, a sidecar naming a marker, or an unclassifiable chain file
+partial-bundle commit refused by the publisher; an unknown role
+token, a sidecar naming a marker, or an unsigned branch file
+digest-reachable from no signed artifact
 invalidating the branch to reconstruction;
 absent-profile preflight refusal carrying a truthful null digest
 (positive control);

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v5
+# Notary admission: design v6
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 5 folds design-review rounds 1–4
-(thirty-four blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 6 folds design-review rounds 1–5
+(forty-two blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -85,14 +85,14 @@ field, missing field, wrong type, or duplicate key is a parse refusal.
 | Kind | JSON encoding |
 |---|---|
 | SHA-256 digest (`*_sha256`, filenames, broker payload) | 64-char lowercase hex string, no prefix; GitHub artifact digests have their `sha256:` prefix stripped before entry |
-| Git object id (`*_git_oid`, incl. `workflow_git_oid`) | 40-char lowercase hex string (SHA-1 object format in the pilot) |
+| Git object id (`*_git_oid`, incl. `workflow_sha_git_oid`) | 40-char lowercase hex string (SHA-1 object format in the pilot) |
 | Ed25519 signature | `signature_base64`: standard base64 with padding (RFC 4648 §4) |
 | `signer_spki_sha256` | SHA-256 of the DER-encoded SubjectPublicKeyInfo, hex as above |
 | `run_id`, `run_attempt` | JSON strings (decimal), never numbers |
 | `chain_predecessor_kind` | exactly one of `"genesis"`, `"receipt"`, `"transition"` |
 | `tier` | exactly one of `"public"`, `"restricted"`, `"ci-attested"` |
 | `ref` | the fully qualified Git ref string (`refs/...`) |
-| `workflow_git_oid` | the commit oid of the workflow-defining commit for the run, as reported by the Actions control plane (`head_sha` of the run) |
+| `workflow_sha_git_oid` | the Actions `workflow_sha` of the run — the commit the workflow file was loaded from, equal to OIDC `job_workflow_sha` because the pilot prohibits reusable workflows for Job 1 (caller and called are identical); never the run's `head_sha` |
 | Entry modes | six-character octal strings: `"100644"`, `"100755"`, `"120000"` |
 | Paths | UTF-8 strings; sorting is bytewise over the UTF-8 encoding |
 
@@ -192,7 +192,25 @@ digests consumed for its chain, in chain order (the unique assignment of
 by `gate_id`, **one entry per gate id** (duplicates are a parse refusal),
 each `{gate_id, outcome, tier}`; `diff_coverage`: `"pass"` or a typed
 refusal object (never `waived`, never `not-run`); `unprotected_changes`
-(sorted paths); `dependency_pins_sha256`; `verifier_commit_git_oid`.
+(sorted paths); `ineligible_records`: sorted array of `{record_sha256, reason}` with a
+closed reason enum (`"unprotected-path-transition"`,
+`"duplicate-transition-paths"`, `"wrong-lane"`, `"wrong-epoch"`,
+`"invalid-signature"`); `dependency_pins_sha256`: the digest of a
+canonical dependency inventory — a body of schema
+`axiom/notary-dependency-inventory/v1` binding the sorted action pins
+(`[ref_spec, git_oid]`), container image digests, the SHA-256 of the
+exact Python lockfile bytes, and the verifier identity — not the digest
+of some file the prose happened to suggest; `verifier`:
+`{repo, git_oid}`, the repository-qualified identity of the verifier
+code that ran. The `diff_coverage` refusal object is itself closed:
+`{code, path | null, detail}` with a closed code enum
+(`"uncovered-path"`, `"ambiguous-assignment"`, `"inconsistent-chain"`,
+`"record-cycle"`, `"inadmissible-entry"`, `"structural"`).
+
+The profile is likewise a closed committed schema at a normative path:
+`.axiom/notary/profile.json`, schema `axiom/notary-profile/v1`, binding
+`required_gates` (sorted `{gate_id, acceptable_outcomes, tier}`) and the
+oracle policy — so `profile_sha256` has exactly one preimage.
 
 The report is a *proposal*. Refusal reports are diagnostic artifacts, and
 even a pass report authorizes nothing: every claim-bearing field is
@@ -209,15 +227,21 @@ closed schema, enumerated: `schema`, `lane`, `epoch_sha256`;
 `chain_predecessor_sha256`, `chain_predecessor_kind`, `profile_sha256`,
 `path_policy_sha256`, `corpus_release`, `waiver_set_sha256`,
 `eligible_records`, `coverage_assignment`, `unprotected_changes`,
-`dependency_pins_sha256`, `verifier_commit_git_oid` — each independently
+`dependency_pins_sha256`, `verifier` — each independently
 recomputed by the trusted side, never copied on trust; `gates` as
 declared (deduplicated, profile-complete, outcomes acceptable); `job1`:
-`{workflow_path, workflow_git_oid, ref, run_id, run_attempt, job_name,
-check_run_id, conclusion, artifact_name, artifact_id, artifact_sha256}` —
-the artifact bound to the specific producing job and attempt via the
-workflow-jobs and per-attempt artifact endpoints, since artifacts
-associate with runs (not jobs) and reruns share a `run_id`; a digest that
-cannot be tied to the claimed attempt's named artifact refuses;
+`{workflow_path, workflow_sha_git_oid, ref, run_id, run_attempt,
+conclusion, artifact_name, artifact_id, artifact_sha256}` — **run-scoped
+provenance, stated as such**: GitHub artifacts carry no producing-job or
+attempt identity, so the receipt claims only that the named artifact
+with this digest existed in this run, which the pilot requires to
+contain exactly one artifact of that name. This narrowing is safe
+because no claim-bearing field depends on the artifact — the trusted
+side recomputes them all — and gate declarations are attributed to "the
+proposing run" as a whole: a different job in the candidate's own run
+forging them is the same trust domain and the same accepted residual as
+the candidate weakening its gates. An OIDC-bound upload attestation
+tightening this to job-level is future work, out of milestone one;
 `authorization`: `{environment, approval_context}` (§11 wording
 decision). Genesis and transitions are distinct schemas; a receipt cannot
 claim their role.
@@ -284,6 +308,22 @@ do not exist at this level. Over the protected subset:
    avoids this by not shipping redundant covering records. Records
    unusable in any valid assignment (dead-end retries) are legal, listed
    as unused, and create no ambiguity.
+
+   Two whole-record rules complete the assignment's consistency. First,
+   **a repository-state execution must exist**: build the consumed-record
+   dependency graph (an edge from record X to record Y wherever, in some
+   path's chain, a transition of Y consumes the state a transition of X
+   produced); the graph must be acyclic, and applying whole records in a
+   topological order from the base must find every transition's
+   before-state current when its record applies and terminate at the
+   subject — cross-path cycles between records (X and Y each feeding the
+   other on different paths) refuse as `record-cycle`, because no
+   repository state ever contained what the subject cherry-picks.
+   Second, **correction predecessors have predicate meaning**: a consumed
+   correction event's `predecessor_record_sha256` must be null or equal
+   the digest of the immediately preceding consumed record in the same
+   path's chain; anything else refuses. It is lineage, verified — not
+   opaque metadata implementations may ignore.
 2. **Blob-and-mode ground truth.** Each chain's first
    `(before_blob_sha256, before_mode)` equals the path's state at the
    base (`(null, null)` for additions); each link's after-state equals
@@ -379,10 +419,19 @@ releases key material to a runner.
 
 Effective-permission constraints, not deployment assumptions (§9): the
 external signer's own deployment holds no model, generation, or
-repository-write credentials; the trusted recomputation job's automatic
-`GITHUB_TOKEN` is read-only (`contents: read`, nothing else) and it
-references no other secrets; and the publisher's identity is denied the
-notary signing operation by the signer's caller allowlist.
+repository-write credentials, and its caller allowlist is exact — the
+trusted recomputation job alone, identified by repository, workflow path
+and `workflow_sha`, job, run, attempt, ref, and the `notary-signing`
+environment, with `id-token: write` allocated for the OIDC proof and
+`actions: read` for control-plane lookups and nothing further. Job 1's
+token is audited to `contents: read` with no other permissions, no
+secrets, and no environment. The trusted job's `GITHUB_TOKEN` is
+read-only and it references no secrets beyond the OIDC exchange. The
+publisher's identity is denied the notary signing operation by that same
+allowlist — and because `checks:write` is itself merge-authorizing, the
+publisher is pinned candidate-free code that validates the signed
+receipt and the current finalized predecessor before ever emitting the
+required check.
 
 **Publisher — separate job.** Holds only a token whose write capability
 is confined to the notary ref by repository ruleset (App tokens scope to
@@ -473,7 +522,28 @@ only the publisher App may push; no force pushes; no deletion; linear
 history. Its contents: content-addressed artifact files (reports,
 receipts, transitions, genesis, and void markers) plus `HEAD.json`
 (`{schema: "axiom/notary-head/v1", tip_sha256, tip_kind}`) as a
-convenience pointer.
+convenience pointer. Two marker schemas complete the branch's contents:
+`axiom/notary-finalization/v1` (`{schema, lane, epoch_sha256,
+target_sha256, target_kind, merged_tip_manifest_sha256, sequence}`) and
+`axiom/notary-void/v1` (`{schema, lane, epoch_sha256, target_sha256,
+target_kind, reason}`), each content-addressed like every other
+artifact. Marker authentication is structural: the branch accepts
+commits from the publisher App alone, linear history, no force pushes —
+so markers are exactly what the pinned publisher committed, in order.
+
+The chain state machine, exhaustively: an artifact is *pending* when its
+body is on the branch with no marker naming it; *finalized* when exactly
+one finalization marker names it; *void* when a void marker names it.
+Finalized and void are terminal and mutually exclusive — the first
+marker in branch history wins, and any later marker naming the same
+target is invalid, rejected by reconstruction. A finalization whose
+target was never pending on the branch, whose `target_kind` mismatches,
+or whose base does not equal the then-current finalized tip is invalid.
+Genesis bootstraps the branch: the branch's first two commits must be
+exactly the genesis body and its finalization marker, published by the
+same CAS branch creation — a competing genesis loses the atomic
+first-push and any later genesis body or marker is invalid by the
+second-genesis rule.
 
 **Verification does not trust the pointer.** The chain's truth is
 reconstructible by rule from the branch alone: the valid chain is the
@@ -545,7 +615,12 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    any environment involved in notary authorization (#1194 re-scoped).
 4. **External signer with identity binding**: the notary key held only
    by the external typed signer; OIDC-claim validation of the requesting
-   workflow/job/run; no raw notary key material on any runner.
+   repository, workflow path and `workflow_sha`, job, run, attempt, ref,
+   and `notary-signing` environment, against an exact allowlist;
+   reusable workflows prohibited for Job 1; `id-token: write` and
+   `actions: read` allocated explicitly and nothing further; no raw
+   notary key material on any runner; Job 1's token audited to
+   `contents: read` with no secrets and no environment.
 5. **Compute isolation**: fresh ephemeral runners for the verification
    and trusted jobs.
 6. Trusted recomputation implemented (§5): every claim-bearing invariant
@@ -559,11 +634,15 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    up-to-date-with-base merges (or verified merge-group heads) on the
    protected content branch; and the two-phase pending/finalize protocol
    with supersession voiding and permanent void markers.
-7a. Effective-permission constraints audited: the external signer
-   deployment holds no model, generation, or repository-write
-   credentials; the trusted recomputation job runs with a read-only
-   `GITHUB_TOKEN` and no other secrets; the publisher identity is denied
-   the notary signing operation.
+7a. Effective-permission constraints audited per §5: signer deployment
+   credentials, exact caller allowlist, Job-1 and trusted-job token
+   audits, and publisher signing denial.
+7b. Publisher write confinement is effective, not nominal: a layered
+   ruleset denies the publisher App pushes to every ref outside the
+   chain branch (accounting for ruleset layering and bypass lists), the
+   publisher runs pinned candidate-free code, and it validates the
+   signed receipt and current finalized predecessor before emitting the
+   App-bound required check.
 8. Signed-leg billing and abuse policy operational (#1193).
 9. Key ceremony completed per §8.
 10. Org-variable trust anchors eliminated from the signing path.
@@ -583,8 +662,10 @@ Grouped by refusal site; each case is a distinct test before the pilot
 gates anything.
 
 **Schemas, encodings, signatures:** unknown/missing field; wrong type;
-number where string required (`run_id`); digest with wrong case, length,
-or retained `sha256:` prefix; wrong content-address filename; malformed
+duplicate JSON member; invalid Unicode in a body; number where string
+required (`run_id`); digest with wrong case, length, or retained
+`sha256:` prefix; unsorted semantic array (gates, records, assignment,
+inventories); wrong content-address filename; malformed
 detached-signature file; wrong scope per the role table (review
 signature under the correction scope and conversely); signature by the
 wrong key for a scope; invalid producer/actor/review/genesis/transition/
@@ -612,7 +693,12 @@ null-sides; partial record consumption; duplicate transition paths
 within a record; record containing an unprotected-path transition
 (ineligible, with reason); **ambiguous assignment (two redundant
 covering records; split-vs-direct chains)**; dead-end retry record
-accepted as unused without ambiguity (positive control); nested
+accepted as unused without ambiguity (positive control); the cross-path
+record-order cycle (two records feeding each other on different paths)
+refusing as record-cycle; correction predecessor naming a nonexistent
+record; correction predecessor mismatching the preceding consumed
+record; `unused_eligible_records` incomplete (a consumed record listed,
+or an unused one omitted); nested
 protected change reported only as its directory by a non-recursive diff
 (must refuse or be impossible under the normative diff);
 `waived`/`not-run` post-epoch; path-policy precedence cases
@@ -665,8 +751,13 @@ chain rollback or void-marker erasure visible to reconstruction;
 `HEAD.json` diverging from chain reconstruction; publisher push outside
 the chain branch rejected; `HEAD.json` naming an unpublished or unsigned
 artifact; recomputation divergence in `eligible_records`,
-`corpus_release`, `waiver_set_sha256`, `dependency_pins_sha256`, or
-`verifier_commit_git_oid`.
+`corpus_release`, `waiver_set_sha256`, `dependency_pins_sha256`, or the
+`verifier` identity; malformed finalization or void marker;
+finalization without a pending target; void-after-finalize rejected
+(first marker wins); conflicting markers for one target; finalization
+whose base is not the then-current tip; competing genesis publication
+losing the atomic branch creation; wrong `workflow_sha` (head_sha
+substituted); signer-environment or attempt binding mismatch.
 
 ## 11. Decisions for sign-off
 
@@ -681,6 +772,12 @@ artifact; recomputation divergence in `eligible_records`,
 - Custody model for the producer, actor, reviewer, and administrative
   keys (the notary key is fixed by §5/§8); reviewer custody is the open
   question deferred from the rulespec-nz custody ruling.
+- Newly protected paths: when a transition expands the path policy, the
+  newly covered paths' current entries are inventoried in the transition
+  body and carry "transition-initialized" provenance (administrative,
+  visible, distinct from v5-attested and unattested-baseline) — the
+  recommended semantics; alternative: require such paths to enter empty
+  and be populated by covered changes.
 
 ## 12. Out of scope for milestone one
 

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v19
+# Notary admission: design v20
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 19 folds design-review rounds 1–18
-(one hundred eleven blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 20 folds design-review rounds 1–19
+(one hundred sixteen blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -226,13 +226,19 @@ assignment nor a determinate unused partition); only `gates`-stage
 refusals carry `coverage_assignment`, `unused_eligible_records`,
 `unprotected_changes`, and `gates` (coverage succeeded there).
 
-| `stage` | additional required fields |
+| `stage` | `established` content |
 |---|---|
-| `"structural"` | none |
-| `"preflight"` | both tree manifests, base/chain fields, policy and profile digests |
-| `"eligibility"` | the preflight fields + `eligible_records`, `ineligible_records` |
-| `"assignment"` | the eligibility fields + `unused_eligible_records` |
-| `"gates"` | the assignment fields + `coverage_assignment`, `unprotected_changes`, `gates` |
+| `"structural"` | the all-null prefix (nothing established) |
+| `"preflight"` | whatever prefix the failing check permitted — a `policy-invalid` for an absent profile truthfully carries `profile_sha256: null` |
+| `"eligibility"` | prefix through the record lists |
+| `"assignment"` | prefix through the record lists — **never** an assignment or unused partition (an ambiguity has neither) |
+| `"gates"` | the full prefix, plus the gates-stage extras below |
+
+The prefix property is the single rule; the table describes what it
+yields per stage and never overrides it. Only `"gates"`-stage refusals
+additionally carry `coverage_assignment`, `unused_eligible_records`,
+`unprotected_changes`, and `gates` — there coverage succeeded, so all
+four are determinate.
 
 A `"gates"`-stage refusal does carry its unique assignment — coverage
 succeeded; a gate outcome did not. The refusal member is named
@@ -285,10 +291,13 @@ prerequisite order: `address-mismatch` and `malformed-record` are
 always computable; `invalid-signature`, `wrong-lane`, `wrong-epoch`,
 `duplicate-transition-paths`, and `unprotected-path-transition` apply
 only when the body parsed (never beside `malformed-record`). Entries
-are keyed by the **store-filename digest** (the name the file claims),
-not the body digest — so a valid body added at its correct path *and*
-at an alias yields one eligible record plus one ineligible
-`address-mismatch` entry, with no identity collision. Same shape in
+are keyed by `store_name` — the literal filename string under
+`.axiom/lineage/` (total over every tree: a name that is not a valid
+lowercase-hex digest, or differs from the body's digest, is simply an
+`address-mismatch` entry under its literal name) — so a valid body
+added at its correct path *and* at an alias yields one eligible record
+plus one ineligible entry, with no identity collision and no
+unrepresentable key. Same shape in
 pass and refusal variants; `dependency_pins_sha256`: the digest of a
 canonical dependency inventory, a body of schema
 `axiom/notary-dependency-inventory/v1` with the closed shape
@@ -724,7 +733,11 @@ SHA-256 equals the beside fingerprint, else the registry refuses) —
 because a fingerprint alone cannot verify a signature. Registry role names are exactly the §2.1 role-table roles —
 `producer`, `actor`, `review`, `admin-approver`, `approver` — plus
 `notary` (whose entry mirrors the SPKI pinned in the lane's consumer
-verification spec; a mismatch refuses). The three typed scopes —
+verification spec; a mismatch refuses) and `corpus-release` (the
+signed-corpus-release verification root the gate execution requires —
+today provisioned from an organization variable, which §9.10
+eliminates in favor of this registry entry; Job 1's toolchain
+verification reads it from here). The three typed scopes —
 `genesis`, `transition`, and `notary` — all resolve to the **`notary`**
 registry entry: the external typed signer signs all three with the
 notary key, and the admin-approver's separate signature is what
@@ -782,13 +795,18 @@ partition property against the manifest before signing):
   schema, not beside it);
 - `legacy_apply_root`: `{raw_key_id, public_key_spki_der_base64}` —
   the exact legacy apply public key that authenticates v5 records at
-  genesis, bound in the closed schema like every other root (the
-  conversion is normative: the raw Ed25519 key bytes wrap into a DER
-  SPKI, and `raw_key_id` is the legacy broker's key identifier for
-  cross-checking). The organization variable that supplies this root
-  today is eliminated by §9.10; a genesis validating v5 records against
-  any key other than this bound root refuses, so root substitution at
-  genesis cannot reclassify pre-epoch hand edits as attested;
+  genesis. `raw_key_id` follows the current formula normatively:
+  `"sha256:" + lowercase-hex SHA-256 of the raw 32-byte Ed25519 key`;
+  the raw key wraps into the DER SPKI for the second field, and the
+  pair must be mutually consistent or genesis refuses. Binding alone
+  proves consistency, not history — so §9 requires the historical
+  root's fingerprint to be **frozen independently before genesis**
+  (recorded in the sign-off packet and compared at ceremony time
+  against the currently provisioned production value, witnessed), and
+  the anti-reclassification claim is scoped to that precondition: given
+  the independently frozen fingerprint, root substitution at genesis
+  cannot reclassify pre-epoch hand edits as attested. The organization
+  variable supplying this root today is eliminated by §9.10;
 - `v5_attested`: sorted `[path, entry_sha256, record_sha256]` — paths
   whose blobs are vouched at genesis by a legacy record that passes the
   **current v5 authentication contract**: schema exactly
@@ -840,10 +858,13 @@ policy, repository-structure rules); the recomputed base→subject diff
 must equal `delta` exactly, every delta path must match the
 transition-path policy, and no delta path may be protected content — a
 protected-content or unclassified change smuggled into a transition
-refuses; and a path policy (or transition-path policy) whose rules
-would protect any `.axiom/lineage/` or `.axiom/notary/` path is itself
-invalid (`policy-invalid`) — the lineage store and trust files live
-outside the coverage domain by construction, not assertion;
+refuses. The two policies have opposite obligations toward the
+reserved prefixes: the **path policy** (protected-content domain) is
+invalid if it protects any `.axiom/lineage/` or `.axiom/notary/` path;
+the **transition-path policy** must **include** the `.axiom/notary/`
+trust files — that is precisely what transitions rotate — and is
+invalid if it covers `.axiom/lineage/` (the store moves by eligibility,
+never by transition);
 signatures and authorization are evaluated **under the predecessor
 state's trust roots** (the old keys and policy authorize the handover, so
 a successor-controlled key cannot self-authorize its own installation);
@@ -1107,6 +1128,15 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
 14. Golden-regeneration QA retained and audited — the charter keeps it
     as the distributional defense, §1 relies on it as a mitigation, and
     its removal fails this precondition.
+15. The legacy apply root's fingerprint frozen independently before
+    genesis (sign-off packet record, compared witnessed against the
+    production value at ceremony time), and the corpus-release root
+    migrated from its organization variable into the registry's
+    `corpus-release` entry — Job 1's toolchain verification must read
+    it from the registry before any lane activates.
+16. Genesis-time equality refusals: `legacy_apply_root` equal to the
+    `notary`, `admin-approver`, or `review` entries refuses; the
+    registry validator enforces the §5 pairwise exclusions.
 
 ## 10. Negative-test floor
 
@@ -1297,6 +1327,16 @@ consumer pin refused; waiver bytes disagreeing with the base toolchain
 pin refused; equal-manifest transition carrying a forged nonempty
 delta refused; bad newly-introduced record enumerated ineligible while
 the candidate passes (positive control — structural scope);
+non-hex or uppercase store filename enumerated address-mismatch under
+its literal store_name (positive control — total keying);
+transition-path policy covering .axiom/notary accepted and covering
+.axiom/lineage refused (the opposite obligations); corpus-release root
+absent from the registry refused; invalid corpus-release signature
+refused; raw_key_id/SPKI pair inconsistent refused; legacy root equal
+to notary, admin-approver, or review refused; finalized receipt whose
+referenced report is unpublished invalid to reconstruction;
+absent-profile preflight refusal carrying a truthful null digest
+(positive control);
 base-present invalid record inert — successor with an honest diff
 passes (positive control — no lane poison); refusal during repository
 or predecessor resolution carrying a truthful all-null established

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v25
+# Notary admission: design v27
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 25 folds design-review rounds 1–24
-(one hundred twenty-nine blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 27 folds design-review rounds 1–26
+(one hundred thirty-three blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -813,29 +813,27 @@ verification reads it from here). The three typed scopes —
 `genesis`, `transition`, and `notary` — all resolve to the **`notary`**
 registry entry: the external typed signer signs all three with the
 notary key, and the admin-approver's separate signature is what
-authorizes the administrative ones. **Role-key exclusions are enumerated pairs, nothing implicit** — and
-the governing principles are stated with them. **The `notary` SPKI is
-disjoint from every other role, without exception**, because any alias
-means a private key outside the typed signer can freshly sign the
-notary domain (domain separation prevents replay, not signing). **The
-`legacy_apply_root` is likewise disjoint from every registry role,
-without exception**: §9.15's freeze pins *which* key is the v5 root,
-never *when* its signatures were made, so the holder of an aliased
-private key could freshly sign v5 records over hand-edited bytes right
-up to the lane lock and have genesis bless them as `v5_attested` — the
-exact retroactive laundering this design exists to refuse. (The
-production signing broker already rejects an apply/corpus-release root
-collision, so the total exclusion restores deployed behavior rather
-than adding a constraint.) The
-forbidden collisions are exactly: `notary`×{every other role,
-`legacy_apply_root` included}; `legacy_apply_root`×{every registry
-role}; `producer`×{`review`, `admin-approver`,
-`approver`, `corpus-release`}; `actor`×{`review`, `admin-approver`,
-`approver`, `corpus-release`}; `review`×`admin-approver`;
-`approver`×{`producer`, `actor`, `corpus-release`}. Any listed
-collision refuses the registry; there is **no permitted service
-pair** — every role, service roles included, holds its own key. (The
-charter's separate-key requirement made
+authorizes the administrative ones. **Role-key separation is total, not enumerated**: the SPKI sets of
+all roles — the seven registry roles and `legacy_apply_root` — are
+**pairwise disjoint**, and any SPKI appearing under two roles refuses
+the registry. Four consecutive review rounds each found a pair a
+sparse forbidden-pair matrix had missed, so the contract is the
+universal rule, with no permitted alias left for an implementer to
+weigh. Two consequences carry their rationale by name. A `notary`
+alias would mean a private key outside the typed signer can freshly
+sign the notary domain (domain separation prevents replay, not
+signing). A `legacy_apply_root` alias would reopen pre-epoch
+laundering: §9.15's freeze pins *which* key is the v5 root, never
+*when* its signatures were made, so an aliased holder could freshly
+sign v5 records over hand-edited bytes right up to the lane lock and
+have genesis bless them as `v5_attested` — and the production signing
+broker already rejects an apply/corpus-release root collision, so
+totality restores deployed behavior rather than adding a constraint.
+The same shape covers every other pair — an `admin-approver` alias of
+`approver`, for one, would escalate ordinary reviewer compromise into
+authority over trust-surface rotation. Whether one person may hold two
+roles' keys is §8 custody policy; the registry contract is about keys:
+no SPKI serves two roles. (The charter's separate-key requirement made
 checkable; the cross-scope matrix alone cannot detect deliberate key
 reuse across scopes.) For every other scope,
 scope-to-registry resolution is the role table itself: a detached signature under a scope verifies
@@ -1261,7 +1259,7 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
     holder could freshly sign v5 records over hand-edited bytes before
     the lane lock and have genesis bless them (§5's window argument —
     and the production broker already rejects this collision); the
-    registry validator enforces the full §5 matrix.
+    registry validator enforces §5's total pairwise disjointness.
 
 ## 10. Negative-test floor
 
@@ -1455,12 +1453,13 @@ registry key bytes failing base64, DER, Ed25519, or fingerprint
 validation refused; protected 100755 entry refused at base, subject,
 and inside a transition (domain-total wall); delete-then-recreate-
 executable across two finalized receipts refused by the same rule
-(positive control); **a table-driven collision suite over every forbidden §5 pair** —
-the matrix now total over `notary` and `legacy_apply_root`: every
-pairing of each a distinct refusal case, `notary`×`review`,
-`notary`×`admin-approver`, and
-`corpus-release`×`legacy_apply_root` included — with an all-distinct
-registry accepted (positive control); finalization requested by rotated not-yet-finalized workflow
+(positive control); **a table-driven collision suite over every unordered role pair** —
+§5's separation is total, so the table is the full pairwise matrix
+over the seven registry roles plus `legacy_apply_root`: all
+twenty-eight pairs distinct refusal cases (`notary`×`review`,
+`admin-approver`×`approver`, and `corpus-release`×`legacy_apply_root`
+included) — with an all-distinct registry accepted (positive
+control); finalization requested by rotated not-yet-finalized workflow
 code validated and executed by the broker, not the workflow (positive
 control); broker refusing finalization when the pending artifact,
 predecessor, or merged tree fails validation; clean-room chain
@@ -1518,7 +1517,7 @@ ineligible_records occurrence, or an omitted or extra applicable
 reason;
 reusable verify job refused; duplicate prompt_sha256s refused; empty
 or wrong pinned artifact_name refused; review/admin-approver SPKI
-collision refused; approver/automation SPKI collision refused; policy
+collision refused (a member of the total suite); policy
 protecting .axiom/lineage or .axiom/notary refused as policy-invalid; intermediate replay projection with a path both
 terminal and directory-prefix refused as no-valid-execution;
 noncanonical JCS bytes or wrong semantic-array order refused; genesis

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v6
+# Notary admission: design v7
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 6 folds design-review rounds 1–5
-(forty-two blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 7 folds design-review rounds 1–6
+(fifty-one blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -90,9 +90,9 @@ field, missing field, wrong type, or duplicate key is a parse refusal.
 | `signer_spki_sha256` | SHA-256 of the DER-encoded SubjectPublicKeyInfo, hex as above |
 | `run_id`, `run_attempt` | JSON strings (decimal), never numbers |
 | `chain_predecessor_kind` | exactly one of `"genesis"`, `"receipt"`, `"transition"` |
-| `tier` | exactly one of `"public"`, `"restricted"`, `"ci-attested"` |
+| `tier` (profile only) | exactly one of `"public"`, `"restricted"`, `"ci-attested"` — never a report or receipt field; consumers read tiers from the profile the receipt binds |
 | `ref` | the fully qualified Git ref string (`refs/...`) |
-| `workflow_sha_git_oid` | the Actions `workflow_sha` of the run — the commit the workflow file was loaded from, equal to OIDC `job_workflow_sha` because the pilot prohibits reusable workflows for Job 1 (caller and called are identical); never the run's `head_sha` |
+| `workflow_sha_git_oid` | the commit the workflow file was loaded from, taken from the **trusted job's own OIDC `workflow_sha` claim** — normative because Job 1 and the trusted job run in the same workflow run (§5), so one authenticated claim covers both; reusable workflows are prohibited for this workflow; never the run's `head_sha`, which the workflow-run REST object reports instead of the loading commit |
 | Entry modes | six-character octal strings: `"100644"`, `"100755"`, `"120000"` |
 | Paths | UTF-8 strings; sorting is bytewise over the UTF-8 encoding |
 
@@ -108,7 +108,11 @@ the tree is a refusal; a non-UTF-8 path anywhere in the tree is a
 refusal; terminal modes outside {"100644", "100755", "120000"} are a
 refusal, and "120000" only outside the protected domain. Within these
 rules the manifest function is total and exact: two trees with equal
-manifests are terminal-entry-identical.
+manifests are terminal-entry-identical. Structural malformation refuses:
+input trees must be fsck-clean, and a duplicate flattened terminal path
+— which Git itself treats as an fsck error but can technically encode —
+is a manifest refusal, so per-path endpoints are always singular and
+manifest set-difference is exact.
 
 **Signature envelope.** Signing uses the existing broker frame verbatim:
 
@@ -190,27 +194,38 @@ Content-addressed output of the verification workflow. Fields: `schema`,
 digests consumed for its chain, in chain order (the unique assignment of
 §3.3); `gates`: array sorted
 by `gate_id`, **one entry per gate id** (duplicates are a parse refusal),
-each `{gate_id, outcome, tier}`; `diff_coverage`: `"pass"` or a typed
+each `{gate_id, outcome}` — tiers are not report fields at all: a gate's
+tier comes from the digest-bound profile, so a report cannot strengthen a
+classification the profile did not grant; `diff_coverage`: `"pass"` or a typed
 refusal object (never `waived`, never `not-run`); `unprotected_changes`
 (sorted paths); `ineligible_records`: sorted array of `{record_sha256, reason}` with a
 closed reason enum (`"unprotected-path-transition"`,
 `"duplicate-transition-paths"`, `"wrong-lane"`, `"wrong-epoch"`,
 `"invalid-signature"`); `dependency_pins_sha256`: the digest of a
-canonical dependency inventory — a body of schema
-`axiom/notary-dependency-inventory/v1` binding the sorted action pins
-(`[ref_spec, git_oid]`), container image digests, the SHA-256 of the
-exact Python lockfile bytes, and the verifier identity — not the digest
-of some file the prose happened to suggest; `verifier`:
-`{repo, git_oid}`, the repository-qualified identity of the verifier
-code that ran. The `diff_coverage` refusal object is itself closed:
+canonical dependency inventory, a body of schema
+`axiom/notary-dependency-inventory/v1` with the closed shape
+`{schema, lane, actions: [[ref_spec, git_oid], …] sorted by ref_spec,
+containers: [[image, digest_sha256], …] sorted by image,
+python_lock_sha256, verifier: {repo, git_oid}}`, where
+`python_lock_sha256` is SHA-256 over the raw bytes of `uv.lock` at
+`verifier.git_oid` in `verifier.repo`; `verifier`: `{repo, git_oid}`,
+the repository-qualified identity of the verifier code that ran.
+`waiver_set_sha256` adopts the existing toolchain contract: SHA-256 over
+the raw bytes of the repository-root `known-validation-gaps.yaml` at the
+base (absent file hashes the empty byte string). The `diff_coverage` refusal object is itself closed:
 `{code, path | null, detail}` with a closed code enum
 (`"uncovered-path"`, `"ambiguous-assignment"`, `"inconsistent-chain"`,
 `"record-cycle"`, `"inadmissible-entry"`, `"structural"`).
 
 The profile is likewise a closed committed schema at a normative path:
-`.axiom/notary/profile.json`, schema `axiom/notary-profile/v1`, binding
-`required_gates` (sorted `{gate_id, acceptable_outcomes, tier}`) and the
-oracle policy — so `profile_sha256` has exactly one preimage.
+`.axiom/notary/profile.json`, schema `axiom/notary-profile/v1`, fields
+`{schema, lane, required_gates, oracle_policy}` with `required_gates`
+sorted by `gate_id`, each `{gate_id, acceptable_outcomes, tier}` where
+`acceptable_outcomes` is a sorted string array, and `oracle_policy`
+exactly one of `"fail-closed"` or `"reduced-tier"` — so `profile_sha256`
+has exactly one preimage. Every committed policy body (`path-policy`,
+`transition-path-policy`, `profile`) carries `schema` and `lane` like
+any other body.
 
 The report is a *proposal*. Refusal reports are diagnostic artifacts, and
 even a pass report authorizes nothing: every claim-bearing field is
@@ -371,6 +386,14 @@ surfaces move only by transition record (§6.4).
 
 ## 5. Execution, trust boundary, and the external signer
 
+**One workflow run, two jobs.** Job 1 and the trusted job are jobs of
+the **same workflow run** — this topology is normative, because it is
+what makes workflow identity derivable: the trusted job's own OIDC token
+carries the `workflow_sha` that governed the entire run, covering Job 1
+without needing any per-job claim GitHub does not issue. The trusted job
+reads Job 1's conclusion through the jobs-for-run endpoint (by job name
+and attempt) rather than any self-asserted value.
+
 **Job 1 — verify (secretless, candidate-executing).** Runs on a fresh
 ephemeral runner (GitHub-hosted or dedicated ephemeral pool) with no
 signing capability, no model credentials, no repository-write credential.
@@ -499,8 +522,17 @@ the chain across them. Closed schema: `schema`, `lane`, `epoch_sha256`,
 after_entry_sha256 | null, after_mode | null}` restricted to
 trust-surface paths, and `reason`.
 
-Rules: the recomputed base→subject diff must equal `delta` exactly — a
-protected-content or unrelated change smuggled into a transition refuses;
+Rules: transition eligibility has a deterministic oracle — a committed
+`.axiom/notary/transition-path-policy.json` (same rule shape and
+semantics as the path policy, schema
+`axiom/notary-transition-path-policy/v1`), evaluated under the
+**predecessor** state, enumerating the trust-surface paths (workflows,
+action pins, verifier pins, trust roots, the three policy files, waiver
+policy, repository-structure rules); the recomputed base→subject diff
+must equal `delta` exactly, every delta path must match the
+transition-path policy, and no delta path may be protected content — a
+protected-content or unclassified change smuggled into a transition
+refuses;
 signatures and authorization are evaluated **under the predecessor
 state's trust roots** (the old keys and policy authorize the handover, so
 a successor-controlled key cannot self-authorize its own installation);
@@ -514,12 +546,19 @@ state.
 
 ## 7. Two-phase publication and the canonical chain
 
-The canonical chain lives on a **protected branch** —
-`refs/heads/notary/chain` — because GitHub rulesets protect branches and
-tags, not arbitrary ref namespaces, and a repository-scoped write token
-can otherwise manipulate qualified refs at will. The branch's ruleset:
-only the publisher App may push; no force pushes; no deletion; linear
-history. Its contents: content-addressed artifact files (reports,
+The canonical chain lives on a **protected branch** — `refs/heads/chain`
+— in a **dedicated notary repository** (`<lane-repo>-notary`, bound by
+name into genesis and the lane's consumer verification spec). The
+separate repository is the capability boundary rulesets cannot provide
+inside the lane repo: a Contents-write App token is repository-scoped
+and can always manipulate qualified custom refs of the repository it
+holds, so single-ref confinement inside the lane repository is not
+implementable — whereas the publisher App's contents-write installation
+covers only the notary repository, and in the lane repository it holds
+checks-write and contents-read alone. The lane repository's refs are
+physically outside the publisher's write capability. The chain branch's
+ruleset in the notary repository: only the publisher App may push; no
+force pushes; no deletion; linear history. Its contents: content-addressed artifact files (reports,
 receipts, transitions, genesis, and void markers) plus `HEAD.json`
 (`{schema: "axiom/notary-head/v1", tip_sha256, tip_kind}`) as a
 convenience pointer. Two marker schemas complete the branch's contents:
@@ -578,14 +617,26 @@ equal what was verified":
    discovered after.
 3. **Finalize.** After the merge, the finalizer (publisher job,
    triggered on the protected content ref) recomputes the merged tip's
-   tree manifest. If it equals `T1` and the artifact's base equals the
-   current finalized tip, it commits the finalization marker and
-   advances `HEAD.json` — compare-and-swap via the atomic branch update.
-   Otherwise finalization refuses, the artifact is permanently void (a
-   void marker commits to the chain branch; a voided digest can never
-   finalize), and verification reruns from the true finalized tip. A
-   pending artifact whose candidate never merges simply never finalizes;
-   the chain never advanced, so nothing strands.
+   tree manifest. Finalization requires all of: the merged tip manifest
+   equals the artifact's subject manifest; **the artifact's
+   `chain_predecessor_sha256` and kind equal the current finalized tip
+   exactly** — manifest-state agreement is not enough, because two
+   pending artifacts for the same tree naming the same predecessor are
+   distinct signed statements and only one may enter the chain; and the
+   marker's `lane`, `epoch_sha256`, `target_kind`, and
+   `merged_tip_manifest_sha256` validate against the artifact. On
+   success the finalization marker commits with the next `sequence` (a
+   strictly increasing decimal-string counter over all markers on the
+   chain; a gap or repeat invalidates the branch to reconstruction) and
+   `HEAD.json` advances — compare-and-swap via the atomic branch
+   update. **All other pending artifacts naming the superseded tip as
+   predecessor are voided in the same publisher pass** (same-state
+   siblings included). Otherwise finalization refuses, the artifact is
+   permanently void (a void marker commits to the chain branch; a
+   voided digest can never finalize), and verification reruns from the
+   true finalized tip. A pending artifact whose candidate never merges
+   simply never finalizes; the chain never advanced, so nothing
+   strands.
 
 Squash and merge-queue rewrites are therefore harmless exactly when they
 preserve the verified tree, and void the attempt exactly when they do
@@ -637,12 +688,15 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
 7a. Effective-permission constraints audited per §5: signer deployment
    credentials, exact caller allowlist, Job-1 and trusted-job token
    audits, and publisher signing denial.
-7b. Publisher write confinement is effective, not nominal: a layered
-   ruleset denies the publisher App pushes to every ref outside the
-   chain branch (accounting for ruleset layering and bypass lists), the
-   publisher runs pinned candidate-free code, and it validates the
-   signed receipt and current finalized predecessor before emitting the
-   App-bound required check.
+7b. Publisher write confinement is physical: the publisher App's
+   contents-write installation covers only the dedicated notary
+   repository (chain branch ruleset: App-only, no force push, no
+   deletion, linear history); in the lane repository it holds
+   checks-write and contents-read only. The publisher runs pinned
+   candidate-free code and validates **every merge-authorizing
+   artifact** — receipt or transition alike — signature, typed fields,
+   and current finalized predecessor under predecessor-state roots,
+   before emitting the App-bound required check.
 8. Signed-leg billing and abuse policy operational (#1193).
 9. Key ceremony completed per §8.
 10. Org-variable trust anchors eliminated from the signing path.
@@ -734,9 +788,9 @@ unfinalized transition used as predecessor; ordinary receipt attempting
 a trust-surface change.
 
 **Signer, publication, finalization:** OIDC identity mismatch (wrong
-workflow, job, run, repository, or ref); Job-1 run non-success; wrong
-`run_attempt` (artifact from an earlier attempt under the same run id);
-artifact name or producing-job mismatch; artifact digest mismatch;
+workflow, run, repository, ref, or environment); Job-1 job conclusion
+non-success via the jobs-for-run lookup; duplicate artifact name within
+the run (run-scope uniqueness violated); artifact digest mismatch;
 replayed artifact under a new run; signing a refusal report; stale base
 at recomputation; pending artifact treated as chain tip; superseded
 pending artifact voided when another candidate finalizes first (positive
@@ -757,7 +811,17 @@ finalization without a pending target; void-after-finalize rejected
 (first marker wins); conflicting markers for one target; finalization
 whose base is not the then-current tip; competing genesis publication
 losing the atomic branch creation; wrong `workflow_sha` (head_sha
-substituted); signer-environment or attempt binding mismatch.
+substituted, or any value diverging from the trusted job's OIDC
+claim); signer-environment or attempt binding mismatch; profile-tier
+strengthening impossible by construction (tiers absent from reports —
+positive control); duplicate flattened tree path refused; same-state
+sibling pending artifact voided at finalization (positive control) and
+rejected if presented later; marker with wrong lane, epoch, target
+kind, or tip manifest; marker sequence gap or repeat invalidating the
+branch; transition delta path unmatched by the transition-path policy;
+transition validated by the publisher under predecessor-state roots
+(positive control) and rejected when its signature or predecessor
+fails.
 
 ## 11. Decisions for sign-off
 

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,47 +1,54 @@
-# Notary admission: design v2
+# Notary admission: design v3
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 2 folds the first cross-family design
-review (nine blocking findings; the review record lives on #1507). Nothing
-admission-capable merges until the preconditions in §9 are satisfied and
-this document is approved by the charter's gate: an independent
-cross-family review of this concrete design plus Max's named sign-off.
+(dual-verdict, 2026-08-17). Version 3 folds design-review rounds 1 and 2
+(seventeen blocking findings total; the review record lives on #1507).
+Nothing admission-capable merges until the preconditions in §9 are
+satisfied and this document is approved by the charter's gate: an
+independent cross-family review of this concrete design plus Max's named
+sign-off, with every §11 decision closed.
 
 ## 1. Claim and threat model
 
 The notary signs one narrow claim:
 
-> Verification report `R` describes subject commit `S` (tree `H1`): under
-> verifier profile `P` and protected-path policy committed at base `B`,
-> every protected-content tree-entry change from `B` to `H1` is covered by
-> the eligible lineage set `L`, every gate in `P` produced the recorded
-> outcome, unprotected tree-entry changes are enumerated in `R`, `B` is the
-> previously admitted tip, and the protected signing policy authorized this
+> Verification report `R` describes subject tree `H1` (manifest digest
+> `T1`), reached from predecessor state `T0` recorded by chain predecessor
+> `C` (a receipt, a transition record, or genesis): under the verifier
+> profile and protected-path policy committed at the base, every
+> protected-content tree-entry change from `T0` to `T1` is covered by the
+> eligible lineage set; every gate the profile requires produced an
+> outcome the profile accepts; unprotected tree-entry changes are
+> enumerated in `R`; and the protected signing policy authorized this
 > acceptance.
 
-The claim covers exactly what the predicate checks: protected-content
-tree-entry changes. Unprotected changes (documentation, tooling) are not
-silently outside the statement — the report enumerates them, so a reader
-sees precisely what was and was not under coverage.
+Admission is a statement about the *delta*: the changes since the chain
+predecessor are covered. It never upgrades the provenance of older bytes.
+Pre-epoch content remains exactly what the genesis inventories say it is —
+v5-attested or unattested baseline — no matter how many receipts later sit
+above it; an empty-delta receipt admits nothing and changes no provenance
+status. The claim covers exactly what the predicate checks
+(protected-content tree-entry changes), and unprotected changes are
+enumerated in the report rather than silently excluded.
 
 The notary does not claim content was model-generated, and never will —
 that claim bred provenance laundering (the Path R pattern) and is retired
-with the v5 era. Lineage records say where bytes came from; the notary says
-the deterministic gates passed, coverage held, and admission chains from
-the last admitted state.
+with the v5 era. Lineage records say where bytes came from; the notary
+says the deterministic gates passed, coverage held, and admission chains
+from the last admitted state.
 
 The scenario this design closes: an agent with repository write access
 hand-edits a published rule and obtains a legitimate signature through the
 sanctioned path, with no record of the edit's origin. Two walls stop the
-*undeclared* hand edit — declared corrections are intentionally admissible,
-loudly. The capability wall: no generation surface holds the
-merge-authorizing notary capability; the notary key lives in a dedicated
-notary-only environment reachable only by the typed signing job, which runs
-no candidate code. (Generation surfaces do hold the non-authorizing
-producer key — that signs lineage, not admission.) The coverage wall: a
-changed protected path with no covering eligible lineage refuses at
-verification, regardless of who approves.
+*undeclared* hand edit — declared corrections are intentionally
+admissible, loudly. The capability wall: no generation surface holds the
+merge-authorizing notary capability; the notary key is reachable only by
+the typed signing job, on isolated compute, in a dedicated notary-only
+environment. (Generation surfaces do hold the non-authorizing producer
+key — that signs lineage, not admission.) The coverage wall: a changed
+protected path with no covering eligible lineage refuses at verification,
+and the signer independently re-enforces that verdict before signing.
 
 Residual risks accepted, per the charter: a verifier soundness bug
 deterministically accepts wrong law; candidate-controlled tests can be
@@ -51,182 +58,234 @@ regeneration QA, and oracles — not additional signatures.
 
 ## 2. Artifacts, schemas, and signature envelope
 
-### 2.1 Serialization and framing, shared by every artifact
+### 2.1 Conventions shared by every artifact
 
-- Bodies are canonical JSON (receipt-canonical serialization: UTF-16
-  code-unit key order, ECMAScript number formatting), UTF-8 bytes,
-  content-addressed by SHA-256. Digest strings are lowercase hex, always
-  written into fields whose names end in `_sha256`; no multihash prefixes.
-- Every body carries `schema` (a closed identifier, e.g.
-  `axiom/notary-receipt/v1`) and `lane` (the canonical `owner/repo`).
-  Unknown fields are a parse refusal; missing fields are a parse refusal;
-  schemas are closed-world.
-- Signatures are detached: `<digest>.json` beside `<digest>.json.sig`. No
-  in-body signature fields exist, so no exclusion rules exist.
-- Signing input is the broker's existing framing, with the domain as the
-  scope: `sign(key, domain || 0x00 || body_sha256_bytes)`. The domain
-  strings below are the complete scope set; a signature made under one
-  domain must fail verification under every other (§10 tests the full
-  pairwise matrix, legacy `apply_ed25519`/`eval_ed25519` included).
-- The signer for the notary domain is a typed operation: the trusted
-  signing component receives the typed fields of §2.4, reconstructs the
-  canonical body itself, computes its digest, and signs. No caller can
-  submit arbitrary bytes to the notary domain.
+**Serialization.** Bodies are canonical JSON (receipt-canonical
+serialization: UTF-16 code-unit key order, ECMAScript number formatting),
+UTF-8 bytes, content-addressed by SHA-256 of the body bytes. Every body
+carries `schema` (its full identifier, e.g. `axiom/notary-receipt/v1` —
+the same full string serves as the signing scope; there are no shortened
+scope names) and `lane` (canonical `owner/repo`). Schemas are
+closed-world: an unknown field, a missing field, or a wrong type is a
+parse refusal.
+
+**Identifiers and digests.** Two disjoint conventions, never mixed:
+
+- `*_git_oid`: a Git object id in the repository's object format (SHA-1
+  in the pilot repositories). Used to *locate* objects and to interact
+  with Git, the Actions control plane, and CAS. Never the
+  collision-resistance-bearing binding.
+- `*_sha256`: SHA-256 over defined content bytes. Blob digests are over
+  raw blob content. A **tree manifest digest** is SHA-256 over the
+  canonical JSON array of `[path, mode, content_sha256]` triples, sorted
+  by path, covering every blob reachable from the tree — the
+  collision-resistant description of a tree state, independent of Git's
+  object format.
+
+**Signature envelope.** Signing uses the existing broker frame verbatim:
+
+```
+"axiom-encode/external-signer-sign/v2" || 0x00 || scope || 0x00 || payload
+```
+
+where `scope` is the artifact's full schema identifier and `payload` is
+the 64-byte lowercase-hex ASCII encoding of the body's SHA-256.
+Signatures are detached files beside the body: `<digest>.json` and
+`<digest>.json.<role>.sig`, where `<role>` is `producer`, `actor`,
+`review`, `genesis`, `transition`, or `notary`. Each `.sig` file is
+canonical JSON: `{schema: "axiom/detached-signature/v1", body_sha256,
+scope, signer_spki_sha256, signature_base64}`. A signature under one
+scope must fail verification under every other scope, legacy
+`apply_ed25519`/`eval_ed25519` operations included (§10 tests the full
+pairwise matrix).
+
+**Typed signing.** For the notary and transition scopes, the trusted
+signing component accepts only the typed fields of §2.5/§6.4,
+reconstructs the canonical body itself, computes its digest, and signs.
+No caller can submit arbitrary bytes to those scopes. Lineage scopes
+(producer, actor, review) are signed at their origins (supervised
+runtime; actor and reviewer tooling) under the same envelope.
 
 ### 2.2 Generation event — `axiom/lineage-generation/v1`
 
 Signed by the supervised-runtime producer key (non-authorizing). Fields:
 `schema`, `lane`, `epoch_sha256` (§6), `runtime_identity`, `model`,
-`cli_version`, `cli_sha256`, `prompt_sha256s`, `emitted_at` (informational,
-unverified), and `transitions`: an array sorted by path, each
-`{path, before_blob_sha256 | null, after_blob_sha256 | null,
-patch_sha256, patch_algorithm}`. `null` before-side is an addition; `null`
-after-side is a deletion. `patch_algorithm` names a versioned canonical
-patch recipe (`git-patch-v1`: `git diff --no-renames --full-index --binary
--U3` with `core.autocrlf=false`, no textconv, no external diff, path
-attributes ignored); the patch digest is audit metadata — blob digests are
+`cli_version`, `cli_sha256`, `prompt_sha256s`, `emitted_at`
+(informational, unverified), and `transitions`: an array sorted by path,
+each:
+
+```
+{path, before_blob_sha256 | null, before_mode | null,
+ after_blob_sha256 | null, after_mode | null,
+ patch_sha256, patch_algorithm}
+```
+
+Modes are restricted to `"100644"` and `"100755"`; the mode is `null`
+exactly when the corresponding blob digest is `null` (absent side). A
+mode-only change is a real transition (same blob digests, differing
+modes). `patch_algorithm` names a versioned canonical recipe
+(`git-patch-v1`: `git diff --no-renames --full-index --binary -U3` with
+`core.autocrlf=false`, no textconv, no external diff, attributes
+ignored); the patch digest is audit metadata — blob digests and modes are
 ground truth.
 
 ### 2.3 Correction event — `axiom/lineage-correction/v1`
 
-Signed by the actor's key and countersigned (a second detached signature
-under `axiom/lineage-correction-review/v1`) by a protected reviewer key
-distinct from the actor's. Fields: `schema`, `lane`, `epoch_sha256`,
-`actor`, `reason`, `predecessor_record_sha256 | null`, and `transitions` as
-in §2.2. The countersignature validates lineage — it never authorizes
-merge. Corrections are first-class and loud: the sanctioned response to a
-wrong encoding remains fix-the-encoder-and-re-encode, and a correction
-event is the recorded exception, never the quiet path.
+Signed by the actor's key (role `actor`) and countersigned by a protected
+reviewer key distinct from the actor's (role `review`, scope
+`axiom/lineage-correction-review/v1` over the same body digest). Fields:
+`schema`, `lane`, `epoch_sha256`, `actor`, `reason`,
+`predecessor_record_sha256 | null`, and `transitions` as in §2.2. The
+countersignature validates lineage — it never authorizes merge.
+Corrections are first-class and loud: the sanctioned response to a wrong
+encoding remains fix-the-encoder-and-re-encode, and a correction event is
+the recorded exception, never the quiet path.
 
 ### 2.4 Verification report (Job 1, unsigned) — `axiom/notary-report/v1`
 
 Content-addressed, produced by the secretless verify job. Fields:
 
 - `schema`, `lane`, `epoch_sha256`
-- `subject_commit`, `subject_tree_sha256`
-- `base_commit`, `base_tree_sha256`
-- `previous_receipt_sha256` (the receipt this admission chains from;
-  genesis reference for the first)
-- `profile_sha256` (digest of the profile definition file committed at
-  `B`), `path_policy_sha256` (likewise; §3.1)
+- `subject_commit_git_oid`, `subject_tree_manifest_sha256`
+- `base_commit_git_oid`, `base_tree_manifest_sha256`
+- `chain_predecessor_sha256` (receipt, transition record, or genesis body
+  digest) and `chain_predecessor_kind`
+- `profile_sha256`, `path_policy_sha256` (digests of the definition files
+  committed at the base)
 - `corpus_release`: `{name, content_sha256}` (the toolchain tuple)
 - `waiver_set_sha256`
 - `eligible_records`: sorted array of record digests (§3.2), and
-  `eligible_records_sha256` over that array's canonical bytes
-- `gates`: sorted array of `{gate_id, outcome, tier}` with `tier` in
+  `unused_eligible_records`: sorted subset not consumed by the assignment
+- `gates`: sorted array of `{gate_id, outcome, tier}`, `tier` in
   `public | restricted | ci-attested`
-- `diff_coverage`: `"pass"` or a refusal object (never `waived`, never
-  `not-run`)
-- `unprotected_changes`: sorted array of paths changed outside the
+- `diff_coverage`: `"pass"` or a typed refusal object (never `waived`,
+  never `not-run`)
+- `unprotected_changes`: sorted array of changed paths outside the
   protected domain
-- `dependency_pins_sha256`: digest of the exact resolved dependency set of
-  the verifier run
-- `verifier_commit`: the axiom-encode commit whose code ran Job 1
+- `dependency_pins_sha256`, `verifier_commit_git_oid`
 
-The report cannot contain the authorization, which does not exist until
-Job 2; the receipt binds the two.
+A report may record a refusal — refusal reports are diagnostic artifacts.
+Nothing downstream may sign one: the signer enforces acceptance itself
+(§5), never inferring it from a job's success.
 
 ### 2.5 Notary receipt (Job 2, signed) — `axiom/notary-receipt/v1`
 
-The only artifact signed under the notary domain, by `notary_ed25519`.
-Fields:
+The only merge-authorizing artifact, signed under the notary scope by
+`notary_ed25519`. Fields:
 
 - `schema`, `lane`, `epoch_sha256`
 - `report_sha256`
-- `subject_commit`, `subject_tree_sha256`, `base_commit`,
-  `previous_receipt_sha256` (copied from the report after independent
-  re-derivation; a mismatch is a refusal, §5)
+- `subject_commit_git_oid`, `subject_tree_manifest_sha256`,
+  `base_tree_manifest_sha256`, `chain_predecessor_sha256`,
+  `chain_predecessor_kind` — each independently re-derived by the signing
+  component and required to match the report (a mismatch is a refusal,
+  §5)
 - `job1`: `{workflow_path, workflow_sha, ref, run_id, run_attempt,
   conclusion, artifact_sha256}` as read from the Actions control plane by
   the signing component itself
-- `authorization`: `{environment, approval_context}` — the protected
-  signing policy reference (see §11 for the wording decision)
-- `genesis`: boolean, `false` for every ordinary receipt (§6)
+- `authorization`: `{environment, approval_context}` (§11 wording
+  decision)
+
+There is no `genesis` flag: genesis and transitions are distinct schemas
+(§6), and a receipt claiming their role fails its closed schema.
 
 ### 2.6 Storage
 
 Lineage records live in the lane repository under `.axiom/lineage/`,
-append-only, one body file per record named by its content digest, with its
+append-only, one body file per record named by its content digest, with
 detached signatures beside it. The lineage directory is outside the
 protected-content coverage domain (its additions need no covering record)
-but inside the preflight's structural checks: schema-valid, authenticated,
-correctly content-addressed, append-only. Deleting or mutating an existing
-lineage record is a refusal. Receipts and reports publish per §7 and are
-never part of the subject tree.
+but inside the preflight's structural checks: schema-valid,
+authenticated, correctly content-addressed, append-only. Deleting or
+mutating an existing lineage record is a refusal. Reports, receipts,
+genesis, and transition records publish per §7 and are never part of the
+subject tree.
 
 ## 3. The diff-coverage predicate
 
 ### 3.1 Protected paths, defined normatively
 
-The protected-path policy is a committed file at `B`
-(`.axiom/notary/path-policy.json`): an ordered list of include/exclude
-prefix rules over UTF-8 paths, closed under the same canonical JSON rules.
-Its digest enters the report as `path_policy_sha256`. Classification uses
-the policy committed at `B` — a candidate cannot reclassify paths in its
-own favor, and a policy change is a trust-surface change the preflight
-refuses from candidates (§4). For the rulespec-nz pilot the policy covers
-the atomic rule roots; whether `programs/` composition outputs enter the
-domain is a §11 decision.
+The protected-path policy is a committed file at the base
+(`.axiom/notary/path-policy.json`):
+
+```
+{schema: "axiom/notary-path-policy/v1",
+ rules: [{action: "include" | "exclude", prefix: "<path prefix>"}]}
+```
+
+Semantics, exactly: a prefix matches path `p` iff `p == prefix` or `p`
+begins with `prefix + "/"` — component-wise, so `rules` never matches
+`rules-evil/x`. Rules are evaluated in order; the **last** matching rule
+decides; a path matching no rule is **unprotected**. Prefixes and paths
+are UTF-8 strings. Classification uses the policy committed at the base —
+a candidate cannot reclassify paths in its own favor, and a policy change
+is a trust-surface change ordinary candidates cannot carry (§4; it moves
+by transition record, §6.4).
+
+Totality rule for undecodable names: any changed path anywhere in the
+base→subject diff that is not valid UTF-8 is a refusal in the pilot —
+protected or not — because neither the policy nor the report's JSON
+arrays can represent it faithfully.
 
 ### 3.2 Eligible lineage set
 
-Eligible records for a verification are exactly the records whose body
-files are present under `.axiom/lineage/` in `H1` and absent in `B` —
+Eligible records are exactly the records whose body files are present
+under `.axiom/lineage/` in the subject tree and absent at the base —
 introduced by this candidate — and which carry this `lane` and this
-`epoch_sha256`. The sorted digest list is bound into the report. This rule
-is what defeats replay: a record merged by an earlier candidate is present
-in `B` and therefore ineligible ever after; a record from another lane or
-epoch refuses on its bindings; and transitions chain from `B`'s actual
-blobs (§3.3), so a stale record whose before-digests no longer match `B`
-refuses even inside its introducing candidate.
+`epoch_sha256`. The sorted digest list is bound into the report. This
+defeats replay: a record merged by an earlier candidate is present at the
+base and ineligible ever after; a cross-lane or cross-epoch record
+refuses on its bindings; a stale record whose before-digests no longer
+match the base refuses in replay (§3.3).
 
-Records are consumed atomically: all of a record's transitions must be used
-by the covering assignment, or the record is unused entirely. A partially
-matching record is a refusal, not a partial cover. Unused eligible records
-are listed in the report (they are legal — a retried generation — but
-never invisible).
+Records are consumed atomically: all of a record's transitions used by
+the covering assignment, or none. A partially matching record is a
+refusal. Unused eligible records are legal (a retried generation) and are
+listed in the report — never invisible.
 
 ### 3.3 The predicate
 
-Compute the tree-entry diff from `B` to `H1` with rename detection
-disabled (`git diff-tree --no-renames` semantics): the diff is a set of
-per-path entry changes — additions, deletions, and modifications. Renames
-do not exist at this level and need no special rule; a moved file is a
-deletion needing a deletion transition and an addition needing an addition
-transition. Then, over the protected subset:
+Compute the tree-entry diff from base tree to subject tree with rename
+detection disabled (`git diff-tree --no-renames` semantics): a set of
+per-path entry changes — additions, deletions, modifications, including
+mode-only modifications. Renames do not exist at this level; a moved file
+is a deletion and an addition, each needing coverage. Then, over the
+protected subset:
 
 1. **Closed-world assignment.** Every changed protected path maps to
-   exactly one non-forking chain of transitions drawn from eligible
-   records — no missing, no overlapping, no extra transitions against
-   unchanged paths, no cycles, no forks.
-2. **Blob-digest ground truth.** Each chain's first before-digest equals
-   the path's blob at `B` (or `null` for an addition); each link's
-   after-digest equals the next link's before-digest; the last
-   after-digest equals the path's blob at `H1` (or `null` for a deletion).
+   exactly one non-forking, non-cyclic chain of transitions drawn from
+   eligible records — no missing, no overlapping, no extra transitions
+   against unchanged paths.
+2. **Blob-and-mode ground truth.** Each chain's first
+   `(before_blob_sha256, before_mode)` equals the path's state at the
+   base (`(null, null)` for an addition); each link's after-state equals
+   the next link's before-state; the last after-state equals the path's
+   state in the subject tree (`(null, null)` for a deletion). A mode-only
+   change requires a covering transition like any other change.
 3. **Admissible entries only.** Protected paths must be regular blobs
-   (mode 100644 or 100755) on both sides where they exist. A gitlink,
-   symlink, or other mode at a protected path — at `B` or `H1` — is a
-   refusal. Protected paths must be valid UTF-8; a non-UTF-8 path inside
-   the protected domain is a refusal. File-to-directory and
-   directory-to-file replacements decompose into entry deletions and
-   additions and are covered as such.
+   (mode 100644 or 100755) wherever they exist. A gitlink, symlink, or
+   other mode at a protected path — either side — is a refusal.
+   File-to-directory and directory-to-file replacements decompose into
+   entry deletions and additions and are covered as such.
 4. **Binary verdict.** `diff_coverage` is `"pass"` or a typed refusal.
    From the enforcement epoch there is no `waived` and no `not-run`; an
-   emergency change without a countersigned correction event is a refusal.
-   This is deliberately stricter than consumer-side declaration
-   completeness, which by design accepts declared `waived`/`not-run`
-   outcomes as well-formed.
+   emergency change without a countersigned correction event is a
+   refusal. This is deliberately stricter than consumer-side declaration
+   completeness, which accepts declared `waived`/`not-run` outcomes as
+   well-formed.
 
 Advisory shadow runs (compute and publish the verdict without gating) are
 permitted only before a lane's enforcement epoch.
 
 ## 4. Verifier profile P and trusted preflight
 
-The profile is a committed definition at `B`, digest-bound into the report.
-It is not the current apply path, and the differences are the point:
+The profile is a committed definition at the base, digest-bound into the
+report. It defines the gate set, each gate's acceptable outcomes, and the
+oracle policy. It is not the current apply path, and the differences are
+the point:
 
 - **Non-mutating.** No deterministic repairs. The subject is verified as
-  presented or refused. A repairable-but-unrepaired subject refuses.
+  presented or refused; a repairable-but-unrepaired subject refuses.
 - **Oracles on.** The apply overlay's oracle disablement does not exist
   here. Licensed or unavailable oracles follow the §11 decision — fail
   closed, or a visibly reduced-tier receipt; never silent.
@@ -234,51 +293,62 @@ It is not the current apply path, and the differences are the point:
   approval.** The validator pipeline's LLM reviewers are QA outside the
   admission path, beside golden regeneration; under the charter's
   no-model-calls rule they cannot gate the notary.
-- **No caller switches.** Skip flags and caller-disableable guards have no
-  notary equivalents.
+- **No caller switches.** Skip flags and caller-disableable guards have
+  no notary equivalents.
 
 The trusted preflight (runs in Job 1, from pinned code, before any
-candidate code executes) resolves: the canonical repository; the admissible
-base (`B` must equal the tip admitted by `previous_receipt` — §6); the
-path policy and profile at `B`; the complete tree-entry diff. It refuses
-candidate changes to workflows, action pins, verifier pins, trust roots,
-the path policy, the profile, waiver policy, repository structure rules,
-and the lineage-record store's integrity (§2.6). Those surfaces move only
-through separately privileged flows.
+candidate code executes) resolves: the canonical repository; the chain
+predecessor and its recorded state (§6); the path policy and profile at
+the base; the complete tree-entry diff. It refuses ordinary candidates
+that change workflows, action pins, verifier pins, trust roots, the path
+policy, the profile, waiver policy, repository-structure rules, or the
+lineage store's integrity (§2.6). Those surfaces move only by transition
+record (§6.4).
 
-## 5. Jobs and capability separation
+## 5. Jobs, compute isolation, and capability separation
 
-**Job 1 — verify (secretless).** Runs candidate code under the strict
-profile with no signing capability, no model credentials, and no
-repository-write credential. Emits the §2.4 report as a content-addressed
-artifact.
+**Job 1 — verify (secretless, isolated).** Runs candidate code under the
+strict profile on a **fresh ephemeral runner** (GitHub-hosted, or a
+dedicated ephemeral pool with per-job teardown) with no signing
+capability, no model credentials, and no repository-write credential.
+Emits the §2.4 report as a content-addressed artifact.
 
-**Job 2 — sign (typed, notary-only).** Runs in a **dedicated
-`notary-signing` environment** — not `production-signing`, which today
-provisions generation workflows with the apply key, a model credential,
-and later a write-capable token, and is therefore structurally
-disqualified from holding the notary key. The environment enforces
-required human reviewers, protected refs, no self-approval, and
-Job-2-only secret access. Job 2 runs no candidate code and holds no model
-or repository-write credential. Its trusted component:
+**Job 2 — sign (typed, notary-only, isolated).** Runs on a fresh
+ephemeral runner in a **dedicated `notary-signing` environment** — not
+`production-signing`, which today provisions generation workflows with
+the apply key, a model credential, and a write-capable token, and is
+structurally disqualified from holding the notary key. The environment
+enforces required human reviewers, protected refs, no self-approval, and
+Job-2-only secret access; the signer additionally binds the requesting
+workflow and job identity, so a leaked approval cannot be replayed from
+elsewhere. Job 2 runs no candidate code and holds no model or
+repository-write credential. Its trusted component:
 
 1. Reads the Job-1 run from the Actions control plane: workflow path and
-   sha, ref, run id and attempt, conclusion, artifact digest. A wrong
-   workflow, wrong ref, non-success conclusion, or artifact digest
-   mismatch is a refusal.
-2. Independently re-fetches and re-hashes `S`, `H1`, `B`, the report body,
-   the profile and path-policy files at `B`, and re-derives
-   `previous_receipt` admissibility. Any mismatch discards the run and
-   forces complete reverification.
-3. Reconstructs the §2.5 receipt body from typed fields and signs its
-   digest under the notary domain. It exposes no arbitrary-byte signing
+   sha, ref, run id and attempt, conclusion, artifact digest. Wrong
+   workflow, wrong ref, non-success conclusion, or artifact mismatch
+   refuses.
+2. Independently re-fetches and re-hashes the subject and base trees
+   (recomputing both tree manifests), the report body, and the profile
+   and path-policy files at the base; independently re-derives the chain
+   predecessor and its admissibility (§6). Any mismatch with the
+   report's fields discards the run and forces complete reverification.
+3. **Enforces the acceptance predicate itself**: `diff_coverage` is
+   exactly `"pass"`; every gate the profile requires is present with an
+   outcome the profile accepts; the report's eligible and unused record
+   lists are well-formed against the trees. A refusal report — however
+   successfully its workflow concluded — is never signable. Actions
+   success is context, not acceptance.
+4. Reconstructs the §2.5 receipt body from typed fields and signs its
+   digest under the notary scope. It exposes no arbitrary-byte signing
    operation.
 
-**Publisher — a third job.** Both verification and signing forbid
+**Publisher — a third job.** Verification and signing forbid
 repository-write capability, so neither publishes. A separate publisher
-job — the pattern the current signed-apply workflow already uses for its
-App-token step — holds only a write token scoped to the receipt
-publication ref, and pushes per §7. It holds no signing capability.
+job holds only a token whose write capability is confined to the receipt
+publication ref — enforced by a repository ruleset, since App tokens
+scope to repositories, not refs — and pushes per §7. It holds no signing
+capability.
 
 Trust roots for all jobs — public keys, profile and policy digests,
 workflow and action pins, waiver authorities — are committed at or
@@ -286,130 +356,182 @@ digest-pinned to the protected base. Runtime organization variables are
 not trust anchors anywhere in the notary path; eliminating the existing
 `vars.*` provisioning from the signing path is a §9 precondition.
 
-## 6. Admission chain, epoch, and genesis
+## 6. Admission chain, epoch, genesis, and transitions
 
-Admission is a chain, receipt to receipt:
+### 6.1 The chain
 
-- Every ordinary receipt names `previous_receipt_sha256`, and its
-  `base_commit` must be that receipt's `subject_commit`. Verifying any
-  other base refuses. An uncovered edit therefore cannot launder itself by
-  becoming the base of the next verification: the base that skipped it is
-  not the admitted tip.
-- **Genesis** is a distinct artifact — `axiom/notary-genesis/v1`, signed
-  under its own domain — not an ordinary receipt. It binds: the lane, the
-  epoch identifier (`epoch_sha256` = digest of the genesis body), the
-  pinned genesis commit and tree, and a **frozen grandfather set**: the
-  digest of the exact v5 record and blob pairs present at genesis. Genesis
-  records state; it does not assert the baseline content was admitted, and
-  it covers nothing. It cannot recur: a second genesis for a lane refuses.
-- The first ordinary receipt uses the genesis as `previous_receipt` and
-  the genesis commit as `B`.
-- **Dual-era rule.** Pre-epoch content stands under the frozen v5
-  grandfather set: a v5 manifest vouches post-epoch only for a path whose
-  blob is byte-identical to its grandfathered pair. Any post-epoch change
-  to any protected path requires notary-era lineage; v5 records cover the
-  pre-epoch bytes only, and new v5 records have no post-epoch standing.
+Every receipt names its chain predecessor: a prior receipt, a transition
+record, or genesis. The receipt's `base_tree_manifest_sha256` must equal
+the predecessor's subject (for receipts and transitions) or recorded
+baseline (for genesis). Verifying from any other base refuses: an
+uncovered edit cannot launder itself by becoming the base of the next
+verification, because the state that skipped it is not the recorded
+chain tip. Commit ids locate; tree manifests bind — so squash and
+merge-queue rewrites are harmless when they preserve the verified tree,
+and void the run when they do not (§7).
 
-Pilot bootstrap on rulespec-nz: pin the lane's current main commit as
-genesis. No historical lineage is invented; the baseline is grandfathered
-as-is, visibly, in the frozen set — including any pre-epoch hand edits,
-which genesis records but does not bless as admitted.
+### 6.2 Genesis — `axiom/notary-genesis/v1`
 
-## 7. Publication
+A distinct artifact signed under its own scope by the administrative
+authority (§6.4's signer). Its body binds: `schema`, `lane`,
+`genesis_commit_git_oid`, `genesis_tree_manifest_sha256`, and two frozen
+inventories over the protected domain at genesis:
 
-The publisher pushes the receipt (and its report) as a detached
-attestation ref referencing `subject_commit`, compare-and-swap;
-alternatively as a mechanical receipt-only child commit whose sole delta
-is the receipt files. If the protected ref or the candidate moves between
-verification and publication, the CAS fails, the verification is
-discarded, and the run repeats from the new admitted tip. The receipt
-distinguishes `subject_commit`, `subject_tree_sha256`, and
-`verifier_commit`; the attestation ref supplies the publication location
-without entering the signed body.
+- `v5_attested`: sorted `[path, content_sha256, record_sha256]` triples —
+  paths whose blobs are vouched by an authenticated v5 record at genesis;
+- `baseline_unattested`: sorted `[path, content_sha256]` pairs — paths
+  with no authenticating record, recorded visibly, including any
+  pre-epoch hand edits. Recorded is not blessed: these bytes carry
+  "unattested baseline" provenance permanently.
+
+The **epoch identifier is the genesis body's content digest**. The body
+contains no epoch field — it *is* the epoch — so every other artifact's
+`epoch_sha256` refers to it without a self-hash fixed point. A second
+genesis for a lane refuses; genesis covers nothing and admits nothing.
+
+### 6.3 Dual-era rule
+
+Post-epoch, a v5 record vouches only for a path whose blob is
+byte-identical to its `v5_attested` pair in the frozen inventory. Any
+post-epoch change to any protected path requires notary-era lineage; new
+v5 records have no post-epoch standing; a path in `baseline_unattested`
+stays unattested until a covered change replaces it.
+
+### 6.4 Transition records — `axiom/notary-transition/v1`
+
+Privileged trust-surface updates (path policy, profile, workflow or
+action pins, trust roots, waiver policy, key rotation) cannot receive
+ordinary receipts — the preflight refuses them from candidates — and
+without a dedicated mechanism the chain would deadlock at the first key
+rotation. A transition record is that mechanism: signed under its own
+scope by the administrative authority through the `notary-signing`
+environment's human approval, its body binds `schema`, `lane`,
+`epoch_sha256`, `chain_predecessor_sha256` and kind, the old and new
+tree manifest digests, the enumerated trust-surface delta (paths and
+before/after digests), and `reason`. A transition covers only
+trust-surface paths — a protected-content change smuggled into a
+transition refuses — and becomes a valid chain predecessor. Ordinary
+admission resumes from its recorded state.
+
+## 7. Publication and the canonical head
+
+The publisher pushes the receipt (with its report) to the lane's
+canonical attestation ref, compare-and-swap. A signed receipt is **void
+until published**: the chain reads only the canonical ref, so a
+CAS-losing or stale signed receipt never becomes chain-eligible, and
+re-verification from the true tip is the only path forward. At
+publication the publisher verifies the protected ref's tip tree manifest
+equals the receipt's subject tree manifest; a merge that produced a
+different tree (a conflicted queue merge, a stale squash) fails the
+check, voids the receipt, and reruns. The receipt distinguishes
+subject/base tree manifests, subject commit oid, and
+`verifier_commit_git_oid`; the attestation ref supplies location without
+entering the signed body.
 
 ## 8. Key ceremony
 
-Before Job 2 exists: generate `notary_ed25519` with documented custodians,
-fingerprint published in committed code (consumer verification specs pin
-the SPKI), storage and rotation procedure, revocation and recovery
-procedure. The producer key, actor keys, and reviewer countersignature key
-get the same treatment under their own domains. §10's pairwise cross-domain
-matrix is part of ceremony acceptance. Rotation is loud, by reviewed change
-to committed pins, exactly as the consumer-side verifier already requires.
+Before Job 2 exists: generate `notary_ed25519` with documented
+custodians, fingerprint published in committed code (consumer
+verification specs pin the SPKI), storage and rotation procedure
+(rotation is a §6.4 transition), revocation and recovery procedure. The
+producer, actor, reviewer, and administrative keys get the same treatment
+under their own scopes. §10's pairwise cross-scope matrix is part of
+ceremony acceptance.
 
 ## 9. Preconditions (nothing admission-capable merges before these)
 
-1. This document approved — threat model, schemas and signature envelope,
-   predicate, profile, chain/epoch/genesis rules, and the §10 suite — by
-   the charter's gate: an independent cross-family review of the concrete
-   design plus **Max's named sign-off**, with every §11 decision closed.
+1. This document approved — threat model, schemas and envelope,
+   predicate, profile, chain/epoch/genesis/transition rules, and the §10
+   suite — by the charter's gate: an independent cross-family review of
+   the concrete design plus **Max's named sign-off**, with every §11
+   decision closed.
 2. The reviewers-semantics resolution in §4 accepted.
 3. The dedicated `notary-signing` environment created and enforcing:
-   required reviewers, protected refs, no self-approval, Job-2-only secret
-   access (#1194 re-scoped to the new environment) — and the generation
-   workflows migrated off any environment that will hold the notary key.
-4. The authenticated Job-1 handoff and typed Job-2 reconstruction of §5
-   implemented in the trusted signing component (no raw-byte notary
-   scope).
-5. The publisher split of §5 implemented; neither verify nor sign holds a
-   write credential.
-6. Signed-leg billing and abuse policy operational (#1193).
-7. Notary key ceremony completed per §8.
-8. Org-variable trust anchors eliminated from the signing path in favor of
-   committed or digest-pinned roots.
-9. rulespec-nz consumer-side pins landed: the notary SPKI and epoch in the
-   lane's committed verification spec; the notary check required and
-   non-bypassable in branch protection; genesis activated atomically with
-   enforcement.
-10. The generated-file guard hardcoded in the protected shared workflow
-    (its caller-controlled boolean retired), per the charter's migration
-    step 3 — merge-time defense in depth during dual-era operation.
-11. Retirement of lane signed-apply legs (#1195) is a cutover exit
+   required reviewers, protected refs, no self-approval, Job-2-only
+   secret access — with generation workflows migrated off any
+   environment that will hold the notary key (#1194 re-scoped).
+4. **Compute isolation**: Jobs 1 and 2 on fresh ephemeral runners (or a
+   dedicated ephemeral pool), and signer-side workflow/job identity
+   binding, so no candidate-code persistence can reach the notary
+   operation.
+5. The authenticated Job-1 handoff, typed Job-2 reconstruction, and
+   Job-2 acceptance enforcement of §5 implemented in the trusted signing
+   component (no raw-byte notary scope).
+6. The publisher split of §5 implemented, with a repository ruleset
+   confining the publisher token's writes to the receipt ref.
+7. Signed-leg billing and abuse policy operational (#1193).
+8. Notary key ceremony completed per §8, transition mechanism included.
+9. Org-variable trust anchors eliminated from the signing path in favor
+   of committed or digest-pinned roots.
+10. rulespec-nz consumer-side pins landed: the notary SPKI and epoch in
+    the lane's committed verification spec; the notary check required and
+    non-bypassable in branch protection; genesis activated atomically
+    with enforcement.
+11. The generated-file guard hardcoded in the protected shared workflow
+    (its caller-controlled boolean retired) — merge-time defense in depth
+    during dual-era operation.
+12. Retirement of lane signed-apply legs (#1195) is a cutover exit
     criterion, not a pilot precondition; dual-era operation is expected.
 
 ## 10. Negative-test floor
 
-Grouped by where the refusal fires; each case is a distinct test before
-the pilot gates anything.
+Grouped by refusal site; each case is a distinct test before the pilot
+gates anything.
 
-**Lineage and records:** malformed record schema; unknown field; wrong
-content-address filename; unauthenticated generation record (producer
-signature invalid or wrong key); correction without countersignature;
+**Schemas and signatures:** unknown field; missing field; wrong type;
+wrong content-address filename; malformed detached-signature file;
+signature by the wrong key for a scope; invalid producer signature;
+invalid actor signature; missing or invalid reviewer countersignature;
 countersignature by the actor; countersignature by an untrusted key;
-mutated existing record; deleted existing record; record with wrong lane;
-record with wrong epoch.
+invalid genesis signature; invalid transition signature; invalid receipt
+signature; raw-byte signing attempt against the notary or transition
+scope; the full pairwise cross-scope matrix (all six scopes plus legacy
+`apply_ed25519`/`eval_ed25519`) — every cross-scope verification fails.
 
-**Eligibility and coverage:** record present at `B` (replay); uncovered
-protected change; overlapping chains; extra transition against an
-unchanged path; forked chain; cyclic chain; discontinuous chain (wrong
-intermediate digest); wrong starting blob; wrong terminal blob; malformed
-null-sides (addition with before-digest; deletion with after-digest);
-partial record consumption; wrong patch digest or unknown
-`patch_algorithm` (audit-metadata refusal); gitlink at a protected path;
-symlink at a protected path; disallowed mode; non-UTF-8 protected path;
-`waived`/`not-run` coverage outcome post-epoch.
+**Lineage store:** mutated existing record; deleted existing record;
+record with wrong lane; record with wrong epoch; mode field present on a
+null side; mode value outside the admissible set.
 
-**Preflight and profile:** candidate touching workflows, pins, trust
-roots, path policy, profile, waiver policy, or lineage-store integrity;
-repairable-but-unrepaired subject; failed gate; oracle-disabled attempt;
-skip-flag attempt; profile or path policy not committed at `B`.
+**Eligibility and coverage:** record present at the base (replay);
+uncovered protected change; uncovered mode-only change; overlapping
+chains; extra transition against an unchanged path; forked chain; cyclic
+chain; discontinuous chain; wrong starting blob or mode; wrong terminal
+blob or mode; malformed null-sides; partial record consumption; wrong
+patch digest or unknown `patch_algorithm`; gitlink at a protected path;
+symlink at a protected path; disallowed mode at a protected path;
+non-UTF-8 changed path anywhere in the diff; `waived`/`not-run` coverage
+outcome post-epoch; path-policy precedence cases (`rules/private/x`
+under include-then-exclude; `rules-evil/x` against prefix `rules`;
+unmatched path defaulting to unprotected).
 
-**Chain, epoch, genesis:** base not the admitted tip; wrong
-`previous_receipt`; second genesis; genesis with a non-empty covered set;
-ordinary receipt claiming genesis; post-epoch change vouched only by v5;
-v5 record whose blob differs from its frozen grandfathered pair.
+**Preflight and profile:** ordinary candidate touching workflows, pins,
+trust roots, path policy, profile, waiver policy, repository-structure
+rules, or lineage-store integrity; repairable-but-unrepaired subject;
+failed gate; gate outcome outside the profile's acceptable set; missing
+required gate; oracle-disabled attempt; skip-flag attempt; profile or
+path policy not committed at the base.
 
-**Job 2 and publication:** report-body digest mismatch; stale `B` or `H1`
-at re-hash; Job-1 run from the wrong workflow or ref; non-success Job-1
-conclusion; artifact digest mismatch; replayed Job-1 artifact under a new
-run id; malformed typed receipt fields; invalid authorization reference;
-CAS loss; receipt-child commit with any extra delta.
+**Chain, epoch, genesis, transitions:** base not the chain tip; wrong
+chain predecessor digest; second genesis; genesis carrying coverage;
+receipt claiming a predecessor role its schema forbids; empty-delta
+first receipt leaving baseline provenance unchanged (positive control);
+post-epoch change vouched only by v5; v5 record whose blob differs from
+its frozen pair; malformed or path-mismatched grandfather inventory
+entry; transition carrying a protected-content change; transition with
+an unenumerated trust-surface delta; ordinary receipt attempting a
+trust-surface change; chain advance over an unpublished (void) receipt.
 
-**Domains:** the full pairwise signature matrix across
-`lineage-generation/v1`, `lineage-correction/v1`,
-`lineage-correction-review/v1`, `notary-genesis/v1`, `notary-receipt/v1`,
-`apply_ed25519`, and `eval_ed25519` — every cross-domain verification
-fails.
+**Job 2 and publication:** report-body digest mismatch; subject or base
+tree-manifest mismatch on re-hash; profile or path-policy re-hash
+mismatch; copied-field mismatch between report and receipt; Job-1 run
+from the wrong workflow, sha, or ref; non-success Job-1 conclusion;
+artifact digest mismatch; replayed Job-1 artifact under a new run;
+**signing a refusal report**; signing with a missing required gate;
+invalid authorization reference; wrong requesting workflow/job identity
+at the signer; CAS loss voids the receipt; stale signed receipt never
+chain-eligible; published-tip tree differing from receipt tree
+(squash/queue rewrite) voids and reruns; receipt-child commit with any
+extra delta; publisher push outside the receipt ref rejected by ruleset.
 
 ## 11. Decisions for sign-off
 
@@ -417,19 +539,19 @@ fails.
   extend the path policy to composition outputs.
 - Licensed or unavailable oracles: fail closed, or visibly reduced-tier
   receipt.
-- Approval wording: `authorization` binds durable digest-bound reviewer
-  evidence, or records "the protected signing policy authorized this
-  receipt" (honest for plain environment approval, which approves a
-  deployment, not a displayed digest; the stronger form needs an explicit
-  approval artifact).
-- Custody model for the producer, actor, and reviewer keys (the notary key
-  is fixed by §5/§8); reviewer custody is the open question deferred from
-  the rulespec-nz custody ruling.
+- Approval wording: `authorization.approval_context` binds durable
+  digest-bound reviewer evidence, or records "the protected signing
+  policy authorized this receipt" (honest for plain environment
+  approval, which approves a deployment, not a displayed digest; the
+  stronger form needs an explicit approval artifact).
+- Custody model for the producer, actor, reviewer, and administrative
+  keys (the notary key is fixed by §5/§8); reviewer custody is the open
+  question deferred from the rulespec-nz custody ruling.
 
 ## 12. Out of scope for milestone one
 
 Witnessed lineage chains (dual RFC 3161 — sequenced behind the notary as
-chartered); historical backfill; rename *modeling* (tree-entry
+chartered); historical backfill; rename modeling (tree-entry
 decomposition makes it unnecessary); fleet-wide shared-workflow
 conversion; v5 retirement; the other eight lanes; ProgramSpec admission
 unless §11 decides otherwise.

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,33 +1,47 @@
-# Notary admission: design v1
+# Notary admission: design v2
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Nothing admission-capable merges until the
-preconditions in §9 are satisfied and this document is approved.
+(dual-verdict, 2026-08-17). Version 2 folds the first cross-family design
+review (nine blocking findings; the review record lives on #1507). Nothing
+admission-capable merges until the preconditions in §9 are satisfied and
+this document is approved by the charter's gate: an independent
+cross-family review of this concrete design plus Max's named sign-off.
 
 ## 1. Claim and threat model
 
 The notary signs one narrow claim:
 
-> Tree `H1` was accepted under verifier profile `P`, protected base `B`,
-> corpus release `Y`, waiver set `W`; every content change from `B` to `H1`
-> is covered by authenticated lineage; the protected signing policy
-> authorized this receipt.
+> Verification report `R` describes subject commit `S` (tree `H1`): under
+> verifier profile `P` and protected-path policy committed at base `B`,
+> every protected-content tree-entry change from `B` to `H1` is covered by
+> the eligible lineage set `L`, every gate in `P` produced the recorded
+> outcome, unprotected tree-entry changes are enumerated in `R`, `B` is the
+> previously admitted tip, and the protected signing policy authorized this
+> acceptance.
 
-It does not claim content was model-generated, and it never will — that
-claim bred provenance laundering (the Path R pattern) and is retired with
-the v5 era. Lineage records say where bytes came from; the notary says the
-deterministic gates passed and coverage held.
+The claim covers exactly what the predicate checks: protected-content
+tree-entry changes. Unprotected changes (documentation, tooling) are not
+silently outside the statement — the report enumerates them, so a reader
+sees precisely what was and was not under coverage.
+
+The notary does not claim content was model-generated, and never will —
+that claim bred provenance laundering (the Path R pattern) and is retired
+with the v5 era. Lineage records say where bytes came from; the notary says
+the deterministic gates passed, coverage held, and admission chains from
+the last admitted state.
 
 The scenario this design closes: an agent with repository write access
 hand-edits a published rule and obtains a legitimate signature through the
-sanctioned path. Two independent walls stop it. The capability wall: no
-generator holds signing capability — Job 2 alone reaches the notary key,
-inside a protected environment with required human reviewers, and runs no
-candidate code. The coverage wall: a changed path with no covering lineage
-record refuses at preflight, regardless of who approves. A hand edit
-therefore either dies unsigned or enters as a declared correction event —
-attributed, countersigned, and visible to the fix-the-encoder loop.
+sanctioned path, with no record of the edit's origin. Two walls stop the
+*undeclared* hand edit — declared corrections are intentionally admissible,
+loudly. The capability wall: no generation surface holds the
+merge-authorizing notary capability; the notary key lives in a dedicated
+notary-only environment reachable only by the typed signing job, which runs
+no candidate code. (Generation surfaces do hold the non-authorizing
+producer key — that signs lineage, not admission.) The coverage wall: a
+changed protected path with no covering eligible lineage refuses at
+verification, regardless of who approves.
 
 Residual risks accepted, per the charter: a verifier soundness bug
 deterministically accepts wrong law; candidate-controlled tests can be
@@ -35,206 +49,387 @@ weakened; reviewer compromise authorizes validator-passing bad content.
 Mitigations are the strict profile, the trusted preflight, golden
 regeneration QA, and oracles — not additional signatures.
 
-## 2. Records
+## 2. Artifacts, schemas, and signature envelope
 
-Three record kinds, all canonical JSON (receipt-canonical serialization:
-UTF-16 code-unit key order, ECMAScript number formatting), content-addressed
-by SHA-256, each signed under its own domain with its own key. Domains are
-single-purpose byte prefixes; cross-domain verification must fail and §10
-tests prove it.
+### 2.1 Serialization and framing, shared by every artifact
 
-| Record | Domain | Signer | Authorizes merge? |
-|---|---|---|---|
-| Generation event | `axiom/lineage-generation/v1` | supervised-runtime producer key | No |
-| Correction event | `axiom/lineage-correction/v1` | actor key + distinct protected reviewer countersignature | No |
-| Notary receipt | `axiom/notary-acceptance/v1` | `notary_ed25519` (Job 2 broker only) | **Yes** |
+- Bodies are canonical JSON (receipt-canonical serialization: UTF-16
+  code-unit key order, ECMAScript number formatting), UTF-8 bytes,
+  content-addressed by SHA-256. Digest strings are lowercase hex, always
+  written into fields whose names end in `_sha256`; no multihash prefixes.
+- Every body carries `schema` (a closed identifier, e.g.
+  `axiom/notary-receipt/v1`) and `lane` (the canonical `owner/repo`).
+  Unknown fields are a parse refusal; missing fields are a parse refusal;
+  schemas are closed-world.
+- Signatures are detached: `<digest>.json` beside `<digest>.json.sig`. No
+  in-body signature fields exist, so no exclusion rules exist.
+- Signing input is the broker's existing framing, with the domain as the
+  scope: `sign(key, domain || 0x00 || body_sha256_bytes)`. The domain
+  strings below are the complete scope set; a signature made under one
+  domain must fail verification under every other (§10 tests the full
+  pairwise matrix, legacy `apply_ed25519`/`eval_ed25519` included).
+- The signer for the notary domain is a typed operation: the trusted
+  signing component receives the typed fields of §2.4, reconstructs the
+  canonical body itself, computes its digest, and signs. No caller can
+  submit arbitrary bytes to the notary domain.
 
-**Generation event.** Emitted by the supervised local runtime (the #1158
-machinery) at generation time. Fields: runtime identity, model, CLI version
-and digest, prompt digests, output tree digest, and per-path transitions
-(§3). Authenticated as a runtime emission by the producer signature —
-content addressing alone proves integrity, not origin.
+### 2.2 Generation event — `axiom/lineage-generation/v1`
 
-**Correction event.** A declared human or agent fix. Fields: actor, reason,
-predecessor record, per-path transitions, canonical patch digest. Valid only
-with a countersignature from a protected reviewer distinct from the actor,
-over the event digest. The countersignature validates lineage; it does not
-authorize merge. Corrections are first-class and loud — the sanctioned
-response to a wrong encoding remains fix-the-encoder-and-re-encode, and a
-correction event is the recorded exception, never the quiet path.
+Signed by the supervised-runtime producer key (non-authorizing). Fields:
+`schema`, `lane`, `epoch_sha256` (§6), `runtime_identity`, `model`,
+`cli_version`, `cli_sha256`, `prompt_sha256s`, `emitted_at` (informational,
+unverified), and `transitions`: an array sorted by path, each
+`{path, before_blob_sha256 | null, after_blob_sha256 | null,
+patch_sha256, patch_algorithm}`. `null` before-side is an addition; `null`
+after-side is a deletion. `patch_algorithm` names a versioned canonical
+patch recipe (`git-patch-v1`: `git diff --no-renames --full-index --binary
+-U3` with `core.autocrlf=false`, no textconv, no external diff, path
+attributes ignored); the patch digest is audit metadata — blob digests are
+ground truth.
 
-**Notary receipt.** The only record Job 2 signs. Fields: `subject_commit`,
-`subject_tree` (`H1`), `protected_base` (`B`), verifier profile digest
-(`P`), corpus release (`Y`), waiver set digest (`W`), per-gate outcomes with
-reproducibility tier (publicly reproducible / restricted pinned inputs /
-CI-attested), the diff-coverage verdict, Job 1 run identity, and the
-authorization reference. The existing `apply_ed25519` domain and v5
-manifests are never reinterpreted; under the dual-era rule they keep their
-generator-produced meaning permanently.
+### 2.3 Correction event — `axiom/lineage-correction/v1`
+
+Signed by the actor's key and countersigned (a second detached signature
+under `axiom/lineage-correction-review/v1`) by a protected reviewer key
+distinct from the actor's. Fields: `schema`, `lane`, `epoch_sha256`,
+`actor`, `reason`, `predecessor_record_sha256 | null`, and `transitions` as
+in §2.2. The countersignature validates lineage — it never authorizes
+merge. Corrections are first-class and loud: the sanctioned response to a
+wrong encoding remains fix-the-encoder-and-re-encode, and a correction
+event is the recorded exception, never the quiet path.
+
+### 2.4 Verification report (Job 1, unsigned) — `axiom/notary-report/v1`
+
+Content-addressed, produced by the secretless verify job. Fields:
+
+- `schema`, `lane`, `epoch_sha256`
+- `subject_commit`, `subject_tree_sha256`
+- `base_commit`, `base_tree_sha256`
+- `previous_receipt_sha256` (the receipt this admission chains from;
+  genesis reference for the first)
+- `profile_sha256` (digest of the profile definition file committed at
+  `B`), `path_policy_sha256` (likewise; §3.1)
+- `corpus_release`: `{name, content_sha256}` (the toolchain tuple)
+- `waiver_set_sha256`
+- `eligible_records`: sorted array of record digests (§3.2), and
+  `eligible_records_sha256` over that array's canonical bytes
+- `gates`: sorted array of `{gate_id, outcome, tier}` with `tier` in
+  `public | restricted | ci-attested`
+- `diff_coverage`: `"pass"` or a refusal object (never `waived`, never
+  `not-run`)
+- `unprotected_changes`: sorted array of paths changed outside the
+  protected domain
+- `dependency_pins_sha256`: digest of the exact resolved dependency set of
+  the verifier run
+- `verifier_commit`: the axiom-encode commit whose code ran Job 1
+
+The report cannot contain the authorization, which does not exist until
+Job 2; the receipt binds the two.
+
+### 2.5 Notary receipt (Job 2, signed) — `axiom/notary-receipt/v1`
+
+The only artifact signed under the notary domain, by `notary_ed25519`.
+Fields:
+
+- `schema`, `lane`, `epoch_sha256`
+- `report_sha256`
+- `subject_commit`, `subject_tree_sha256`, `base_commit`,
+  `previous_receipt_sha256` (copied from the report after independent
+  re-derivation; a mismatch is a refusal, §5)
+- `job1`: `{workflow_path, workflow_sha, ref, run_id, run_attempt,
+  conclusion, artifact_sha256}` as read from the Actions control plane by
+  the signing component itself
+- `authorization`: `{environment, approval_context}` — the protected
+  signing policy reference (see §11 for the wording decision)
+- `genesis`: boolean, `false` for every ordinary receipt (§6)
+
+### 2.6 Storage
 
 Lineage records live in the lane repository under `.axiom/lineage/`,
-append-only, one file per record named by its content digest. The lineage
-directory is outside the protected-content coverage domain (its additions
-need no covering record — that would regress infinitely) but inside the
-preflight's structural checks: schema-valid, authenticated, append-only,
-correctly content-addressed. Deleting or mutating an existing lineage record
-is a preflight refusal.
+append-only, one body file per record named by its content digest, with its
+detached signatures beside it. The lineage directory is outside the
+protected-content coverage domain (its additions need no covering record)
+but inside the preflight's structural checks: schema-valid, authenticated,
+correctly content-addressed, append-only. Deleting or mutating an existing
+lineage record is a refusal. Receipts and reports publish per §7 and are
+never part of the subject tree.
 
 ## 3. The diff-coverage predicate
 
-For the complete git-object diff from `B` to `H1`, restricted to protected
-content paths:
+### 3.1 Protected paths, defined normatively
 
-1. Every changed path maps to exactly one non-forking chain of transitions
-   drawn from lineage records — closed-world set equality: no missing, no
-   overlapping, no extra transitions.
-2. Each transition binds the full before-blob digest and after-blob digest
-   for its path, plus a versioned canonical patch digest (`git-patch-v1`:
-   `git diff` with pinned flags, retained for audit; the blob digests are
-   ground truth because hunk computation is algorithm-dependent).
-3. Replaying each path's chain from its blob at `B` must terminate exactly
-   at its blob at `H1`.
-4. Additions and deletions are modeled explicitly (null-digest sides).
-   Renames, mode changes, and symlinks are rejected in the pilot rather than
-   modeled.
-5. The verdict is binary. From the enforcement epoch, `waived`, `not-run`,
-   missing coverage, or an emergency "correction" without a valid
-   countersigned event is a refusal. Notary-v1 acceptance requires exactly
-   `diff-coverage=pass` — deliberately stricter than consumer-side
-   declaration completeness, which by design accepts declared `waived` and
-   `not-run` outcomes as well-formed.
+The protected-path policy is a committed file at `B`
+(`.axiom/notary/path-policy.json`): an ordered list of include/exclude
+prefix rules over UTF-8 paths, closed under the same canonical JSON rules.
+Its digest enters the report as `path_policy_sha256`. Classification uses
+the policy committed at `B` — a candidate cannot reclassify paths in its
+own favor, and a policy change is a trust-surface change the preflight
+refuses from candidates (§4). For the rulespec-nz pilot the policy covers
+the atomic rule roots; whether `programs/` composition outputs enter the
+domain is a §11 decision.
+
+### 3.2 Eligible lineage set
+
+Eligible records for a verification are exactly the records whose body
+files are present under `.axiom/lineage/` in `H1` and absent in `B` —
+introduced by this candidate — and which carry this `lane` and this
+`epoch_sha256`. The sorted digest list is bound into the report. This rule
+is what defeats replay: a record merged by an earlier candidate is present
+in `B` and therefore ineligible ever after; a record from another lane or
+epoch refuses on its bindings; and transitions chain from `B`'s actual
+blobs (§3.3), so a stale record whose before-digests no longer match `B`
+refuses even inside its introducing candidate.
+
+Records are consumed atomically: all of a record's transitions must be used
+by the covering assignment, or the record is unused entirely. A partially
+matching record is a refusal, not a partial cover. Unused eligible records
+are listed in the report (they are legal — a retried generation — but
+never invisible).
+
+### 3.3 The predicate
+
+Compute the tree-entry diff from `B` to `H1` with rename detection
+disabled (`git diff-tree --no-renames` semantics): the diff is a set of
+per-path entry changes — additions, deletions, and modifications. Renames
+do not exist at this level and need no special rule; a moved file is a
+deletion needing a deletion transition and an addition needing an addition
+transition. Then, over the protected subset:
+
+1. **Closed-world assignment.** Every changed protected path maps to
+   exactly one non-forking chain of transitions drawn from eligible
+   records — no missing, no overlapping, no extra transitions against
+   unchanged paths, no cycles, no forks.
+2. **Blob-digest ground truth.** Each chain's first before-digest equals
+   the path's blob at `B` (or `null` for an addition); each link's
+   after-digest equals the next link's before-digest; the last
+   after-digest equals the path's blob at `H1` (or `null` for a deletion).
+3. **Admissible entries only.** Protected paths must be regular blobs
+   (mode 100644 or 100755) on both sides where they exist. A gitlink,
+   symlink, or other mode at a protected path — at `B` or `H1` — is a
+   refusal. Protected paths must be valid UTF-8; a non-UTF-8 path inside
+   the protected domain is a refusal. File-to-directory and
+   directory-to-file replacements decompose into entry deletions and
+   additions and are covered as such.
+4. **Binary verdict.** `diff_coverage` is `"pass"` or a typed refusal.
+   From the enforcement epoch there is no `waived` and no `not-run`; an
+   emergency change without a countersigned correction event is a refusal.
+   This is deliberately stricter than consumer-side declaration
+   completeness, which by design accepts declared `waived`/`not-run`
+   outcomes as well-formed.
 
 Advisory shadow runs (compute and publish the verdict without gating) are
-permitted only before a lane's enforcement epoch, to burn in the predicate.
+permitted only before a lane's enforcement epoch.
 
-## 4. Verifier profile P
+## 4. Verifier profile P and trusted preflight
 
-The notary profile is not the current apply path, and the differences are
-the point:
+The profile is a committed definition at `B`, digest-bound into the report.
+It is not the current apply path, and the differences are the point:
 
 - **Non-mutating.** No deterministic repairs. The subject is verified as
-  presented or refused.
-- **Oracles on.** The apply overlay's `enable_oracles=False` does not exist
-  here. Licensed or unavailable oracles follow the sign-off decision in
-  §11 — fail closed, or a visibly reduced-tier receipt; never silent.
+  presented or refused. A repairable-but-unrepaired subject refuses.
+- **Oracles on.** The apply overlay's oracle disablement does not exist
+  here. Licensed or unavailable oracles follow the §11 decision — fail
+  closed, or a visibly reduced-tier receipt; never silent.
 - **Reviewers means deterministic checks plus protected-environment human
-  approval.** Today's "reviewers" in the validator pipeline are LLM
-  reviewers; under the charter's no-model-calls rule they cannot be part of
-  the notary profile. LLM review remains QA outside the admission path,
-  beside golden regeneration.
-- **No skips.** `--skip-reviewers` and caller-disableable guards have no
-  notary equivalents. The generated-file guard's merge-time role continues
-  during dual-era operation, but the notary does not consult caller
-  booleans.
+  approval.** The validator pipeline's LLM reviewers are QA outside the
+  admission path, beside golden regeneration; under the charter's
+  no-model-calls rule they cannot gate the notary.
+- **No caller switches.** Skip flags and caller-disableable guards have no
+  notary equivalents.
 
-The profile is itself content-addressed; `P` in the receipt is the digest of
-the profile definition committed at `B`.
+The trusted preflight (runs in Job 1, from pinned code, before any
+candidate code executes) resolves: the canonical repository; the admissible
+base (`B` must equal the tip admitted by `previous_receipt` — §6); the
+path policy and profile at `B`; the complete tree-entry diff. It refuses
+candidate changes to workflows, action pins, verifier pins, trust roots,
+the path policy, the profile, waiver policy, repository structure rules,
+and the lineage-record store's integrity (§2.6). Those surfaces move only
+through separately privileged flows.
 
-## 5. Two jobs, one capability split
+## 5. Jobs and capability separation
 
 **Job 1 — verify (secretless).** Runs candidate code under the strict
-profile in an environment with no signing capability, no model credentials,
-and no repository-write credential. Produces the content-addressed unsigned
-receipt body: subject digests, gate outcomes and tiers, diff-coverage
-verdict, exact dependency pins, run identity.
+profile with no signing capability, no model credentials, and no
+repository-write credential. Emits the §2.4 report as a content-addressed
+artifact.
 
-**Job 2 — sign (narrow, typed).** Runs in the `production-signing`
-environment with required reviewers enforced (#1194). Runs no candidate
-code. Independently re-fetches and re-hashes `B`, `H1`, and the receipt
-body; parses only the typed notary schema; refuses on any mismatch by
-forcing complete reverification; holds no model or repository-write
-credential; signs only `axiom/notary-acceptance/v1`. Environment approval
-gates Job 2 so the human approves a completed receipt, never a
-not-yet-run pipeline.
+**Job 2 — sign (typed, notary-only).** Runs in a **dedicated
+`notary-signing` environment** — not `production-signing`, which today
+provisions generation workflows with the apply key, a model credential,
+and later a write-capable token, and is therefore structurally
+disqualified from holding the notary key. The environment enforces
+required human reviewers, protected refs, no self-approval, and
+Job-2-only secret access. Job 2 runs no candidate code and holds no model
+or repository-write credential. Its trusted component:
 
-Trust roots for both jobs — public keys, profile digests, policies,
+1. Reads the Job-1 run from the Actions control plane: workflow path and
+   sha, ref, run id and attempt, conclusion, artifact digest. A wrong
+   workflow, wrong ref, non-success conclusion, or artifact digest
+   mismatch is a refusal.
+2. Independently re-fetches and re-hashes `S`, `H1`, `B`, the report body,
+   the profile and path-policy files at `B`, and re-derives
+   `previous_receipt` admissibility. Any mismatch discards the run and
+   forces complete reverification.
+3. Reconstructs the §2.5 receipt body from typed fields and signs its
+   digest under the notary domain. It exposes no arbitrary-byte signing
+   operation.
+
+**Publisher — a third job.** Both verification and signing forbid
+repository-write capability, so neither publishes. A separate publisher
+job — the pattern the current signed-apply workflow already uses for its
+App-token step — holds only a write token scoped to the receipt
+publication ref, and pushes per §7. It holds no signing capability.
+
+Trust roots for all jobs — public keys, profile and policy digests,
 workflow and action pins, waiver authorities — are committed at or
-digest-pinned to the protected base. Runtime organization variables are not
-trust anchors anywhere in the notary path; the existing `vars.*`
-provisioning in the signing workflows is eliminated as a precondition (§9).
+digest-pinned to the protected base. Runtime organization variables are
+not trust anchors anywhere in the notary path; eliminating the existing
+`vars.*` provisioning from the signing path is a §9 precondition.
 
-## 6. Epoch and bootstrap
+## 6. Admission chain, epoch, and genesis
 
-Per-repo enforcement epochs, pilot on rulespec-nz:
+Admission is a chain, receipt to receipt:
 
-1. Pin the lane's current main commit as the one-time enforcement genesis.
-2. Issue a genesis receipt over the empty `B → H1` range. No historical
-   lineage is invented; pre-epoch content is covered by the dual-era rule
-   (v5 manifests keep their meaning; untouched content needs nothing).
-3. Every subsequent non-empty diff of protected content must pass coverage.
-4. Cross-class supersession: a post-epoch change to a v5-covered path
-   requires notary-v1 lineage for the change; the v5 record continues to
-   describe the pre-epoch bytes only.
+- Every ordinary receipt names `previous_receipt_sha256`, and its
+  `base_commit` must be that receipt's `subject_commit`. Verifying any
+  other base refuses. An uncovered edit therefore cannot launder itself by
+  becoming the base of the next verification: the base that skipped it is
+  not the admitted tip.
+- **Genesis** is a distinct artifact — `axiom/notary-genesis/v1`, signed
+  under its own domain — not an ordinary receipt. It binds: the lane, the
+  epoch identifier (`epoch_sha256` = digest of the genesis body), the
+  pinned genesis commit and tree, and a **frozen grandfather set**: the
+  digest of the exact v5 record and blob pairs present at genesis. Genesis
+  records state; it does not assert the baseline content was admitted, and
+  it covers nothing. It cannot recur: a second genesis for a lane refuses.
+- The first ordinary receipt uses the genesis as `previous_receipt` and
+  the genesis commit as `B`.
+- **Dual-era rule.** Pre-epoch content stands under the frozen v5
+  grandfather set: a v5 manifest vouches post-epoch only for a path whose
+  blob is byte-identical to its grandfathered pair. Any post-epoch change
+  to any protected path requires notary-era lineage; v5 records cover the
+  pre-epoch bytes only, and new v5 records have no post-epoch standing.
+
+Pilot bootstrap on rulespec-nz: pin the lane's current main commit as
+genesis. No historical lineage is invented; the baseline is grandfathered
+as-is, visibly, in the frozen set — including any pre-epoch hand edits,
+which genesis records but does not bless as admitted.
 
 ## 7. Publication
 
-Receipts publish as detached attestations referencing `subject_commit`,
-pushed compare-and-swap; alternatively a mechanical receipt-only child
-commit whose sole delta is the receipt. If the protected base or the
-candidate moves between verification and publication, the verification is
-discarded and rerun from the new `B`. The manifest distinguishes
-`subject_commit`, `subject_tree`, `attestation_commit`, and
-`verifier_commit` so no reader conflates what was verified with where the
-receipt landed.
+The publisher pushes the receipt (and its report) as a detached
+attestation ref referencing `subject_commit`, compare-and-swap;
+alternatively as a mechanical receipt-only child commit whose sole delta
+is the receipt files. If the protected ref or the candidate moves between
+verification and publication, the CAS fails, the verification is
+discarded, and the run repeats from the new admitted tip. The receipt
+distinguishes `subject_commit`, `subject_tree_sha256`, and
+`verifier_commit`; the attestation ref supplies the publication location
+without entering the signed body.
 
 ## 8. Key ceremony
 
 Before Job 2 exists: generate `notary_ed25519` with documented custodians,
-fingerprint publication in committed code (consumer verification specs pin
+fingerprint published in committed code (consumer verification specs pin
 the SPKI), storage and rotation procedure, revocation and recovery
-procedure, and negative tests proving apply-domain signatures cannot verify
-as notary signatures and conversely. The producer and reviewer keys for
-lineage records get the same treatment with their own domains. Rotation is
-loud, by reviewed change to committed pins, exactly as the consumer-side
-verifier already requires.
+procedure. The producer key, actor keys, and reviewer countersignature key
+get the same treatment under their own domains. §10's pairwise cross-domain
+matrix is part of ceremony acceptance. Rotation is loud, by reviewed change
+to committed pins, exactly as the consumer-side verifier already requires.
 
 ## 9. Preconditions (nothing admission-capable merges before these)
 
-1. This document approved — threat model, canonical signed bytes, profile,
-   epoch and bootstrap rules, and the §10 suite — by the human gate the
-   charter names.
-2. The reviewers-semantics resolution in §4 accepted (deterministic checks
-   plus human environment approval; LLM review is QA only).
-3. `production-signing` environment enforcing required reviewers, protected
-   refs, no self-approval, Job-2-only secret access (#1194).
-4. Signed-leg billing and abuse policy operational (#1193).
-5. Notary key ceremony completed per §8.
-6. Org-variable trust anchors eliminated from the signing path in favor of
+1. This document approved — threat model, schemas and signature envelope,
+   predicate, profile, chain/epoch/genesis rules, and the §10 suite — by
+   the charter's gate: an independent cross-family review of the concrete
+   design plus **Max's named sign-off**, with every §11 decision closed.
+2. The reviewers-semantics resolution in §4 accepted.
+3. The dedicated `notary-signing` environment created and enforcing:
+   required reviewers, protected refs, no self-approval, Job-2-only secret
+   access (#1194 re-scoped to the new environment) — and the generation
+   workflows migrated off any environment that will hold the notary key.
+4. The authenticated Job-1 handoff and typed Job-2 reconstruction of §5
+   implemented in the trusted signing component (no raw-byte notary
+   scope).
+5. The publisher split of §5 implemented; neither verify nor sign holds a
+   write credential.
+6. Signed-leg billing and abuse policy operational (#1193).
+7. Notary key ceremony completed per §8.
+8. Org-variable trust anchors eliminated from the signing path in favor of
    committed or digest-pinned roots.
-7. Retirement of lane signed-apply legs (#1195) is a cutover exit
-   criterion, not a pilot precondition; dual-era operation is expected.
+9. rulespec-nz consumer-side pins landed: the notary SPKI and epoch in the
+   lane's committed verification spec; the notary check required and
+   non-bypassable in branch protection; genesis activated atomically with
+   enforcement.
+10. The generated-file guard hardcoded in the protected shared workflow
+    (its caller-controlled boolean retired), per the charter's migration
+    step 3 — merge-time defense in depth during dual-era operation.
+11. Retirement of lane signed-apply legs (#1195) is a cutover exit
+    criterion, not a pilot precondition; dual-era operation is expected.
 
-## 10. Negative-test suite (acceptance floor for Job 1)
+## 10. Negative-test floor
 
-Each is a distinct refusal with its own test before the pilot gates
-anything: uncovered changed path; overlapping chains; extra transition
-covering an unchanged path; forked chain; replay terminating at the wrong
-blob; correction event without countersignature; countersignature by the
-actor; generation event not authenticated by the producer key; mutated or
-deleted lineage record; rename, mode change, symlink in the diff; candidate
-touching workflows, pins, trust roots, waiver policy, or repository
-structure; `waived`/`not-run` coverage outcome post-epoch; stale `B` or
-`H1` at Job 2; receipt-body mismatch at Job 2; cross-domain signature
-verification in both directions; genesis receipt claiming a non-empty
-range.
+Grouped by where the refusal fires; each case is a distinct test before
+the pilot gates anything.
+
+**Lineage and records:** malformed record schema; unknown field; wrong
+content-address filename; unauthenticated generation record (producer
+signature invalid or wrong key); correction without countersignature;
+countersignature by the actor; countersignature by an untrusted key;
+mutated existing record; deleted existing record; record with wrong lane;
+record with wrong epoch.
+
+**Eligibility and coverage:** record present at `B` (replay); uncovered
+protected change; overlapping chains; extra transition against an
+unchanged path; forked chain; cyclic chain; discontinuous chain (wrong
+intermediate digest); wrong starting blob; wrong terminal blob; malformed
+null-sides (addition with before-digest; deletion with after-digest);
+partial record consumption; wrong patch digest or unknown
+`patch_algorithm` (audit-metadata refusal); gitlink at a protected path;
+symlink at a protected path; disallowed mode; non-UTF-8 protected path;
+`waived`/`not-run` coverage outcome post-epoch.
+
+**Preflight and profile:** candidate touching workflows, pins, trust
+roots, path policy, profile, waiver policy, or lineage-store integrity;
+repairable-but-unrepaired subject; failed gate; oracle-disabled attempt;
+skip-flag attempt; profile or path policy not committed at `B`.
+
+**Chain, epoch, genesis:** base not the admitted tip; wrong
+`previous_receipt`; second genesis; genesis with a non-empty covered set;
+ordinary receipt claiming genesis; post-epoch change vouched only by v5;
+v5 record whose blob differs from its frozen grandfathered pair.
+
+**Job 2 and publication:** report-body digest mismatch; stale `B` or `H1`
+at re-hash; Job-1 run from the wrong workflow or ref; non-success Job-1
+conclusion; artifact digest mismatch; replayed Job-1 artifact under a new
+run id; malformed typed receipt fields; invalid authorization reference;
+CAS loss; receipt-child commit with any extra delta.
+
+**Domains:** the full pairwise signature matrix across
+`lineage-generation/v1`, `lineage-correction/v1`,
+`lineage-correction-review/v1`, `notary-genesis/v1`, `notary-receipt/v1`,
+`apply_ed25519`, and `eval_ed25519` — every cross-domain verification
+fails.
 
 ## 11. Decisions for sign-off
 
 - ProgramSpec scope: atomic RuleSpec only in the pilot (recommended), or
-  extend to composition outputs.
+  extend the path policy to composition outputs.
 - Licensed or unavailable oracles: fail closed, or visibly reduced-tier
   receipt.
-- Approval wording: bind durable reviewer evidence, or "the protected
-  signing policy authorized this receipt" (recommended; matches the
-  environment-approval mechanism).
-- Custody model for the three key roles (notary / producer / reviewer):
-  broker environment for the notary per §5; producer stays with the
-  supervised runtime; reviewer custody is the open question deferred from
+- Approval wording: `authorization` binds durable digest-bound reviewer
+  evidence, or records "the protected signing policy authorized this
+  receipt" (honest for plain environment approval, which approves a
+  deployment, not a displayed digest; the stronger form needs an explicit
+  approval artifact).
+- Custody model for the producer, actor, and reviewer keys (the notary key
+  is fixed by §5/§8); reviewer custody is the open question deferred from
   the rulespec-nz custody ruling.
 
 ## 12. Out of scope for milestone one
 
 Witnessed lineage chains (dual RFC 3161 — sequenced behind the notary as
-chartered); historical backfill; rename/mode/symlink modeling; fleet-wide
-shared-workflow conversion; v5 retirement; the other eight lanes; ProgramSpec
-admission unless §11 decides otherwise.
+chartered); historical backfill; rename *modeling* (tree-entry
+decomposition makes it unnecessary); fleet-wide shared-workflow
+conversion; v5 retirement; the other eight lanes; ProgramSpec admission
+unless §11 decides otherwise.

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,9 +1,9 @@
-# Notary admission: design v4
+# Notary admission: design v5
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 4 folds design-review rounds 1–3
-(twenty-five blocking findings; the record lives on #1507). Nothing
+(dual-verdict, 2026-08-17). Version 5 folds design-review rounds 1–4
+(thirty-four blocking findings; the record lives on #1507). Nothing
 admission-capable merges until the §9 preconditions are satisfied and this
 document is approved by the charter's gate: an independent cross-family
 review of this concrete design plus Max's named sign-off, with every §11
@@ -70,11 +70,15 @@ signatures.
 
 ### 2.1 Conventions shared by every artifact
 
-**Serialization.** Bodies are canonical JSON (receipt-canonical
-serialization: UTF-16 code-unit key order, ECMAScript number formatting),
-UTF-8 bytes, content-addressed by SHA-256 of the body bytes. Every body
-carries `schema` and `lane`. Schemas are closed-world: an unknown field,
-missing field, or wrong type is a parse refusal.
+**Serialization.** Bodies are canonical JSON per **RFC 8785 (JCS)** —
+the complete named contract for property ordering, string escaping, and
+number serialization — over I-JSON-restricted input: no invalid Unicode,
+no duplicate keys; every digest, id, and mode in these schemas is a JSON
+string, so numeric-precision edge cases cannot arise. Bodies are UTF-8
+bytes, content-addressed by SHA-256. Every body carries `schema` and
+`lane` (`lane` is the canonical `owner/repo` name, compared
+case-sensitively byte-for-byte). Schemas are closed-world: an unknown
+field, missing field, wrong type, or duplicate key is a parse refusal.
 
 **Value encodings, normatively.** One table, no exceptions:
 
@@ -86,19 +90,25 @@ missing field, or wrong type is a parse refusal.
 | `signer_spki_sha256` | SHA-256 of the DER-encoded SubjectPublicKeyInfo, hex as above |
 | `run_id`, `run_attempt` | JSON strings (decimal), never numbers |
 | `chain_predecessor_kind` | exactly one of `"genesis"`, `"receipt"`, `"transition"` |
+| `tier` | exactly one of `"public"`, `"restricted"`, `"ci-attested"` |
+| `ref` | the fully qualified Git ref string (`refs/...`) |
+| `workflow_git_oid` | the commit oid of the workflow-defining commit for the run, as reported by the Actions control plane (`head_sha` of the run) |
+| Entry modes | six-character octal strings: `"100644"`, `"100755"`, `"120000"` |
 | Paths | UTF-8 strings; sorting is bytewise over the UTF-8 encoding |
 
-**Tree manifests.** A tree manifest binds **every entry** reachable from a
-tree, not only blobs: the canonical JSON array of
-`[path, mode, entry_sha256]` sorted bytewise by path, where `entry_sha256`
-is SHA-256 over blob content for blob modes and over the UTF-8 target
-string for symlinks. Pilot totality rules, applied to **whole trees** at
-verification, genesis, and finalization — not merely to diffs: a gitlink
-(mode 160000) anywhere in the tree is a refusal; a non-UTF-8 path anywhere
-in the tree is a refusal; modes outside {100644, 100755, 120000} are a
-refusal, and 120000 only outside the protected domain. Within these rules
-the manifest is a complete binding of the tree: two trees with equal
-manifests are entry-identical.
+**Tree manifests.** A tree manifest is the recursively flattened list of
+**terminal entries** (blobs and symlinks; directories appear only through
+their contents' paths): the canonical JSON array of
+`[path, mode, entry_sha256]` triples sorted bytewise by path, where
+`entry_sha256` is SHA-256 over the entry's raw blob bytes — for symlinks,
+the raw target bytes of the symlink blob, whatever they are. Pilot
+totality rules, applied to **whole trees** at verification, genesis, and
+finalization — not merely to diffs: a gitlink (mode 160000) anywhere in
+the tree is a refusal; a non-UTF-8 path anywhere in the tree is a
+refusal; terminal modes outside {"100644", "100755", "120000"} are a
+refusal, and "120000" only outside the protected domain. Within these
+rules the manifest function is total and exact: two trees with equal
+manifests are terminal-entry-identical.
 
 **Signature envelope.** Signing uses the existing broker frame verbatim:
 
@@ -175,8 +185,10 @@ Content-addressed output of the verification workflow. Fields: `schema`,
 `chain_predecessor_kind`; `profile_sha256`, `path_policy_sha256`;
 `corpus_release` `{name, content_sha256}`; `waiver_set_sha256`;
 `eligible_records` and `unused_eligible_records` (sorted digest arrays);
-`coverage_assignment` (per changed protected path, the ordered record
-digests consumed — the unique assignment of §3.3); `gates`: array sorted
+`coverage_assignment`: array sorted bytewise by path of
+`{path, record_sha256s}` — for each changed protected path, the record
+digests consumed for its chain, in chain order (the unique assignment of
+§3.3); `gates`: array sorted
 by `gate_id`, **one entry per gate id** (duplicates are a parse refusal),
 each `{gate_id, outcome, tier}`; `diff_coverage`: `"pass"` or a typed
 refusal object (never `waived`, never `not-run`); `unprotected_changes`
@@ -190,12 +202,22 @@ fails reconciliation rather than getting signed.
 
 ### 2.5 Notary receipt (signed) — `axiom/notary-receipt/v1`
 
-The only artifact that, once finalized (§7), authorizes admission. Fields:
-`schema`, `lane`, `epoch_sha256`; `report_sha256`; the §2.4 chain and
-tree fields, each independently recomputed by the trusted side; `gates`
-as declared (deduplicated, profile-complete, outcomes acceptable);
-`job1`: `{workflow_path, workflow_git_oid, ref, run_id, run_attempt,
-conclusion, artifact_sha256}` as read from the Actions control plane;
+The only artifact that, once finalized (§7), authorizes admission. Its
+closed schema, enumerated: `schema`, `lane`, `epoch_sha256`;
+`report_sha256`; `subject_commit_git_oid`, `subject_tree_manifest_sha256`,
+`base_commit_git_oid`, `base_tree_manifest_sha256`,
+`chain_predecessor_sha256`, `chain_predecessor_kind`, `profile_sha256`,
+`path_policy_sha256`, `corpus_release`, `waiver_set_sha256`,
+`eligible_records`, `coverage_assignment`, `unprotected_changes`,
+`dependency_pins_sha256`, `verifier_commit_git_oid` — each independently
+recomputed by the trusted side, never copied on trust; `gates` as
+declared (deduplicated, profile-complete, outcomes acceptable); `job1`:
+`{workflow_path, workflow_git_oid, ref, run_id, run_attempt, job_name,
+check_run_id, conclusion, artifact_name, artifact_id, artifact_sha256}` —
+the artifact bound to the specific producing job and attempt via the
+workflow-jobs and per-attempt artifact endpoints, since artifacts
+associate with runs (not jobs) and reruns share a `run_id`; a digest that
+cannot be tied to the claimed attempt's named artifact refuses;
 `authorization`: `{environment, approval_context}` (§11 wording
 decision). Genesis and transitions are distinct schemas; a receipt cannot
 claim their role.
@@ -238,21 +260,30 @@ records refuse in replay (§3.3).
 
 ### 3.3 The predicate, deterministic and total
 
-Compute the tree-entry diff between the base and subject manifests
-(equivalently `git diff-tree --no-renames`): per-path additions,
+Compute the tree-entry diff between the base and subject manifests —
+manifest set-difference is normative; the Git equivalent is
+`git diff-tree -r --raw -z --no-renames` (recursive: without `-r`,
+diff-tree reports directory names, which would let nested protected
+changes hide behind an unprotected directory entry): per-path additions,
 deletions, and modifications, including mode-only modifications. Renames
 do not exist at this level. Over the protected subset:
 
-1. **Unique valid assignment.** A valid assignment maps every changed
-   protected path to exactly one non-forking, non-cyclic chain of
-   transitions drawn from eligible records — records consumed atomically
-   (all transitions used, or none), no transition against an unchanged
-   path, endpoints per rule 2. If no valid assignment exists, refuse
-   (uncovered or inconsistent). **If more than one valid assignment
-   exists, refuse as ambiguous** — a candidate avoids this by not
-   shipping redundant covering records. Records unusable in any valid
-   assignment (dead-end retries) are legal, listed as unused, and create
-   no ambiguity.
+1. **Unique valid assignment.** Record hygiene first: a record's
+   transitions must have unique paths (duplicates refuse the record at
+   parse), and every transition path in an eligible record must be
+   protected under the base policy — a record touching any unprotected
+   path is ineligible, listed with its reason, and can never be
+   consumed, so consumption semantics never depend on unprotected diff
+   entries. A valid assignment then maps every changed protected path to
+   exactly one non-forking, non-cyclic chain of transitions drawn from
+   eligible records — records consumed atomically (every transition of a
+   consumed record used against the diff, or none), no transition
+   against an unchanged path, endpoints per rule 2. If no valid
+   assignment exists, refuse (uncovered or inconsistent). **If more than
+   one valid assignment exists, refuse as ambiguous** — a candidate
+   avoids this by not shipping redundant covering records. Records
+   unusable in any valid assignment (dead-end retries) are legal, listed
+   as unused, and create no ambiguity.
 2. **Blob-and-mode ground truth.** Each chain's first
    `(before_blob_sha256, before_mode)` equals the path's state at the
    base (`(null, null)` for additions); each link's after-state equals
@@ -343,8 +374,15 @@ self-approval) — an environment that holds no generation credentials and
 no write tokens, unlike today's `production-signing`, which provisions
 generation workflows with the apply key, a model credential, and a
 write-capable token and is structurally disqualified. Environment
-approval releases the *request* to the external signer; it never releases
-key material to a runner.
+approval releases the *request* to the external signer; it never
+releases key material to a runner.
+
+Effective-permission constraints, not deployment assumptions (§9): the
+external signer's own deployment holds no model, generation, or
+repository-write credentials; the trusted recomputation job's automatic
+`GITHUB_TOKEN` is read-only (`contents: read`, nothing else) and it
+references no other secrets; and the publisher's identity is denied the
+notary signing operation by the signer's caller allowlist.
 
 **Publisher — separate job.** Holds only a token whose write capability
 is confined to the notary ref by repository ruleset (App tokens scope to
@@ -427,31 +465,57 @@ state.
 
 ## 7. Two-phase publication and the canonical chain
 
-The canonical chain lives at a dedicated ref
-(`refs/notary/chain`) in the lane repository: content-addressed artifact
-files plus a single `HEAD.json` naming the current finalized tip
-(`{schema: "axiom/notary-head/v1", tip_sha256, tip_kind}`). All updates
-are compare-and-swap; the publisher's ruleset confines writes to this
-ref.
+The canonical chain lives on a **protected branch** —
+`refs/heads/notary/chain` — because GitHub rulesets protect branches and
+tags, not arbitrary ref namespaces, and a repository-scoped write token
+can otherwise manipulate qualified refs at will. The branch's ruleset:
+only the publisher App may push; no force pushes; no deletion; linear
+history. Its contents: content-addressed artifact files (reports,
+receipts, transitions, genesis, and void markers) plus `HEAD.json`
+(`{schema: "axiom/notary-head/v1", tip_sha256, tip_kind}`) as a
+convenience pointer.
 
-Admission is two-phase, which resolves the ordering circularity between
+**Verification does not trust the pointer.** The chain's truth is
+reconstructible by rule from the branch alone: the valid chain is the
+unique sequence of signed artifacts starting at genesis in which each
+artifact's base manifest equals its predecessor's subject manifest, each
+was finalized by an on-branch finalization commit, and no void marker
+names it. Because the ruleset forbids force pushes and deletions, a
+rollback, a void erasure, or a pointer rewrite is either blocked outright
+or visible as history the reconstruction rejects. `HEAD.json` diverging
+from the reconstruction is itself a refusal.
+
+Admission is two-phase, resolving the ordering circularity between
 "receipt must exist to authorize the merge" and "the merged state must
 equal what was verified":
 
 1. **Pending.** Job 1 verifies the candidate head (subject tree `T1`);
-   the signer signs the receipt (or transition). The publisher writes it
-   to the notary ref as *pending* and sets the required status check on
-   the candidate. A pending artifact authorizes exactly one thing: the
-   merge of a head whose tree manifest is `T1`. It is not the chain tip.
-2. **Finalize.** After the merge, the finalizer (publisher job,
-   triggered on the protected ref) recomputes the merged tip's tree
-   manifest. If it equals `T1`, it advances `HEAD.json` to the artifact
-   by CAS — the artifact is now finalized and chain-eligible. If it
-   differs (conflicted queue merge, stale squash), finalization refuses,
-   the artifact is permanently void (a voided digest is recorded and can
-   never finalize), and verification reruns from the true finalized tip.
-   A pending artifact whose candidate never merges simply never
-   finalizes; the chain never advanced, so nothing strands.
+   the signer signs the receipt (or transition). The publisher commits it
+   to the chain branch as *pending* and sets the required status check on
+   the candidate — a check whose required context is **bound to the
+   publisher App** in branch protection, so a same-named context from
+   Actions or any other integration does not satisfy the requirement. A
+   pending artifact authorizes exactly one thing: the merge of a head
+   whose tree manifest is `T1` onto the finalized tip it names as base.
+2. **Freshness.** The protected content branch requires strict
+   up-to-date-with-base merges (or a merge queue whose `merge_group`
+   head is itself verified). A pending artifact binds its base manifest;
+   when another candidate finalizes first, the stale candidate's base no
+   longer matches the finalized tip, the strict requirement forces a new
+   head, and the superseded pending artifact is voided by the publisher
+   rather than left green. The race sol named — two green pendings, the
+   second merging onto a moved base — is closed before merge, not
+   discovered after.
+3. **Finalize.** After the merge, the finalizer (publisher job,
+   triggered on the protected content ref) recomputes the merged tip's
+   tree manifest. If it equals `T1` and the artifact's base equals the
+   current finalized tip, it commits the finalization marker and
+   advances `HEAD.json` — compare-and-swap via the atomic branch update.
+   Otherwise finalization refuses, the artifact is permanently void (a
+   void marker commits to the chain branch; a voided digest can never
+   finalize), and verification reruns from the true finalized tip. A
+   pending artifact whose candidate never merges simply never finalizes;
+   the chain never advanced, so nothing strands.
 
 Squash and merge-queue rewrites are therefore harmless exactly when they
 preserve the verified tree, and void the attempt exactly when they do
@@ -488,9 +552,18 @@ scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
    re-derived from content-addressed inputs before signing; typed
    operations for genesis, transition, and receipt scopes; no raw-byte
    signing for those scopes.
-7. The publisher split implemented, with a repository ruleset confining
-   the publisher token's writes to the notary ref, and the two-phase
-   pending/finalize protocol with CAS and permanent voiding.
+7. The publisher split implemented: the chain on its protected branch
+   with an App-restricted, no-force-push, no-deletion ruleset; the
+   required admission check bound to the publisher App (a same-named
+   context from any other source must not satisfy it); strict
+   up-to-date-with-base merges (or verified merge-group heads) on the
+   protected content branch; and the two-phase pending/finalize protocol
+   with supersession voiding and permanent void markers.
+7a. Effective-permission constraints audited: the external signer
+   deployment holds no model, generation, or repository-write
+   credentials; the trusted recomputation job runs with a read-only
+   `GITHUB_TOKEN` and no other secrets; the publisher identity is denied
+   the notary signing operation.
 8. Signed-leg billing and abuse policy operational (#1193).
 9. Key ceremony completed per §8.
 10. Org-variable trust anchors eliminated from the signing path.
@@ -520,8 +593,10 @@ attempt against genesis, transition, or notary scopes; full pairwise
 cross-scope matrix including legacy operations.
 
 **Manifests and totality:** gitlink anywhere in the tree; non-UTF-8 path
-anywhere in the tree (changed or unchanged); inadmissible mode; symlink
-inside the protected domain; manifest sort-order violation; two trees
+anywhere in the tree (changed or unchanged); inadmissible terminal mode;
+symlink inside the protected domain; symlink with non-UTF-8 target bytes
+outside the protected domain manifests correctly (positive control —
+targets hash as raw bytes); manifest sort-order violation; two trees
 differing only by a gitlink refused rather than treated as
 manifest-equal.
 
@@ -533,9 +608,13 @@ admissible set.
 uncovered protected change; uncovered mode-only change; overlapping
 chains; transition against an unchanged path; forked, cyclic, or
 discontinuous chain; wrong starting or terminal blob/mode; malformed
-null-sides; partial record consumption; **ambiguous assignment (two
-redundant covering records; split-vs-direct chains)**; dead-end retry
-record accepted as unused without ambiguity (positive control);
+null-sides; partial record consumption; duplicate transition paths
+within a record; record containing an unprotected-path transition
+(ineligible, with reason); **ambiguous assignment (two redundant
+covering records; split-vs-direct chains)**; dead-end retry record
+accepted as unused without ambiguity (positive control); nested
+protected change reported only as its directory by a non-recursive diff
+(must refuse or be impossible under the normative diff);
 `waived`/`not-run` post-epoch; path-policy precedence cases
 (include-then-exclude; `rules-evil/x`; unmatched default-unprotected).
 
@@ -556,7 +635,9 @@ skip-flag attempt; profile or policy not committed at the base.
 wrong chain predecessor digest or kind enum; second genesis; genesis
 with a non-exhaustive, overlapping, or duplicate-path partition; genesis
 entry citing a record failing the v5 contract (wrong schema family,
-invalid signature, path/blob disagreement); nonexistent
+invalid signature, wrong encoder identity, wrong waiver binding,
+path/blob disagreement); transition whose enumerated delta contains a
+non-trust-surface path; nonexistent
 `record_sha256`; duplicate qualifying v5 records for one path; genesis
 carrying coverage; empty-delta first receipt leaving baseline provenance
 unchanged (positive control); post-epoch change vouched only by v5; v5
@@ -567,13 +648,25 @@ unfinalized transition used as predecessor; ordinary receipt attempting
 a trust-surface change.
 
 **Signer, publication, finalization:** OIDC identity mismatch (wrong
-workflow, job, run, repository, or ref); Job-1 run non-success; artifact
-digest mismatch; replayed artifact under a new run; signing a refusal
-report; stale base at recomputation; pending artifact treated as chain
-tip; finalization with merged-tip manifest differing from the verified
-subject (voids, permanently); voided digest re-finalization attempt; CAS
-loss on `HEAD.json`; publisher push outside the notary ref rejected by
-ruleset; `HEAD.json` naming an unpublished or unsigned artifact.
+workflow, job, run, repository, or ref); Job-1 run non-success; wrong
+`run_attempt` (artifact from an earlier attempt under the same run id);
+artifact name or producing-job mismatch; artifact digest mismatch;
+replayed artifact under a new run; signing a refusal report; stale base
+at recomputation; pending artifact treated as chain tip; superseded
+pending artifact voided when another candidate finalizes first (positive
+control) and refused if presented after; required-check context from a
+non-App source (same-named Actions check) not satisfying branch
+protection; merge-group head differing from the verified subject;
+finalization with merged-tip manifest differing from the verified
+subject (voids, permanently); voided digest re-finalization attempt;
+finalization when the artifact's base is not the current finalized tip;
+chain-branch force-push and deletion rejected by ruleset; unauthorized
+chain rollback or void-marker erasure visible to reconstruction;
+`HEAD.json` diverging from chain reconstruction; publisher push outside
+the chain branch rejected; `HEAD.json` naming an unpublished or unsigned
+artifact; recomputation divergence in `eligible_records`,
+`corpus_release`, `waiver_set_sha256`, `dependency_pins_sha256`, or
+`verifier_commit_git_oid`.
 
 ## 11. Decisions for sign-off
 

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,13 +1,13 @@
-# Notary admission: design v3
+# Notary admission: design v4
 
 Status: draft for sign-off. Implements the #1192 charter with the #1506
 diff-coverage delta, under the build decision recorded on both issues
-(dual-verdict, 2026-08-17). Version 3 folds design-review rounds 1 and 2
-(seventeen blocking findings total; the review record lives on #1507).
-Nothing admission-capable merges until the preconditions in §9 are
-satisfied and this document is approved by the charter's gate: an
-independent cross-family review of this concrete design plus Max's named
-sign-off, with every §11 decision closed.
+(dual-verdict, 2026-08-17). Version 4 folds design-review rounds 1–3
+(twenty-five blocking findings; the record lives on #1507). Nothing
+admission-capable merges until the §9 preconditions are satisfied and this
+document is approved by the charter's gate: an independent cross-family
+review of this concrete design plus Max's named sign-off, with every §11
+decision closed.
 
 ## 1. Claim and threat model
 
@@ -18,43 +18,53 @@ The notary signs one narrow claim:
 > `C` (a receipt, a transition record, or genesis): under the verifier
 > profile and protected-path policy committed at the base, every
 > protected-content tree-entry change from `T0` to `T1` is covered by the
-> eligible lineage set; every gate the profile requires produced an
-> outcome the profile accepts; unprotected tree-entry changes are
-> enumerated in `R`; and the protected signing policy authorized this
-> acceptance.
+> unique valid assignment over the eligible lineage set; every gate the
+> profile requires is declared with an outcome the profile accepts;
+> unprotected tree-entry changes are enumerated in `R`; and the protected
+> signing policy authorized this acceptance.
+
+Two classes of statement inside that claim have different evidentiary
+strength, and the receipt does not blur them. **Recomputed invariants** —
+tree manifests, the diff, protected-path classification, lineage
+eligibility and authentication, the coverage assignment, the unprotected
+enumeration, chain linkage — are computed by trusted pinned code from
+content-addressed inputs, independently of anything the candidate
+executed, and cannot be forged by candidate code. **Gate outcomes** are
+declarations produced by running the candidate's own gates; a compromised
+candidate weakening its gates is the residual risk the charter accepts,
+unchanged in kind from today, and the receipt words them as declarations
+("declared with an outcome the profile accepts"), never as re-established
+facts.
 
 Admission is a statement about the *delta*: the changes since the chain
 predecessor are covered. It never upgrades the provenance of older bytes.
-Pre-epoch content remains exactly what the genesis inventories say it is —
+Pre-epoch content remains exactly what the genesis inventories say —
 v5-attested or unattested baseline — no matter how many receipts later sit
 above it; an empty-delta receipt admits nothing and changes no provenance
-status. The claim covers exactly what the predicate checks
-(protected-content tree-entry changes), and unprotected changes are
-enumerated in the report rather than silently excluded.
+status.
 
-The notary does not claim content was model-generated, and never will —
-that claim bred provenance laundering (the Path R pattern) and is retired
-with the v5 era. Lineage records say where bytes came from; the notary
-says the deterministic gates passed, coverage held, and admission chains
-from the last admitted state.
+The notary does not claim content was model-generated, and never will.
+Lineage records say where bytes came from; the notary says the recomputed
+invariants held, the gates were declared acceptable, and admission chains
+from the last finalized state.
 
 The scenario this design closes: an agent with repository write access
 hand-edits a published rule and obtains a legitimate signature through the
 sanctioned path, with no record of the edit's origin. Two walls stop the
 *undeclared* hand edit — declared corrections are intentionally
-admissible, loudly. The capability wall: no generation surface holds the
-merge-authorizing notary capability; the notary key is reachable only by
-the typed signing job, on isolated compute, in a dedicated notary-only
-environment. (Generation surfaces do hold the non-authorizing producer
-key — that signs lineage, not admission.) The coverage wall: a changed
-protected path with no covering eligible lineage refuses at verification,
-and the signer independently re-enforces that verdict before signing.
+admissible, loudly. The capability wall: the notary key never enters any
+runner; an external typed signer validates an independently authenticated
+job identity, and generation surfaces hold only the non-authorizing
+producer key. The coverage wall: coverage is a recomputed invariant — the
+trusted side re-derives it from git data and lineage records, so neither a
+hand edit nor a forged report can pass it.
 
 Residual risks accepted, per the charter: a verifier soundness bug
-deterministically accepts wrong law; candidate-controlled tests can be
-weakened; reviewer compromise authorizes validator-passing bad content.
-Mitigations are the strict profile, the trusted preflight, golden
-regeneration QA, and oracles — not additional signatures.
+deterministically accepts wrong law; candidate-controlled gates can be
+weakened (declared outcomes only); reviewer compromise authorizes
+validator-passing bad content. Mitigations are the strict profile, the
+trusted preflight, golden regeneration QA, and oracles — not additional
+signatures.
 
 ## 2. Artifacts, schemas, and signature envelope
 
@@ -63,24 +73,32 @@ regeneration QA, and oracles — not additional signatures.
 **Serialization.** Bodies are canonical JSON (receipt-canonical
 serialization: UTF-16 code-unit key order, ECMAScript number formatting),
 UTF-8 bytes, content-addressed by SHA-256 of the body bytes. Every body
-carries `schema` (its full identifier, e.g. `axiom/notary-receipt/v1` —
-the same full string serves as the signing scope; there are no shortened
-scope names) and `lane` (canonical `owner/repo`). Schemas are
-closed-world: an unknown field, a missing field, or a wrong type is a
-parse refusal.
+carries `schema` and `lane`. Schemas are closed-world: an unknown field,
+missing field, or wrong type is a parse refusal.
 
-**Identifiers and digests.** Two disjoint conventions, never mixed:
+**Value encodings, normatively.** One table, no exceptions:
 
-- `*_git_oid`: a Git object id in the repository's object format (SHA-1
-  in the pilot repositories). Used to *locate* objects and to interact
-  with Git, the Actions control plane, and CAS. Never the
-  collision-resistance-bearing binding.
-- `*_sha256`: SHA-256 over defined content bytes. Blob digests are over
-  raw blob content. A **tree manifest digest** is SHA-256 over the
-  canonical JSON array of `[path, mode, content_sha256]` triples, sorted
-  by path, covering every blob reachable from the tree — the
-  collision-resistant description of a tree state, independent of Git's
-  object format.
+| Kind | JSON encoding |
+|---|---|
+| SHA-256 digest (`*_sha256`, filenames, broker payload) | 64-char lowercase hex string, no prefix; GitHub artifact digests have their `sha256:` prefix stripped before entry |
+| Git object id (`*_git_oid`, incl. `workflow_git_oid`) | 40-char lowercase hex string (SHA-1 object format in the pilot) |
+| Ed25519 signature | `signature_base64`: standard base64 with padding (RFC 4648 §4) |
+| `signer_spki_sha256` | SHA-256 of the DER-encoded SubjectPublicKeyInfo, hex as above |
+| `run_id`, `run_attempt` | JSON strings (decimal), never numbers |
+| `chain_predecessor_kind` | exactly one of `"genesis"`, `"receipt"`, `"transition"` |
+| Paths | UTF-8 strings; sorting is bytewise over the UTF-8 encoding |
+
+**Tree manifests.** A tree manifest binds **every entry** reachable from a
+tree, not only blobs: the canonical JSON array of
+`[path, mode, entry_sha256]` sorted bytewise by path, where `entry_sha256`
+is SHA-256 over blob content for blob modes and over the UTF-8 target
+string for symlinks. Pilot totality rules, applied to **whole trees** at
+verification, genesis, and finalization — not merely to diffs: a gitlink
+(mode 160000) anywhere in the tree is a refusal; a non-UTF-8 path anywhere
+in the tree is a refusal; modes outside {100644, 100755, 120000} are a
+refusal, and 120000 only outside the protected domain. Within these rules
+the manifest is a complete binding of the tree: two trees with equal
+manifests are entry-identical.
 
 **Signature envelope.** Signing uses the existing broker frame verbatim:
 
@@ -88,450 +106,474 @@ parse refusal.
 "axiom-encode/external-signer-sign/v2" || 0x00 || scope || 0x00 || payload
 ```
 
-where `scope` is the artifact's full schema identifier and `payload` is
-the 64-byte lowercase-hex ASCII encoding of the body's SHA-256.
-Signatures are detached files beside the body: `<digest>.json` and
-`<digest>.json.<role>.sig`, where `<role>` is `producer`, `actor`,
-`review`, `genesis`, `transition`, or `notary`. Each `.sig` file is
-canonical JSON: `{schema: "axiom/detached-signature/v1", body_sha256,
-scope, signer_spki_sha256, signature_base64}`. A signature under one
-scope must fail verification under every other scope, legacy
-`apply_ed25519`/`eval_ed25519` operations included (§10 tests the full
-pairwise matrix).
+with `payload` the 64-char lowercase-hex ASCII digest of the body. Scopes
+are bound by a normative role table — the scope is the *signing role's*
+identifier, which for countersignatures deliberately differs from the
+body's schema:
 
-**Typed signing.** For the notary and transition scopes, the trusted
-signing component accepts only the typed fields of §2.5/§6.4,
-reconstructs the canonical body itself, computes its digest, and signs.
-No caller can submit arbitrary bytes to those scopes. Lineage scopes
-(producer, actor, review) are signed at their origins (supervised
-runtime; actor and reviewer tooling) under the same envelope.
+| Role | Scope | Body signed |
+|---|---|---|
+| producer | `axiom/lineage-generation/v1` | generation event |
+| actor | `axiom/lineage-correction/v1` | correction event |
+| review | `axiom/lineage-correction-review/v1` | correction event (same body digest) |
+| genesis | `axiom/notary-genesis/v1` | genesis |
+| transition | `axiom/notary-transition/v1` | transition record |
+| notary | `axiom/notary-receipt/v1` | notary receipt |
+
+Signatures are detached files beside the body (`<digest>.json`,
+`<digest>.json.<role>.sig`), each canonical JSON:
+`{schema: "axiom/detached-signature/v1", body_sha256, scope,
+signer_spki_sha256, signature_base64}`. Every cross-scope verification
+must fail, legacy `apply_ed25519`/`eval_ed25519` included (§10 tests the
+full pairwise matrix).
+
+**Typed signing.** The genesis, transition, and notary scopes are signed
+only by the external typed signer (§5): it accepts typed fields,
+reconstructs the canonical body itself, computes the digest, and signs. No
+caller can submit arbitrary bytes to those scopes, genesis included.
+Lineage scopes are signed at their origins (supervised runtime; actor and
+reviewer tooling).
 
 ### 2.2 Generation event — `axiom/lineage-generation/v1`
 
-Signed by the supervised-runtime producer key (non-authorizing). Fields:
-`schema`, `lane`, `epoch_sha256` (§6), `runtime_identity`, `model`,
-`cli_version`, `cli_sha256`, `prompt_sha256s`, `emitted_at`
-(informational, unverified), and `transitions`: an array sorted by path,
-each:
+Signed by the producer key (non-authorizing). Fields: `schema`, `lane`,
+`epoch_sha256`, `runtime_identity`, `model`, `cli_version`, `cli_sha256`,
+`prompt_sha256s`, `emitted_at` (informational, unverified), and
+`transitions`, sorted bytewise by path:
 
 ```
 {path, before_blob_sha256 | null, before_mode | null,
  after_blob_sha256 | null, after_mode | null,
- patch_sha256, patch_algorithm}
+ patch_note_sha256 | null}
 ```
 
-Modes are restricted to `"100644"` and `"100755"`; the mode is `null`
-exactly when the corresponding blob digest is `null` (absent side). A
-mode-only change is a real transition (same blob digests, differing
-modes). `patch_algorithm` names a versioned canonical recipe
-(`git-patch-v1`: `git diff --no-renames --full-index --binary -U3` with
-`core.autocrlf=false`, no textconv, no external diff, attributes
-ignored); the patch digest is audit metadata — blob digests and modes are
+Modes are `"100644"` or `"100755"`, `null` exactly when the corresponding
+blob digest is `null`. A mode-only change is a real transition (equal blob
+digests, differing modes). `patch_note_sha256` is **opaque audit
+metadata**: a producer-chosen digest of whatever diff rendering the
+runtime archived. It is never verified, carries no algorithm contract, and
+no refusal depends on it — endpoint blob digests and modes are the sole
 ground truth.
 
 ### 2.3 Correction event — `axiom/lineage-correction/v1`
 
-Signed by the actor's key (role `actor`) and countersigned by a protected
-reviewer key distinct from the actor's (role `review`, scope
-`axiom/lineage-correction-review/v1` over the same body digest). Fields:
-`schema`, `lane`, `epoch_sha256`, `actor`, `reason`,
-`predecessor_record_sha256 | null`, and `transitions` as in §2.2. The
-countersignature validates lineage — it never authorizes merge.
-Corrections are first-class and loud: the sanctioned response to a wrong
-encoding remains fix-the-encoder-and-re-encode, and a correction event is
-the recorded exception, never the quiet path.
+Signed by the actor (role `actor`) and countersigned by a protected
+reviewer key distinct from the actor's (role `review`, per the §2.1 role
+table). Fields: `schema`, `lane`, `epoch_sha256`, `actor`, `reason`,
+`predecessor_record_sha256 | null`, `transitions` as §2.2. The
+countersignature validates lineage; it never authorizes merge. Corrections
+are first-class and loud: the sanctioned response to a wrong encoding
+remains fix-the-encoder-and-re-encode, and a correction event is the
+recorded exception, never the quiet path.
 
 ### 2.4 Verification report (Job 1, unsigned) — `axiom/notary-report/v1`
 
-Content-addressed, produced by the secretless verify job. Fields:
+Content-addressed output of the verification workflow. Fields: `schema`,
+`lane`, `epoch_sha256`; `subject_commit_git_oid`,
+`subject_tree_manifest_sha256`; `base_commit_git_oid`,
+`base_tree_manifest_sha256`; `chain_predecessor_sha256`,
+`chain_predecessor_kind`; `profile_sha256`, `path_policy_sha256`;
+`corpus_release` `{name, content_sha256}`; `waiver_set_sha256`;
+`eligible_records` and `unused_eligible_records` (sorted digest arrays);
+`coverage_assignment` (per changed protected path, the ordered record
+digests consumed — the unique assignment of §3.3); `gates`: array sorted
+by `gate_id`, **one entry per gate id** (duplicates are a parse refusal),
+each `{gate_id, outcome, tier}`; `diff_coverage`: `"pass"` or a typed
+refusal object (never `waived`, never `not-run`); `unprotected_changes`
+(sorted paths); `dependency_pins_sha256`; `verifier_commit_git_oid`.
 
-- `schema`, `lane`, `epoch_sha256`
-- `subject_commit_git_oid`, `subject_tree_manifest_sha256`
-- `base_commit_git_oid`, `base_tree_manifest_sha256`
-- `chain_predecessor_sha256` (receipt, transition record, or genesis body
-  digest) and `chain_predecessor_kind`
-- `profile_sha256`, `path_policy_sha256` (digests of the definition files
-  committed at the base)
-- `corpus_release`: `{name, content_sha256}` (the toolchain tuple)
-- `waiver_set_sha256`
-- `eligible_records`: sorted array of record digests (§3.2), and
-  `unused_eligible_records`: sorted subset not consumed by the assignment
-- `gates`: sorted array of `{gate_id, outcome, tier}`, `tier` in
-  `public | restricted | ci-attested`
-- `diff_coverage`: `"pass"` or a typed refusal object (never `waived`,
-  never `not-run`)
-- `unprotected_changes`: sorted array of changed paths outside the
-  protected domain
-- `dependency_pins_sha256`, `verifier_commit_git_oid`
+The report is a *proposal*. Refusal reports are diagnostic artifacts, and
+even a pass report authorizes nothing: every claim-bearing field is
+recomputed by the trusted side (§5) before signing, so a candidate-forged
+report — pass verdict, trimmed unprotected list, invented assignment —
+fails reconciliation rather than getting signed.
 
-A report may record a refusal — refusal reports are diagnostic artifacts.
-Nothing downstream may sign one: the signer enforces acceptance itself
-(§5), never inferring it from a job's success.
+### 2.5 Notary receipt (signed) — `axiom/notary-receipt/v1`
 
-### 2.5 Notary receipt (Job 2, signed) — `axiom/notary-receipt/v1`
-
-The only merge-authorizing artifact, signed under the notary scope by
-`notary_ed25519`. Fields:
-
-- `schema`, `lane`, `epoch_sha256`
-- `report_sha256`
-- `subject_commit_git_oid`, `subject_tree_manifest_sha256`,
-  `base_tree_manifest_sha256`, `chain_predecessor_sha256`,
-  `chain_predecessor_kind` — each independently re-derived by the signing
-  component and required to match the report (a mismatch is a refusal,
-  §5)
-- `job1`: `{workflow_path, workflow_sha, ref, run_id, run_attempt,
-  conclusion, artifact_sha256}` as read from the Actions control plane by
-  the signing component itself
-- `authorization`: `{environment, approval_context}` (§11 wording
-  decision)
-
-There is no `genesis` flag: genesis and transitions are distinct schemas
-(§6), and a receipt claiming their role fails its closed schema.
+The only artifact that, once finalized (§7), authorizes admission. Fields:
+`schema`, `lane`, `epoch_sha256`; `report_sha256`; the §2.4 chain and
+tree fields, each independently recomputed by the trusted side; `gates`
+as declared (deduplicated, profile-complete, outcomes acceptable);
+`job1`: `{workflow_path, workflow_git_oid, ref, run_id, run_attempt,
+conclusion, artifact_sha256}` as read from the Actions control plane;
+`authorization`: `{environment, approval_context}` (§11 wording
+decision). Genesis and transitions are distinct schemas; a receipt cannot
+claim their role.
 
 ### 2.6 Storage
 
 Lineage records live in the lane repository under `.axiom/lineage/`,
-append-only, one body file per record named by its content digest, with
+append-only, one body file per record named by its content digest,
 detached signatures beside it. The lineage directory is outside the
-protected-content coverage domain (its additions need no covering record)
-but inside the preflight's structural checks: schema-valid,
-authenticated, correctly content-addressed, append-only. Deleting or
-mutating an existing lineage record is a refusal. Reports, receipts,
-genesis, and transition records publish per §7 and are never part of the
-subject tree.
+protected-content coverage domain but inside the preflight's structural
+checks: schema-valid, authenticated, correctly content-addressed,
+append-only; deleting or mutating an existing record is a refusal.
+Reports, receipts, genesis, and transition records publish per §7 and are
+never part of the subject tree.
 
 ## 3. The diff-coverage predicate
 
-### 3.1 Protected paths, defined normatively
+### 3.1 Protected paths
 
-The protected-path policy is a committed file at the base
+The policy is a committed file at the base
 (`.axiom/notary/path-policy.json`):
-
-```
-{schema: "axiom/notary-path-policy/v1",
- rules: [{action: "include" | "exclude", prefix: "<path prefix>"}]}
-```
-
-Semantics, exactly: a prefix matches path `p` iff `p == prefix` or `p`
-begins with `prefix + "/"` — component-wise, so `rules` never matches
-`rules-evil/x`. Rules are evaluated in order; the **last** matching rule
-decides; a path matching no rule is **unprotected**. Prefixes and paths
-are UTF-8 strings. Classification uses the policy committed at the base —
-a candidate cannot reclassify paths in its own favor, and a policy change
-is a trust-surface change ordinary candidates cannot carry (§4; it moves
-by transition record, §6.4).
-
-Totality rule for undecodable names: any changed path anywhere in the
-base→subject diff that is not valid UTF-8 is a refusal in the pilot —
-protected or not — because neither the policy nor the report's JSON
-arrays can represent it faithfully.
+`{schema: "axiom/notary-path-policy/v1", rules: [{action:
+"include" | "exclude", prefix}]}`. A prefix matches path `p` iff
+`p == prefix` or `p` starts with `prefix + "/"` (component-wise; `rules`
+never matches `rules-evil/x`). Last matching rule wins; a path matching no
+rule is unprotected. Classification uses the policy committed at the
+base. Tree-wide totality (UTF-8, no gitlinks, admissible modes) is
+enforced by §2.1's manifest rules, so classification is total over every
+manifest the system accepts.
 
 ### 3.2 Eligible lineage set
 
-Eligible records are exactly the records whose body files are present
-under `.axiom/lineage/` in the subject tree and absent at the base —
-introduced by this candidate — and which carry this `lane` and this
-`epoch_sha256`. The sorted digest list is bound into the report. This
-defeats replay: a record merged by an earlier candidate is present at the
-base and ineligible ever after; a cross-lane or cross-epoch record
-refuses on its bindings; a stale record whose before-digests no longer
-match the base refuses in replay (§3.3).
+Records present under `.axiom/lineage/` in the subject tree and absent at
+the base — introduced by this candidate — carrying this `lane` and
+`epoch_sha256`, with valid signatures per the role table. The sorted
+digest list is bound into report and receipt. Replay is dead: a record
+merged by an earlier candidate is present at the base and ineligible ever
+after; cross-lane and cross-epoch records refuse on their bindings; stale
+records refuse in replay (§3.3).
 
-Records are consumed atomically: all of a record's transitions used by
-the covering assignment, or none. A partially matching record is a
-refusal. Unused eligible records are legal (a retried generation) and are
-listed in the report — never invisible.
+### 3.3 The predicate, deterministic and total
 
-### 3.3 The predicate
+Compute the tree-entry diff between the base and subject manifests
+(equivalently `git diff-tree --no-renames`): per-path additions,
+deletions, and modifications, including mode-only modifications. Renames
+do not exist at this level. Over the protected subset:
 
-Compute the tree-entry diff from base tree to subject tree with rename
-detection disabled (`git diff-tree --no-renames` semantics): a set of
-per-path entry changes — additions, deletions, modifications, including
-mode-only modifications. Renames do not exist at this level; a moved file
-is a deletion and an addition, each needing coverage. Then, over the
-protected subset:
-
-1. **Closed-world assignment.** Every changed protected path maps to
-   exactly one non-forking, non-cyclic chain of transitions drawn from
-   eligible records — no missing, no overlapping, no extra transitions
-   against unchanged paths.
+1. **Unique valid assignment.** A valid assignment maps every changed
+   protected path to exactly one non-forking, non-cyclic chain of
+   transitions drawn from eligible records — records consumed atomically
+   (all transitions used, or none), no transition against an unchanged
+   path, endpoints per rule 2. If no valid assignment exists, refuse
+   (uncovered or inconsistent). **If more than one valid assignment
+   exists, refuse as ambiguous** — a candidate avoids this by not
+   shipping redundant covering records. Records unusable in any valid
+   assignment (dead-end retries) are legal, listed as unused, and create
+   no ambiguity.
 2. **Blob-and-mode ground truth.** Each chain's first
    `(before_blob_sha256, before_mode)` equals the path's state at the
-   base (`(null, null)` for an addition); each link's after-state equals
-   the next link's before-state; the last after-state equals the path's
-   state in the subject tree (`(null, null)` for a deletion). A mode-only
-   change requires a covering transition like any other change.
-3. **Admissible entries only.** Protected paths must be regular blobs
-   (mode 100644 or 100755) wherever they exist. A gitlink, symlink, or
-   other mode at a protected path — either side — is a refusal.
-   File-to-directory and directory-to-file replacements decompose into
-   entry deletions and additions and are covered as such.
+   base (`(null, null)` for additions); each link's after-state equals
+   the next link's before-state; the final after-state equals the path's
+   state in the subject (`(null, null)` for deletions). Mode-only changes
+   need a covering transition like any other change.
+3. **Admissible entries.** Protected paths are regular blobs (100644 or
+   100755) wherever they exist — symlinks are inadmissible in the
+   protected domain, and gitlinks are refused tree-wide by §2.1.
+   File/directory replacements decompose into entry deletions and
+   additions and are covered as such.
 4. **Binary verdict.** `diff_coverage` is `"pass"` or a typed refusal.
-   From the enforcement epoch there is no `waived` and no `not-run`; an
-   emergency change without a countersigned correction event is a
-   refusal. This is deliberately stricter than consumer-side declaration
-   completeness, which accepts declared `waived`/`not-run` outcomes as
-   well-formed.
+   From the enforcement epoch there is no `waived` and no `not-run`. This
+   is deliberately stricter than consumer-side declaration completeness.
 
-Advisory shadow runs (compute and publish the verdict without gating) are
-permitted only before a lane's enforcement epoch.
+The entire predicate — manifests, diff, classification, eligibility,
+authentication, assignment uniqueness, unprotected enumeration — is a
+pure function of git data and lineage records. It runs twice: in Job 1
+(producing the report) and independently on the trusted side (§5), which
+is why a forged report cannot survive.
+
+Advisory shadow runs are permitted only before a lane's enforcement
+epoch.
 
 ## 4. Verifier profile P and trusted preflight
 
-The profile is a committed definition at the base, digest-bound into the
-report. It defines the gate set, each gate's acceptable outcomes, and the
-oracle policy. It is not the current apply path, and the differences are
-the point:
+The profile is a committed definition at the base, digest-bound into
+report and receipt. It defines the required gate set, each gate's
+acceptable outcomes, and the oracle policy. Against the current apply
+path: non-mutating (no repairs; repairable-but-unrepaired refuses);
+oracles on (licensed/unavailable oracles per the §11 decision — fail
+closed or visibly reduced-tier, never silent); reviewers means
+deterministic checks plus protected-environment human approval (the
+validator pipeline's LLM reviewers are QA outside the admission path);
+no caller switches (skip flags and caller-disableable guards have no
+notary equivalents).
 
-- **Non-mutating.** No deterministic repairs. The subject is verified as
-  presented or refused; a repairable-but-unrepaired subject refuses.
-- **Oracles on.** The apply overlay's oracle disablement does not exist
-  here. Licensed or unavailable oracles follow the §11 decision — fail
-  closed, or a visibly reduced-tier receipt; never silent.
-- **Reviewers means deterministic checks plus protected-environment human
-  approval.** The validator pipeline's LLM reviewers are QA outside the
-  admission path, beside golden regeneration; under the charter's
-  no-model-calls rule they cannot gate the notary.
-- **No caller switches.** Skip flags and caller-disableable guards have
-  no notary equivalents.
+The trusted preflight (pinned code, before any candidate code executes)
+resolves the canonical repository, the chain predecessor and its recorded
+state, the policy and profile at the base, and the complete tree-entry
+diff. Ordinary candidates changing workflows, action pins, verifier pins,
+trust roots, the path policy, the profile, waiver policy,
+repository-structure rules, or lineage-store integrity refuse; those
+surfaces move only by transition record (§6.4).
 
-The trusted preflight (runs in Job 1, from pinned code, before any
-candidate code executes) resolves: the canonical repository; the chain
-predecessor and its recorded state (§6); the path policy and profile at
-the base; the complete tree-entry diff. It refuses ordinary candidates
-that change workflows, action pins, verifier pins, trust roots, the path
-policy, the profile, waiver policy, repository-structure rules, or the
-lineage store's integrity (§2.6). Those surfaces move only by transition
-record (§6.4).
+## 5. Execution, trust boundary, and the external signer
 
-## 5. Jobs, compute isolation, and capability separation
+**Job 1 — verify (secretless, candidate-executing).** Runs on a fresh
+ephemeral runner (GitHub-hosted or dedicated ephemeral pool) with no
+signing capability, no model credentials, no repository-write credential.
+Runs the preflight and predicate from pinned code, executes the
+candidate's gates, and emits the report artifact. Because candidate code
+executes in this job, **nothing Job 1 emits is trusted**: its report is a
+proposal to be reconciled.
 
-**Job 1 — verify (secretless, isolated).** Runs candidate code under the
-strict profile on a **fresh ephemeral runner** (GitHub-hosted, or a
-dedicated ephemeral pool with per-job teardown) with no signing
-capability, no model credentials, and no repository-write credential.
-Emits the §2.4 report as a content-addressed artifact.
+**Trusted recomputation and signing.** The signer is **external**: the
+notary key never enters any runner. The trusted signing component (the
+supervisor/broker service, extended with typed notary operations)
+validates an independently authenticated caller identity via OIDC claims
+(workflow path, job, run id, attempt, repository, ref) rather than
+trusting runner-resident state, and then, itself or through a dedicated
+trusted job running only pinned code on a fresh runner:
 
-**Job 2 — sign (typed, notary-only, isolated).** Runs on a fresh
-ephemeral runner in a **dedicated `notary-signing` environment** — not
-`production-signing`, which today provisions generation workflows with
-the apply key, a model credential, and a write-capable token, and is
-structurally disqualified from holding the notary key. The environment
-enforces required human reviewers, protected refs, no self-approval, and
-Job-2-only secret access; the signer additionally binds the requesting
-workflow and job identity, so a leaked approval cannot be replayed from
-elsewhere. Job 2 runs no candidate code and holds no model or
-repository-write credential. Its trusted component:
-
-1. Reads the Job-1 run from the Actions control plane: workflow path and
-   sha, ref, run id and attempt, conclusion, artifact digest. Wrong
+1. Reads the Job-1 run from the Actions control plane (workflow path and
+   git oid, ref, run id/attempt, conclusion, artifact digest); wrong
    workflow, wrong ref, non-success conclusion, or artifact mismatch
    refuses.
-2. Independently re-fetches and re-hashes the subject and base trees
-   (recomputing both tree manifests), the report body, and the profile
-   and path-policy files at the base; independently re-derives the chain
-   predecessor and its admissibility (§6). Any mismatch with the
-   report's fields discards the run and forces complete reverification.
-3. **Enforces the acceptance predicate itself**: `diff_coverage` is
-   exactly `"pass"`; every gate the profile requires is present with an
-   outcome the profile accepts; the report's eligible and unused record
-   lists are well-formed against the trees. A refusal report — however
-   successfully its workflow concluded — is never signable. Actions
-   success is context, not acceptance.
-4. Reconstructs the §2.5 receipt body from typed fields and signs its
-   digest under the notary scope. It exposes no arbitrary-byte signing
-   operation.
+2. **Recomputes every claim-bearing invariant from content-addressed
+   inputs**: both tree manifests (with §2.1 totality rules), the diff,
+   protected classification under the base-committed policy, lineage
+   eligibility and signature validity, the unique coverage assignment,
+   the unprotected enumeration, and chain-predecessor admissibility
+   (§6/§7). Any divergence from the report refuses — this, not the
+   report, is what the receipt's recomputed fields mean.
+3. Validates the declared gates: one entry per profile-required gate id,
+   no extras outside the profile, outcomes within the profile's
+   acceptable set, tiers valid. Gate outcomes remain declarations (§1).
+4. Requires `diff_coverage` exactly `"pass"` as recomputed. A refusal
+   report — or a pass report that fails recomputation — is never
+   signable, regardless of its workflow's success.
+5. Reconstructs the §2.5 receipt body from typed fields and signs. It
+   exposes no arbitrary-byte operation for the genesis, transition, or
+   notary scopes.
 
-**Publisher — a third job.** Verification and signing forbid
-repository-write capability, so neither publishes. A separate publisher
-job holds only a token whose write capability is confined to the receipt
-publication ref — enforced by a repository ruleset, since App tokens
-scope to repositories, not refs — and pushes per §7. It holds no signing
-capability.
+**Human authorization** gates the signing step through the dedicated
+`notary-signing` environment (required reviewers, protected refs, no
+self-approval) — an environment that holds no generation credentials and
+no write tokens, unlike today's `production-signing`, which provisions
+generation workflows with the apply key, a model credential, and a
+write-capable token and is structurally disqualified. Environment
+approval releases the *request* to the external signer; it never releases
+key material to a runner.
 
-Trust roots for all jobs — public keys, profile and policy digests,
-workflow and action pins, waiver authorities — are committed at or
-digest-pinned to the protected base. Runtime organization variables are
-not trust anchors anywhere in the notary path; eliminating the existing
-`vars.*` provisioning from the signing path is a §9 precondition.
+**Publisher — separate job.** Holds only a token whose write capability
+is confined to the notary ref by repository ruleset (App tokens scope to
+repositories, not refs); publishes per §7; holds no signing capability.
+
+Trust roots for every step are committed at or digest-pinned to the
+protected base. Runtime organization variables are not trust anchors
+anywhere in the notary path.
 
 ## 6. Admission chain, epoch, genesis, and transitions
 
 ### 6.1 The chain
 
-Every receipt names its chain predecessor: a prior receipt, a transition
-record, or genesis. The receipt's `base_tree_manifest_sha256` must equal
-the predecessor's subject (for receipts and transitions) or recorded
-baseline (for genesis). Verifying from any other base refuses: an
-uncovered edit cannot launder itself by becoming the base of the next
-verification, because the state that skipped it is not the recorded
-chain tip. Commit ids locate; tree manifests bind — so squash and
-merge-queue rewrites are harmless when they preserve the verified tree,
-and void the run when they do not (§7).
+Every receipt and transition names its chain predecessor (`genesis`,
+`receipt`, or `transition`) and the predecessor's recorded state; the new
+artifact's base tree manifest must equal that state. The chain consists
+of **finalized** artifacts only (§7): an unfinalized or superseded signed
+artifact is void and never chain-eligible. An uncovered edit cannot
+launder itself by becoming a later verification's base: the state that
+skipped it was never finalized as tip.
 
 ### 6.2 Genesis — `axiom/notary-genesis/v1`
 
-A distinct artifact signed under its own scope by the administrative
-authority (§6.4's signer). Its body binds: `schema`, `lane`,
+Produced only through the typed signer under administrative authorization
+(§6.4's authority). Its body binds: `schema`, `lane`,
 `genesis_commit_git_oid`, `genesis_tree_manifest_sha256`, and two frozen
-inventories over the protected domain at genesis:
+inventories forming an **exhaustive, disjoint, exactly-once partition of
+the protected paths** at genesis (the typed signer verifies the
+partition property against the manifest before signing):
 
-- `v5_attested`: sorted `[path, content_sha256, record_sha256]` triples —
-  paths whose blobs are vouched by an authenticated v5 record at genesis;
-- `baseline_unattested`: sorted `[path, content_sha256]` pairs — paths
-  with no authenticating record, recorded visibly, including any
-  pre-epoch hand edits. Recorded is not blessed: these bytes carry
-  "unattested baseline" provenance permanently.
+- `v5_attested`: sorted `[path, entry_sha256, record_sha256]` — paths
+  whose blobs are vouched at genesis by a legacy record that passes the
+  **current v5 authentication contract**: schema exactly
+  `axiom-encode/applied-rulespec/v5`, producer signature valid over the
+  canonical unsigned bytes, encoder identity and waiver checks per the
+  pinned v5 verifier, and path/blob agreement with the genesis tree.
+  `record_sha256` is SHA-256 over the record's raw file bytes. Two
+  qualifying records for one path is a genesis refusal (clean up first).
+- `baseline_unattested`: sorted `[path, entry_sha256]` — everything
+  else, visibly, including any pre-epoch hand edits. Recorded is not
+  blessed: permanent "unattested baseline" provenance.
 
-The **epoch identifier is the genesis body's content digest**. The body
-contains no epoch field — it *is* the epoch — so every other artifact's
-`epoch_sha256` refers to it without a self-hash fixed point. A second
-genesis for a lane refuses; genesis covers nothing and admits nothing.
+The epoch identifier is the genesis body's content digest; the body
+carries no epoch field, so there is no self-hash fixed point. A second
+genesis for a lane refuses. Genesis covers nothing and admits nothing.
 
 ### 6.3 Dual-era rule
 
 Post-epoch, a v5 record vouches only for a path whose blob is
-byte-identical to its `v5_attested` pair in the frozen inventory. Any
-post-epoch change to any protected path requires notary-era lineage; new
-v5 records have no post-epoch standing; a path in `baseline_unattested`
-stays unattested until a covered change replaces it.
+byte-identical to its frozen `v5_attested` pair. Any post-epoch change to
+any protected path requires notary-era lineage; new v5 records have no
+post-epoch standing; `baseline_unattested` paths stay unattested until a
+covered change replaces them.
 
 ### 6.4 Transition records — `axiom/notary-transition/v1`
 
-Privileged trust-surface updates (path policy, profile, workflow or
-action pins, trust roots, waiver policy, key rotation) cannot receive
-ordinary receipts — the preflight refuses them from candidates — and
-without a dedicated mechanism the chain would deadlock at the first key
-rotation. A transition record is that mechanism: signed under its own
-scope by the administrative authority through the `notary-signing`
-environment's human approval, its body binds `schema`, `lane`,
-`epoch_sha256`, `chain_predecessor_sha256` and kind, the old and new
-tree manifest digests, the enumerated trust-surface delta (paths and
-before/after digests), and `reason`. A transition covers only
-trust-surface paths — a protected-content change smuggled into a
-transition refuses — and becomes a valid chain predecessor. Ordinary
-admission resumes from its recorded state.
+Trust-surface updates (path policy, profile, workflow or action pins,
+trust roots, waiver policy, key rotation) cannot ride ordinary receipts —
+the preflight refuses them — so the transition record exists to advance
+the chain across them. Closed schema: `schema`, `lane`, `epoch_sha256`,
+`chain_predecessor_sha256`, `chain_predecessor_kind`,
+`base_tree_manifest_sha256`, `subject_tree_manifest_sha256`,
+`subject_commit_git_oid`, `delta`: sorted array of
+`{path, before_entry_sha256 | null, before_mode | null,
+after_entry_sha256 | null, after_mode | null}` restricted to
+trust-surface paths, and `reason`.
 
-## 7. Publication and the canonical head
+Rules: the recomputed base→subject diff must equal `delta` exactly — a
+protected-content or unrelated change smuggled into a transition refuses;
+signatures and authorization are evaluated **under the predecessor
+state's trust roots** (the old keys and policy authorize the handover, so
+a successor-controlled key cannot self-authorize its own installation);
+transitions are produced only through the typed signer under the
+`notary-signing` environment's human approval; and transitions are void
+until finalized (§7), exactly like receipts. For merge gating, a pending
+transition plays the pending receipt's role for its own subject (§7): it
+is the merge-authorizing artifact for exactly its enumerated delta.
+Ordinary admission resumes from the finalized transition's recorded
+state.
 
-The publisher pushes the receipt (with its report) to the lane's
-canonical attestation ref, compare-and-swap. A signed receipt is **void
-until published**: the chain reads only the canonical ref, so a
-CAS-losing or stale signed receipt never becomes chain-eligible, and
-re-verification from the true tip is the only path forward. At
-publication the publisher verifies the protected ref's tip tree manifest
-equals the receipt's subject tree manifest; a merge that produced a
-different tree (a conflicted queue merge, a stale squash) fails the
-check, voids the receipt, and reruns. The receipt distinguishes
-subject/base tree manifests, subject commit oid, and
-`verifier_commit_git_oid`; the attestation ref supplies location without
-entering the signed body.
+## 7. Two-phase publication and the canonical chain
+
+The canonical chain lives at a dedicated ref
+(`refs/notary/chain`) in the lane repository: content-addressed artifact
+files plus a single `HEAD.json` naming the current finalized tip
+(`{schema: "axiom/notary-head/v1", tip_sha256, tip_kind}`). All updates
+are compare-and-swap; the publisher's ruleset confines writes to this
+ref.
+
+Admission is two-phase, which resolves the ordering circularity between
+"receipt must exist to authorize the merge" and "the merged state must
+equal what was verified":
+
+1. **Pending.** Job 1 verifies the candidate head (subject tree `T1`);
+   the signer signs the receipt (or transition). The publisher writes it
+   to the notary ref as *pending* and sets the required status check on
+   the candidate. A pending artifact authorizes exactly one thing: the
+   merge of a head whose tree manifest is `T1`. It is not the chain tip.
+2. **Finalize.** After the merge, the finalizer (publisher job,
+   triggered on the protected ref) recomputes the merged tip's tree
+   manifest. If it equals `T1`, it advances `HEAD.json` to the artifact
+   by CAS — the artifact is now finalized and chain-eligible. If it
+   differs (conflicted queue merge, stale squash), finalization refuses,
+   the artifact is permanently void (a voided digest is recorded and can
+   never finalize), and verification reruns from the true finalized tip.
+   A pending artifact whose candidate never merges simply never
+   finalizes; the chain never advanced, so nothing strands.
+
+Squash and merge-queue rewrites are therefore harmless exactly when they
+preserve the verified tree, and void the attempt exactly when they do
+not. Commits locate; trees bind.
 
 ## 8. Key ceremony
 
-Before Job 2 exists: generate `notary_ed25519` with documented
-custodians, fingerprint published in committed code (consumer
-verification specs pin the SPKI), storage and rotation procedure
-(rotation is a §6.4 transition), revocation and recovery procedure. The
-producer, actor, reviewer, and administrative keys get the same treatment
-under their own scopes. §10's pairwise cross-scope matrix is part of
-ceremony acceptance.
+Before the typed signer holds any notary-scope key: generate
+`notary_ed25519` with documented custodians, fingerprint published in
+committed code (consumer verification specs pin the SPKI), storage and
+rotation procedure (rotation is a §6.4 transition evaluated under
+predecessor roots), revocation and recovery. The producer, actor,
+reviewer, and administrative keys get the same treatment under their own
+scopes. §10's pairwise cross-scope matrix is part of ceremony acceptance.
 
 ## 9. Preconditions (nothing admission-capable merges before these)
 
 1. This document approved — threat model, schemas and envelope,
-   predicate, profile, chain/epoch/genesis/transition rules, and the §10
-   suite — by the charter's gate: an independent cross-family review of
-   the concrete design plus **Max's named sign-off**, with every §11
+   predicate, profile, chain/epoch/genesis/transition rules, two-phase
+   publication, and the §10 suite — by the charter's gate: independent
+   cross-family review plus **Max's named sign-off**, with every §11
    decision closed.
 2. The reviewers-semantics resolution in §4 accepted.
-3. The dedicated `notary-signing` environment created and enforcing:
-   required reviewers, protected refs, no self-approval, Job-2-only
-   secret access — with generation workflows migrated off any
-   environment that will hold the notary key (#1194 re-scoped).
-4. **Compute isolation**: Jobs 1 and 2 on fresh ephemeral runners (or a
-   dedicated ephemeral pool), and signer-side workflow/job identity
-   binding, so no candidate-code persistence can reach the notary
-   operation.
-5. The authenticated Job-1 handoff, typed Job-2 reconstruction, and
-   Job-2 acceptance enforcement of §5 implemented in the trusted signing
-   component (no raw-byte notary scope).
-6. The publisher split of §5 implemented, with a repository ruleset
-   confining the publisher token's writes to the receipt ref.
-7. Signed-leg billing and abuse policy operational (#1193).
-8. Notary key ceremony completed per §8, transition mechanism included.
-9. Org-variable trust anchors eliminated from the signing path in favor
-   of committed or digest-pinned roots.
-10. rulespec-nz consumer-side pins landed: the notary SPKI and epoch in
-    the lane's committed verification spec; the notary check required and
-    non-bypassable in branch protection; genesis activated atomically
-    with enforcement.
-11. The generated-file guard hardcoded in the protected shared workflow
-    (its caller-controlled boolean retired) — merge-time defense in depth
-    during dual-era operation.
-12. Retirement of lane signed-apply legs (#1195) is a cutover exit
-    criterion, not a pilot precondition; dual-era operation is expected.
+3. The dedicated `notary-signing` environment created (required
+   reviewers, protected refs, no self-approval), holding no generation
+   credentials and no write tokens; generation workflows migrated off
+   any environment involved in notary authorization (#1194 re-scoped).
+4. **External signer with identity binding**: the notary key held only
+   by the external typed signer; OIDC-claim validation of the requesting
+   workflow/job/run; no raw notary key material on any runner.
+5. **Compute isolation**: fresh ephemeral runners for the verification
+   and trusted jobs.
+6. Trusted recomputation implemented (§5): every claim-bearing invariant
+   re-derived from content-addressed inputs before signing; typed
+   operations for genesis, transition, and receipt scopes; no raw-byte
+   signing for those scopes.
+7. The publisher split implemented, with a repository ruleset confining
+   the publisher token's writes to the notary ref, and the two-phase
+   pending/finalize protocol with CAS and permanent voiding.
+8. Signed-leg billing and abuse policy operational (#1193).
+9. Key ceremony completed per §8.
+10. Org-variable trust anchors eliminated from the signing path.
+11. rulespec-nz consumer-side pins landed: notary SPKI and epoch in the
+    lane's committed verification spec; the pending-artifact check
+    required and non-bypassable in branch protection; genesis activated
+    atomically with enforcement.
+12. The generated-file guard hardcoded in the protected shared workflow
+    (caller boolean retired) — merge-time defense in depth during
+    dual-era operation.
+13. Retirement of lane signed-apply legs (#1195) is a cutover exit
+    criterion, not a pilot precondition.
 
 ## 10. Negative-test floor
 
 Grouped by refusal site; each case is a distinct test before the pilot
 gates anything.
 
-**Schemas and signatures:** unknown field; missing field; wrong type;
-wrong content-address filename; malformed detached-signature file;
-signature by the wrong key for a scope; invalid producer signature;
-invalid actor signature; missing or invalid reviewer countersignature;
-countersignature by the actor; countersignature by an untrusted key;
-invalid genesis signature; invalid transition signature; invalid receipt
-signature; raw-byte signing attempt against the notary or transition
-scope; the full pairwise cross-scope matrix (all six scopes plus legacy
-`apply_ed25519`/`eval_ed25519`) — every cross-scope verification fails.
+**Schemas, encodings, signatures:** unknown/missing field; wrong type;
+number where string required (`run_id`); digest with wrong case, length,
+or retained `sha256:` prefix; wrong content-address filename; malformed
+detached-signature file; wrong scope per the role table (review
+signature under the correction scope and conversely); signature by the
+wrong key for a scope; invalid producer/actor/review/genesis/transition/
+receipt signature; countersignature by the actor; raw-byte signing
+attempt against genesis, transition, or notary scopes; full pairwise
+cross-scope matrix including legacy operations.
+
+**Manifests and totality:** gitlink anywhere in the tree; non-UTF-8 path
+anywhere in the tree (changed or unchanged); inadmissible mode; symlink
+inside the protected domain; manifest sort-order violation; two trees
+differing only by a gitlink refused rather than treated as
+manifest-equal.
 
 **Lineage store:** mutated existing record; deleted existing record;
-record with wrong lane; record with wrong epoch; mode field present on a
-null side; mode value outside the admissible set.
+wrong lane; wrong epoch; mode present on a null side; mode outside the
+admissible set.
 
 **Eligibility and coverage:** record present at the base (replay);
 uncovered protected change; uncovered mode-only change; overlapping
-chains; extra transition against an unchanged path; forked chain; cyclic
-chain; discontinuous chain; wrong starting blob or mode; wrong terminal
-blob or mode; malformed null-sides; partial record consumption; wrong
-patch digest or unknown `patch_algorithm`; gitlink at a protected path;
-symlink at a protected path; disallowed mode at a protected path;
-non-UTF-8 changed path anywhere in the diff; `waived`/`not-run` coverage
-outcome post-epoch; path-policy precedence cases (`rules/private/x`
-under include-then-exclude; `rules-evil/x` against prefix `rules`;
-unmatched path defaulting to unprotected).
+chains; transition against an unchanged path; forked, cyclic, or
+discontinuous chain; wrong starting or terminal blob/mode; malformed
+null-sides; partial record consumption; **ambiguous assignment (two
+redundant covering records; split-vs-direct chains)**; dead-end retry
+record accepted as unused without ambiguity (positive control);
+`waived`/`not-run` post-epoch; path-policy precedence cases
+(include-then-exclude; `rules-evil/x`; unmatched default-unprotected).
 
-**Preflight and profile:** ordinary candidate touching workflows, pins,
-trust roots, path policy, profile, waiver policy, repository-structure
-rules, or lineage-store integrity; repairable-but-unrepaired subject;
-failed gate; gate outcome outside the profile's acceptable set; missing
-required gate; oracle-disabled attempt; skip-flag attempt; profile or
-path policy not committed at the base.
+**Report reconciliation (trusted side):** forged pass report over a
+refusing diff; trimmed, padded, duplicated, or misclassified
+`unprotected_changes`; wrong or non-unique `coverage_assignment`;
+`unused_eligible_records` not a subset or overlapping consumed records;
+duplicate gate ids; missing required gate; extra-profile gate; outcome
+outside the acceptable set; invalid tier; report/receipt copied-field
+mismatch; tree-manifest mismatch on recomputation; profile or
+path-policy digest mismatch at the base.
 
-**Chain, epoch, genesis, transitions:** base not the chain tip; wrong
-chain predecessor digest; second genesis; genesis carrying coverage;
-receipt claiming a predecessor role its schema forbids; empty-delta
-first receipt leaving baseline provenance unchanged (positive control);
-post-epoch change vouched only by v5; v5 record whose blob differs from
-its frozen pair; malformed or path-mismatched grandfather inventory
-entry; transition carrying a protected-content change; transition with
-an unenumerated trust-surface delta; ordinary receipt attempting a
-trust-surface change; chain advance over an unpublished (void) receipt.
+**Preflight and profile:** ordinary candidate touching any §4 trust
+surface; repairable-but-unrepaired subject; oracle-disabled attempt;
+skip-flag attempt; profile or policy not committed at the base.
 
-**Job 2 and publication:** report-body digest mismatch; subject or base
-tree-manifest mismatch on re-hash; profile or path-policy re-hash
-mismatch; copied-field mismatch between report and receipt; Job-1 run
-from the wrong workflow, sha, or ref; non-success Job-1 conclusion;
-artifact digest mismatch; replayed Job-1 artifact under a new run;
-**signing a refusal report**; signing with a missing required gate;
-invalid authorization reference; wrong requesting workflow/job identity
-at the signer; CAS loss voids the receipt; stale signed receipt never
-chain-eligible; published-tip tree differing from receipt tree
-(squash/queue rewrite) voids and reruns; receipt-child commit with any
-extra delta; publisher push outside the receipt ref rejected by ruleset.
+**Chain, epoch, genesis, transitions:** base not the finalized tip;
+wrong chain predecessor digest or kind enum; second genesis; genesis
+with a non-exhaustive, overlapping, or duplicate-path partition; genesis
+entry citing a record failing the v5 contract (wrong schema family,
+invalid signature, path/blob disagreement); nonexistent
+`record_sha256`; duplicate qualifying v5 records for one path; genesis
+carrying coverage; empty-delta first receipt leaving baseline provenance
+unchanged (positive control); post-epoch change vouched only by v5; v5
+record whose blob differs from its frozen pair; transition whose
+recomputed diff differs from its enumerated delta (smuggled content);
+transition evaluated under successor roots (self-authorizing rotation);
+unfinalized transition used as predecessor; ordinary receipt attempting
+a trust-surface change.
+
+**Signer, publication, finalization:** OIDC identity mismatch (wrong
+workflow, job, run, repository, or ref); Job-1 run non-success; artifact
+digest mismatch; replayed artifact under a new run; signing a refusal
+report; stale base at recomputation; pending artifact treated as chain
+tip; finalization with merged-tip manifest differing from the verified
+subject (voids, permanently); voided digest re-finalization attempt; CAS
+loss on `HEAD.json`; publisher push outside the notary ref rejected by
+ruleset; `HEAD.json` naming an unpublished or unsigned artifact.
 
 ## 11. Decisions for sign-off
 
@@ -542,8 +584,7 @@ extra delta; publisher push outside the receipt ref rejected by ruleset.
 - Approval wording: `authorization.approval_context` binds durable
   digest-bound reviewer evidence, or records "the protected signing
   policy authorized this receipt" (honest for plain environment
-  approval, which approves a deployment, not a displayed digest; the
-  stronger form needs an explicit approval artifact).
+  approval; the stronger form needs an explicit approval artifact).
 - Custody model for the producer, actor, reviewer, and administrative
   keys (the notary key is fixed by §5/§8); reviewer custody is the open
   question deferred from the rulespec-nz custody ruling.
@@ -552,6 +593,7 @@ extra delta; publisher push outside the receipt ref rejected by ruleset.
 
 Witnessed lineage chains (dual RFC 3161 — sequenced behind the notary as
 chartered); historical backfill; rename modeling (tree-entry
-decomposition makes it unnecessary); fleet-wide shared-workflow
-conversion; v5 retirement; the other eight lanes; ProgramSpec admission
-unless §11 decides otherwise.
+decomposition makes it unnecessary); gitlink/submodule support (refused
+tree-wide in the pilot); fleet-wide shared-workflow conversion; v5
+retirement; the other eight lanes; ProgramSpec admission unless §11
+decides otherwise.

--- a/docs/notary-admission-design.md
+++ b/docs/notary-admission-design.md
@@ -1,0 +1,240 @@
+# Notary admission: design v1
+
+Status: draft for sign-off. Implements the #1192 charter with the #1506
+diff-coverage delta, under the build decision recorded on both issues
+(dual-verdict, 2026-08-17). Nothing admission-capable merges until the
+preconditions in §9 are satisfied and this document is approved.
+
+## 1. Claim and threat model
+
+The notary signs one narrow claim:
+
+> Tree `H1` was accepted under verifier profile `P`, protected base `B`,
+> corpus release `Y`, waiver set `W`; every content change from `B` to `H1`
+> is covered by authenticated lineage; the protected signing policy
+> authorized this receipt.
+
+It does not claim content was model-generated, and it never will — that
+claim bred provenance laundering (the Path R pattern) and is retired with
+the v5 era. Lineage records say where bytes came from; the notary says the
+deterministic gates passed and coverage held.
+
+The scenario this design closes: an agent with repository write access
+hand-edits a published rule and obtains a legitimate signature through the
+sanctioned path. Two independent walls stop it. The capability wall: no
+generator holds signing capability — Job 2 alone reaches the notary key,
+inside a protected environment with required human reviewers, and runs no
+candidate code. The coverage wall: a changed path with no covering lineage
+record refuses at preflight, regardless of who approves. A hand edit
+therefore either dies unsigned or enters as a declared correction event —
+attributed, countersigned, and visible to the fix-the-encoder loop.
+
+Residual risks accepted, per the charter: a verifier soundness bug
+deterministically accepts wrong law; candidate-controlled tests can be
+weakened; reviewer compromise authorizes validator-passing bad content.
+Mitigations are the strict profile, the trusted preflight, golden
+regeneration QA, and oracles — not additional signatures.
+
+## 2. Records
+
+Three record kinds, all canonical JSON (receipt-canonical serialization:
+UTF-16 code-unit key order, ECMAScript number formatting), content-addressed
+by SHA-256, each signed under its own domain with its own key. Domains are
+single-purpose byte prefixes; cross-domain verification must fail and §10
+tests prove it.
+
+| Record | Domain | Signer | Authorizes merge? |
+|---|---|---|---|
+| Generation event | `axiom/lineage-generation/v1` | supervised-runtime producer key | No |
+| Correction event | `axiom/lineage-correction/v1` | actor key + distinct protected reviewer countersignature | No |
+| Notary receipt | `axiom/notary-acceptance/v1` | `notary_ed25519` (Job 2 broker only) | **Yes** |
+
+**Generation event.** Emitted by the supervised local runtime (the #1158
+machinery) at generation time. Fields: runtime identity, model, CLI version
+and digest, prompt digests, output tree digest, and per-path transitions
+(§3). Authenticated as a runtime emission by the producer signature —
+content addressing alone proves integrity, not origin.
+
+**Correction event.** A declared human or agent fix. Fields: actor, reason,
+predecessor record, per-path transitions, canonical patch digest. Valid only
+with a countersignature from a protected reviewer distinct from the actor,
+over the event digest. The countersignature validates lineage; it does not
+authorize merge. Corrections are first-class and loud — the sanctioned
+response to a wrong encoding remains fix-the-encoder-and-re-encode, and a
+correction event is the recorded exception, never the quiet path.
+
+**Notary receipt.** The only record Job 2 signs. Fields: `subject_commit`,
+`subject_tree` (`H1`), `protected_base` (`B`), verifier profile digest
+(`P`), corpus release (`Y`), waiver set digest (`W`), per-gate outcomes with
+reproducibility tier (publicly reproducible / restricted pinned inputs /
+CI-attested), the diff-coverage verdict, Job 1 run identity, and the
+authorization reference. The existing `apply_ed25519` domain and v5
+manifests are never reinterpreted; under the dual-era rule they keep their
+generator-produced meaning permanently.
+
+Lineage records live in the lane repository under `.axiom/lineage/`,
+append-only, one file per record named by its content digest. The lineage
+directory is outside the protected-content coverage domain (its additions
+need no covering record — that would regress infinitely) but inside the
+preflight's structural checks: schema-valid, authenticated, append-only,
+correctly content-addressed. Deleting or mutating an existing lineage record
+is a preflight refusal.
+
+## 3. The diff-coverage predicate
+
+For the complete git-object diff from `B` to `H1`, restricted to protected
+content paths:
+
+1. Every changed path maps to exactly one non-forking chain of transitions
+   drawn from lineage records — closed-world set equality: no missing, no
+   overlapping, no extra transitions.
+2. Each transition binds the full before-blob digest and after-blob digest
+   for its path, plus a versioned canonical patch digest (`git-patch-v1`:
+   `git diff` with pinned flags, retained for audit; the blob digests are
+   ground truth because hunk computation is algorithm-dependent).
+3. Replaying each path's chain from its blob at `B` must terminate exactly
+   at its blob at `H1`.
+4. Additions and deletions are modeled explicitly (null-digest sides).
+   Renames, mode changes, and symlinks are rejected in the pilot rather than
+   modeled.
+5. The verdict is binary. From the enforcement epoch, `waived`, `not-run`,
+   missing coverage, or an emergency "correction" without a valid
+   countersigned event is a refusal. Notary-v1 acceptance requires exactly
+   `diff-coverage=pass` — deliberately stricter than consumer-side
+   declaration completeness, which by design accepts declared `waived` and
+   `not-run` outcomes as well-formed.
+
+Advisory shadow runs (compute and publish the verdict without gating) are
+permitted only before a lane's enforcement epoch, to burn in the predicate.
+
+## 4. Verifier profile P
+
+The notary profile is not the current apply path, and the differences are
+the point:
+
+- **Non-mutating.** No deterministic repairs. The subject is verified as
+  presented or refused.
+- **Oracles on.** The apply overlay's `enable_oracles=False` does not exist
+  here. Licensed or unavailable oracles follow the sign-off decision in
+  §11 — fail closed, or a visibly reduced-tier receipt; never silent.
+- **Reviewers means deterministic checks plus protected-environment human
+  approval.** Today's "reviewers" in the validator pipeline are LLM
+  reviewers; under the charter's no-model-calls rule they cannot be part of
+  the notary profile. LLM review remains QA outside the admission path,
+  beside golden regeneration.
+- **No skips.** `--skip-reviewers` and caller-disableable guards have no
+  notary equivalents. The generated-file guard's merge-time role continues
+  during dual-era operation, but the notary does not consult caller
+  booleans.
+
+The profile is itself content-addressed; `P` in the receipt is the digest of
+the profile definition committed at `B`.
+
+## 5. Two jobs, one capability split
+
+**Job 1 — verify (secretless).** Runs candidate code under the strict
+profile in an environment with no signing capability, no model credentials,
+and no repository-write credential. Produces the content-addressed unsigned
+receipt body: subject digests, gate outcomes and tiers, diff-coverage
+verdict, exact dependency pins, run identity.
+
+**Job 2 — sign (narrow, typed).** Runs in the `production-signing`
+environment with required reviewers enforced (#1194). Runs no candidate
+code. Independently re-fetches and re-hashes `B`, `H1`, and the receipt
+body; parses only the typed notary schema; refuses on any mismatch by
+forcing complete reverification; holds no model or repository-write
+credential; signs only `axiom/notary-acceptance/v1`. Environment approval
+gates Job 2 so the human approves a completed receipt, never a
+not-yet-run pipeline.
+
+Trust roots for both jobs — public keys, profile digests, policies,
+workflow and action pins, waiver authorities — are committed at or
+digest-pinned to the protected base. Runtime organization variables are not
+trust anchors anywhere in the notary path; the existing `vars.*`
+provisioning in the signing workflows is eliminated as a precondition (§9).
+
+## 6. Epoch and bootstrap
+
+Per-repo enforcement epochs, pilot on rulespec-nz:
+
+1. Pin the lane's current main commit as the one-time enforcement genesis.
+2. Issue a genesis receipt over the empty `B → H1` range. No historical
+   lineage is invented; pre-epoch content is covered by the dual-era rule
+   (v5 manifests keep their meaning; untouched content needs nothing).
+3. Every subsequent non-empty diff of protected content must pass coverage.
+4. Cross-class supersession: a post-epoch change to a v5-covered path
+   requires notary-v1 lineage for the change; the v5 record continues to
+   describe the pre-epoch bytes only.
+
+## 7. Publication
+
+Receipts publish as detached attestations referencing `subject_commit`,
+pushed compare-and-swap; alternatively a mechanical receipt-only child
+commit whose sole delta is the receipt. If the protected base or the
+candidate moves between verification and publication, the verification is
+discarded and rerun from the new `B`. The manifest distinguishes
+`subject_commit`, `subject_tree`, `attestation_commit`, and
+`verifier_commit` so no reader conflates what was verified with where the
+receipt landed.
+
+## 8. Key ceremony
+
+Before Job 2 exists: generate `notary_ed25519` with documented custodians,
+fingerprint publication in committed code (consumer verification specs pin
+the SPKI), storage and rotation procedure, revocation and recovery
+procedure, and negative tests proving apply-domain signatures cannot verify
+as notary signatures and conversely. The producer and reviewer keys for
+lineage records get the same treatment with their own domains. Rotation is
+loud, by reviewed change to committed pins, exactly as the consumer-side
+verifier already requires.
+
+## 9. Preconditions (nothing admission-capable merges before these)
+
+1. This document approved — threat model, canonical signed bytes, profile,
+   epoch and bootstrap rules, and the §10 suite — by the human gate the
+   charter names.
+2. The reviewers-semantics resolution in §4 accepted (deterministic checks
+   plus human environment approval; LLM review is QA only).
+3. `production-signing` environment enforcing required reviewers, protected
+   refs, no self-approval, Job-2-only secret access (#1194).
+4. Signed-leg billing and abuse policy operational (#1193).
+5. Notary key ceremony completed per §8.
+6. Org-variable trust anchors eliminated from the signing path in favor of
+   committed or digest-pinned roots.
+7. Retirement of lane signed-apply legs (#1195) is a cutover exit
+   criterion, not a pilot precondition; dual-era operation is expected.
+
+## 10. Negative-test suite (acceptance floor for Job 1)
+
+Each is a distinct refusal with its own test before the pilot gates
+anything: uncovered changed path; overlapping chains; extra transition
+covering an unchanged path; forked chain; replay terminating at the wrong
+blob; correction event without countersignature; countersignature by the
+actor; generation event not authenticated by the producer key; mutated or
+deleted lineage record; rename, mode change, symlink in the diff; candidate
+touching workflows, pins, trust roots, waiver policy, or repository
+structure; `waived`/`not-run` coverage outcome post-epoch; stale `B` or
+`H1` at Job 2; receipt-body mismatch at Job 2; cross-domain signature
+verification in both directions; genesis receipt claiming a non-empty
+range.
+
+## 11. Decisions for sign-off
+
+- ProgramSpec scope: atomic RuleSpec only in the pilot (recommended), or
+  extend to composition outputs.
+- Licensed or unavailable oracles: fail closed, or visibly reduced-tier
+  receipt.
+- Approval wording: bind durable reviewer evidence, or "the protected
+  signing policy authorized this receipt" (recommended; matches the
+  environment-approval mechanism).
+- Custody model for the three key roles (notary / producer / reviewer):
+  broker environment for the notary per §5; producer stays with the
+  supervised runtime; reviewer custody is the open question deferred from
+  the rulespec-nz custody ruling.
+
+## 12. Out of scope for milestone one
+
+Witnessed lineage chains (dual RFC 3161 — sequenced behind the notary as
+chartered); historical backfill; rename/mode/symlink modeling; fleet-wide
+shared-workflow conversion; v5 retirement; the other eight lanes; ProgramSpec
+admission unless §11 decides otherwise.


### PR DESCRIPTION
The consolidated design for #1192 with the #1506 diff-coverage delta, under the build decision recorded on both issues (dual-verdict: BUILD WITH PRECONDITIONS). Draft until the charter's gate is satisfied: an independent cross-family design review plus Max's sign-off.

One document: docs/notary-admission-design.md — claim and threat model (two walls: capability and coverage), record schemas and signature domains, the diff-coverage predicate (per-path state-transition chains, blob-digest ground truth, closed-world equality, binary verdict strictly tighter than consumer-side declaration completeness), the strict verifier profile including the reviewers-semantics resolution the review surfaced (today's pipeline reviewers are LLM reviewers; the notary profile counts only deterministic checks and protected-environment human approval), the two-job capability split, rulespec-nz epoch bootstrap, compare-and-swap publication, key ceremony, preconditions, the negative-test acceptance floor, and the decisions reserved for sign-off (§11).

Docs-only. **Cycle complete**: 32 adversarial sol design-review rounds against the charter's acceptance criteria, 139 blocking findings folded (per-round record in the comments), **round 32: APPROVE** — the independent cross-family review leg of the charter gate is satisfied. Out of draft for the remaining leg: Max's named sign-off with the §11 decisions (enumerated in the final review comment). Nothing admission-capable merges before the §9 preconditions are satisfied; after sign-off, the first code is the non-authorizing Job-1 surface piloted on rulespec-nz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
