### PR TITLE
fix: repair parser-marked YAML evidence scalars (quote ': ' in generated source/excerpt)

### DIFF
--- a/changelog.d/parser-marked-evidence-scalar-repair.fixed.md
+++ b/changelog.d/parser-marked-evidence-scalar-repair.fixed.md
@@ -1,0 +1,1 @@
+Guarded pre-apply repair now quotes parser-marked `source:`/`excerpt:` scalars containing YAML-significant `: ` (e.g. Danish amendment text `ændres »12« til: »24«`) at PyYAML's exact scanner mark — comment-preserving, fail-closed, content untouched.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1694"
+version = "0.2.1695"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1694"
+__version__ = "0.2.1695"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -40834,7 +40834,7 @@ def _try_repair_generated_unquoted_source_scalars_for_apply(
     *,
     output_root: Path,
 ) -> list[str]:
-    """Quote generated source: scalars that contain YAML-significant colons."""
+    """Quote generated source-evidence scalars with YAML-significant colons."""
     try:
         _relative_generated_output_path(result, output_root=output_root)
     except RuntimeError:
@@ -40939,46 +40939,75 @@ def _remove_empty_deferred_source_values(*, rules_file: Path) -> list[str]:
 
 
 def _quote_unquoted_source_scalars(*, rules_file: Path) -> list[str]:
+    """Quote only source text at PyYAML's unexpected-mapping mark."""
+
     if not rules_file.exists():
         return []
     try:
         original = rules_file.read_text()
     except OSError:
         return []
-    try:
-        yaml.safe_load(original)
-        return []
-    except (RecursionError, yaml.YAMLError, ValueError):
-        pass
-
-    repaired_lines: list[str] = []
+    candidate_lines = original.splitlines(keepends=True)
     repaired: list[str] = []
-    for line_number, raw_line in enumerate(
-        original.splitlines(keepends=True),
-        start=1,
-    ):
+    repaired_line_indexes: set[int] = set()
+    while True:
+        candidate = "".join(candidate_lines)
+        try:
+            yaml.safe_load(candidate)
+            break
+        except yaml.scanner.ScannerError as exc:
+            mark = getattr(exc, "problem_mark", None)
+            line_index = getattr(mark, "line", None)
+            column_index = getattr(mark, "column", None)
+            if (
+                exc.problem != "mapping values are not allowed here"
+                or type(line_index) is not int
+                or type(column_index) is not int
+                or not 0 <= line_index < len(candidate_lines)
+                or line_index in repaired_line_indexes
+            ):
+                return []
+        except (RecursionError, yaml.YAMLError, ValueError):
+            return []
+
+        raw_line = candidate_lines[line_index]
         newline = "\n" if raw_line.endswith("\n") else ""
         line = raw_line[:-1] if newline else raw_line
         match = re.match(
-            r"^(\s*source:\s+)([^'\"|>{\[].*:\s+.*?)(\s*)$",
+            r"^(?P<prefix>\s*(?P<key>source|excerpt):\s+)(?P<body>.*)$",
             line,
         )
         if match is None:
-            repaired_lines.append(raw_line)
-            continue
-        prefix, value, trailing = match.groups()
+            return []
+        prefix = match.group("prefix")
+        key = match.group("key")
+        body = match.group("body")
+        comment_match = re.search(r"[ \t]+#.*$", body)
+        if comment_match is not None:
+            value = body[: comment_match.start()]
+            suffix = body[comment_match.start() :]
+        else:
+            value = body.rstrip(" \t\r")
+            suffix = body[len(value) :]
+        if (
+            not value
+            or value[0] in {"'", '"', "|", ">", "{", "[", "!", "&", "*"}
+            or not match.start("body")
+            <= column_index
+            < match.start("body") + len(value)
+            or line[column_index] != ":"
+            or column_index + 1 >= len(line)
+            or line[column_index + 1] not in " \t"
+        ):
+            return []
         quoted = value.replace("'", "''")
-        repaired_lines.append(f"{prefix}'{quoted}'{trailing}{newline}")
-        repaired.append(f"source:{line_number}")
+        candidate_lines[line_index] = f"{prefix}'{quoted}'{suffix}{newline}"
+        repaired_line_indexes.add(line_index)
+        repaired.append(f"{key}:{line_index + 1}")
 
     if not repaired:
         return []
-    repaired_text = "".join(repaired_lines)
-    try:
-        yaml.safe_load(repaired_text)
-    except (yaml.YAMLError, ValueError):
-        return []
-    rules_file.write_text(repaired_text)
+    rules_file.write_text(candidate)
     return repaired
 
 

--- a/tests/fixtures/generated_yaml_scanner/sol_p1r4_rejected.yaml
+++ b/tests/fixtures/generated_yaml_scanner/sol_p1r4_rejected.yaml
@@ -1,0 +1,465 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+    source_sha256: 2e135cac3ca5eb201b948ca915bf9554e864a09ebc8576c2603b6115730329ec
+  summary: |-
+    For børn under 15 år udbetales en skattefri børneydelse. For børn mellem 15 og 17 år udbetales en skattefri ungeydelse. Beløbene reguleres efter forbrugerprisindekset og afrundes til nærmeste kronebeløb, der kan deles med 12. I 2023 forhøjes beløbene derudover samlet med 660 kr.
+rules:
+  - name: early_childhood_age_upper_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: indtil det fyldte 3. år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          3
+
+  - name: middle_childhood_age_lower_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: fra og med det fyldte 3. år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          3
+
+  - name: middle_childhood_age_upper_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: indtil det fyldte 7. år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          7
+
+  - name: later_childhood_age_lower_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: fra og med det fyldte 7. år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          7
+
+  - name: childhood_age_upper_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: børn under 15 år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          15
+
+  - name: youth_age_lower_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: børn mellem 15 og 17 år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          15
+
+  - name: youth_age_upper_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: børn mellem 15 og 17 år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          17
+
+  - name: benefit_base_level_year
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1-2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: 2011-niveau
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          2011
+
+  - name: annual_benefit_2011_level
+    kind: parameter
+    dtype: Money
+    unit: DKK
+    indexed_by: benefit_age_band
+    source: § 1, stk. 1-2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              table:
+                header: annual benefit at 2011 level
+                row_key: benefit_age_band
+                column_key: annual_amount
+              excerpt: 16.992 kr. årligt (2011-niveau)
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              table:
+                header: annual benefit at 2011 level
+                row_key: benefit_age_band
+                column_key: annual_amount
+              excerpt: 13.452 kr. årligt (2011-niveau)
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              table:
+                header: annual benefit at 2011 level
+                row_key: benefit_age_band
+                column_key: annual_amount
+              excerpt: 10.584 kr. årligt (2011-niveau)
+    versions:
+      - effective_from: '2012-01-01'
+        values:
+          0: 16992
+          1: 13452
+          2: 10584
+          3: 10584
+
+  - name: cpi_index_base_year
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 1. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: indekset for 2009
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          2009
+
+  - name: cpi_measurement_lag_years
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 2. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: året 2 år forud
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          2
+
+  - name: first_adjustment_calendar_year
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 8. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: første gang for kalenderåret 2012
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          2012
+
+  - name: later_reduction_first_calendar_year
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 5. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: I 2013 og efterfølgende kalenderår
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          2013
+
+  - name: cpi_adjustment_reduction_percentage_points_2012
+    kind: parameter
+    dtype: Decimal
+    source: § 1, stk. 3, 4. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med 1,9 procentenheder
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          1.9
+
+  - name: cpi_adjustment_reduction_percentage_points_2013_and_later
+    kind: parameter
+    dtype: Decimal
+    source: § 1, stk. 3, 5. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med 3,9 procentenheder
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          3.9
+
+  - name: cpi_adjustment_reduction_rate
+    kind: parameter
+    dtype: Rate
+    source: § 1, stk. 3, 4.-5. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med 1,9 procentenheder
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med 3,9 procentenheder
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          0.019
+      - effective_from: '2013-01-01'
+        formula: |-
+          0.039
+
+  - name: cpi_change_decimal_places
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 6. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med en decimal
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          1
+
+  - name: benefit_rounding_multiple
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 7. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: kan deles med 12
+          - path: versions[1].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lov-1642-2025/aendring-af-boerne-og-ungeydelsesloven-mv/aendringcentreretparagraf-1
+              excerpt: ændres »12« til: »24«
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          12
+      - effective_from: '2026-01-01'
+        formula: |-
+          24
+
+  - name: additional_benefit_calendar_year
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 9. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: I 2023 forhøjes
+    versions:
+      - effective_from: '2023-01-01'
+        formula: |-
+          2023
+
+  - name: additional_annual_benefit_amount
+    kind: parameter
+    dtype: Money
+    unit: DKK
+    source: § 1, stk. 3, 9. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: samlet med 660 kr.
+    versions:
+      - effective_from: '2023-01-01'
+        formula: |-
+          660
+
+  - name: benefit_age_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: § 1, stk. 1-2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: ordering
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: indtil det fyldte 3. år
+          - path: versions[0].formula
+            kind: ordering
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: fra og med det fyldte 3. år
+          - path: versions[0].formula
+            kind: ordering
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: fra og med det fyldte 7. år
+          - path: versions[0].formula
+            kind: ordering
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: børn mellem 15 og 17 år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          if child_age_years < early_childhood_age_upper_bound: 0 else: if child_age_years < middle_childhood_age_upper_bound: 1 else: if child_age_years < childhood_age_upper_bound: 2 else: if child_age_years <= youth_age_upper_bound: 3 else: -1
+
+  - name: annual_tax_free_child_or_youth_benefit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: DKK
+    source: § 1, stk. 1-3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: Beløbene forhøjes eller nedsættes med samme procent
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: afrundes til nærmeste kronebeløb
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: I 2023 forhøjes
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: samlet med 660 kr.
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          if benefit_age_band == -1: 0 else: floor(((annual_benefit_2011_level[benefit_age_band] * (1 + percentage_change_rounded_to_one_decimal_place - cpi_adjustment_reduction_rate)) / benefit_rounding_multiple) + 0.5) * benefit_rounding_multiple
+      - effective_from: '2023-01-01'
+        formula: |-
+          if benefit_age_band == -1: 0 else: (floor(((annual_benefit_2011_level[benefit_age_band] * (1 + percentage_change_rounded_to_one_decimal_place - cpi_adjustment_reduction_rate)) / benefit_rounding_multiple) + 0.5) * benefit_rounding_multiple) + additional_annual_benefit_amount

--- a/tests/fixtures/generated_yaml_scanner/terra_p1r4_rejected.yaml
+++ b/tests/fixtures/generated_yaml_scanner/terra_p1r4_rejected.yaml
@@ -1,0 +1,387 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+    source_sha256: 2e135cac3ca5eb201b948ca915bf9554e864a09ebc8576c2603b6115730329ec
+  summary: |-
+    "For børn under 15 år udbetales en skattefri børneydelse." "For børn mellem 15 og 17 år udbetales en skattefri ungeydelse." Beløbene reguleres årligt efter forbrugerprisindekset og forhøjes i 2023 derudover samlet med 660 kr.
+rules:
+  - name: early_childhood_age_upper_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: indtil det fyldte 3. år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          3
+
+  - name: middle_childhood_age_lower_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: fra og med det fyldte 3. år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          3
+
+  - name: middle_childhood_age_upper_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: indtil det fyldte 7. år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          7
+
+  - name: later_childhood_age_lower_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: fra og med det fyldte 7. år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          7
+
+  - name: childhood_age_upper_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 1
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: børn under 15 år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          15
+
+  - name: youth_age_lower_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: børn mellem 15 og 17 år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          15
+
+  - name: youth_age_upper_bound
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: børn mellem 15 og 17 år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          17
+
+  - name: annual_benefit_2011_level
+    kind: parameter
+    dtype: Money
+    unit: DKK
+    indexed_by: benefit_age_band
+    source: § 1, stk. 1-2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: 16.992 kr. årligt (2011-niveau)
+          - path: versions[0].values
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: 13.452 kr. årligt (2011-niveau)
+          - path: versions[0].values
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: 10.584 kr. årligt (2011-niveau)
+    versions:
+      - effective_from: '2012-01-01'
+        values:
+          0: 16992
+          1: 13452
+          2: 10584
+          3: 10584
+
+  - name: cpi_index_base_year
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 1. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: indekset for 2009
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          2009
+
+  - name: cpi_measurement_lag_years
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 2. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: året 2 år forud
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          2
+
+  - name: cpi_adjustment_reduction_percentage_points_2012
+    kind: parameter
+    dtype: Decimal
+    source: § 1, stk. 3, 4. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med 1,9 procentenheder
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          1.9
+
+  - name: cpi_adjustment_reduction_percentage_points_2013_and_later
+    kind: parameter
+    dtype: Decimal
+    source: § 1, stk. 3, 5. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med 3,9 procentenheder
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          3.9
+
+  - name: cpi_adjustment_reduction_rate
+    kind: parameter
+    dtype: Rate
+    source: § 1, stk. 3, 4.-5. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med 1,9 procentenheder
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med 3,9 procentenheder
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          0.019
+      - effective_from: '2013-01-01'
+        formula: |-
+          0.039
+
+  - name: cpi_change_decimal_places
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 6. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: med en decimal
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          1
+
+  - name: benefit_rounding_multiple
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 7. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: kan deles med 12
+          - path: versions[1].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lov-1642-2025/aendring-af-boerne-og-ungeydelsesloven-mv/aendringcentreretparagraf-1
+              excerpt: ændres »12« til: »24«
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          12
+      - effective_from: '2026-01-01'
+        formula: |-
+          24
+
+  - name: additional_benefit_calendar_year
+    kind: parameter
+    dtype: Integer
+    source: § 1, stk. 3, 9. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: I 2023 forhøjes
+    versions:
+      - effective_from: '2023-01-01'
+        formula: |-
+          2023
+
+  - name: additional_annual_benefit_amount
+    kind: parameter
+    dtype: Money
+    unit: DKK
+    source: § 1, stk. 3, 9. pkt.
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: samlet med 660 kr.
+    versions:
+      - effective_from: '2023-01-01'
+        formula: |-
+          660
+
+  - name: benefit_age_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: § 1, stk. 1-2
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: ordering
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: børn under 15 år
+          - path: versions[0].formula
+            kind: ordering
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: børn mellem 15 og 17 år
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          if child_age_years < early_childhood_age_upper_bound: 0 else: if child_age_years < middle_childhood_age_upper_bound: 1 else: if child_age_years < childhood_age_upper_bound: 2 else: if child_age_years <= youth_age_upper_bound: 3 else: -1
+
+  - name: annual_tax_free_child_or_youth_benefit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: DKK
+    source: § 1, stk. 1-3
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: Beløbene forhøjes eller nedsættes
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: afrundes til nærmeste kronebeløb
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1
+              excerpt: I 2023 forhøjes
+    versions:
+      - effective_from: '2012-01-01'
+        formula: |-
+          if benefit_age_band == -1: 0 else: floor(((annual_benefit_2011_level[benefit_age_band] * (1 + percentage_change_rounded_to_one_decimal_place - cpi_adjustment_reduction_rate)) / benefit_rounding_multiple) + 0.5) * benefit_rounding_multiple
+      - effective_from: '2023-01-01'
+        formula: |-
+          if benefit_age_band == -1: 0 else: (floor(((annual_benefit_2011_level[benefit_age_band] * (1 + percentage_change_rounded_to_one_decimal_place - cpi_adjustment_reduction_rate)) / benefit_rounding_multiple) + 0.5) * benefit_rounding_multiple) + (if payment_year_has_additional_statutory_increase: additional_annual_benefit_amount else: 0)

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1694"
+ENCODER_VERSION = "0.2.1695"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,7 @@ from axiom_encode.cli import (
     _person_scoped_definition_issue_names,
     _promote_boolean_comparison_predicates_to_judgment,
     _qualify_deferred_output_subsection_paths,
+    _quote_unquoted_source_scalars,
     _quoted_review_finding_excerpts,
     _read_only_guard_encoder_execution_identity,
     _reanchor_legacy_exact_dependent_proof_excerpts,
@@ -33882,6 +33883,193 @@ rules: []
         assert run.outcome["auto_repaired_unquoted_source_scalars"] == ["source:7"]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_encode_apply_repairs_unquoted_proof_excerpt_colons(self, capsys, tmp_path):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed compile validation"
+        output_file = tmp_path / "out" / "codex-test-model" / "statutes/42/426.yaml"
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/426
+rules:
+  - name: hospital_insurance_entitlement
+    kind: parameter
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/426
+              excerpt: entitlement changes at age: 65
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 'true'
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/42/426.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                return_value=(True, [], {}),
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, TEST_APPLY_SIGNING_ENV, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_unquoted_source_scalars:excerpt:15" in output
+        repaired = yaml.safe_load(output_file.read_text())
+        assert (
+            repaired["rules"][0]["metadata"]["proof"]["atoms"][0]["source"]["excerpt"]
+            == "entitlement changes at age: 65"
+        )
+        assert mock_overlay.call_count == 1
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_unquoted_source_scalars"] == ["excerpt:15"]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
+    @pytest.mark.parametrize(
+        (
+            "fixture_name",
+            "fixture_sha256",
+            "line_number",
+            "column_number",
+            "byte_column_number",
+        ),
+        (
+            (
+                "terra_p1r4_rejected.yaml",
+                "218738a3ee2d62b195599522f0177d5b969d70d7f2f53425cab189e0b28e335c",
+                288,
+                39,
+                42,
+            ),
+            (
+                "sol_p1r4_rejected.yaml",
+                "24ad3da727512998428cab4489f475a26737c7822af6b1a2195f7c49fac1c299",
+                351,
+                39,
+                42,
+            ),
+        ),
+    )
+    def test_generated_yaml_repair_quotes_trace_candidate_proof_excerpts(
+        self,
+        fixture_name,
+        fixture_sha256,
+        line_number,
+        column_number,
+        byte_column_number,
+        tmp_path,
+    ):
+        original = (
+            Path(__file__).parent / "fixtures" / "generated_yaml_scanner" / fixture_name
+        ).read_text()
+        # These are the complete rejected RuleSpecs embedded in run 32093928177's
+        # retry traces. The final output paths contain later, valid attempts.
+        assert hashlib.sha256(original.encode()).hexdigest() == fixture_sha256
+        generated = tmp_path / "paragraf-1.yaml"
+        generated.write_text(original)
+
+        with pytest.raises(yaml.scanner.ScannerError) as exc_info:
+            yaml.safe_load(original)
+
+        mark = exc_info.value.problem_mark
+        assert (mark.line + 1, mark.column + 1) == (
+            line_number,
+            column_number,
+        )
+        offending_line = original.splitlines()[mark.line]
+        assert offending_line[mark.column] == ":"
+        assert len(offending_line[: mark.column].encode("utf-8")) + 1 == (
+            byte_column_number
+        )
+        result = SimpleNamespace(backend="openai")
+        with pytest.raises(RuntimeError) as diagnostic_exc:
+            _stamp_generated_source_attestation_for_apply(result, generated)
+        assert str(diagnostic_exc.value) == (
+            "[generated-yaml:scanner] invalid YAML at line "
+            f"{line_number}, column {column_number}: unexpected mapping-value ':' "
+            "delimiter; quote scalar text containing ': '"
+        )
+
+        repaired = _quote_unquoted_source_scalars(rules_file=generated)
+
+        assert repaired == [f"excerpt:{line_number}"]
+        repaired_text = generated.read_text()
+        expected_lines = original.splitlines(keepends=True)
+        expected_lines[line_number - 1] = (
+            "              excerpt: 'ændres »12« til: »24«'\n"
+        )
+        assert repaired_text == "".join(expected_lines)
+        assert yaml.safe_load(repaired_text)["format"] == "rulespec/v1"
+
+        source_path = "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1"
+        with patch(
+            "axiom_encode.cli._generated_result_source_attestation",
+            return_value=_complete_source_attestation(source_path),
+        ):
+            _stamp_generated_source_attestation_for_apply(result, generated)
+        assert yaml.safe_load(generated.read_text())["format"] == "rulespec/v1"
+
+    def test_generated_yaml_proof_excerpt_repair_keeps_invalid_document_unchanged(
+        self, tmp_path
+    ):
+        generated = tmp_path / "paragraf-1.yaml"
+        original = """format: rulespec/v1
+rules:
+  - metadata:
+      proof:
+        atoms:
+          - source:
+              excerpt: ændres »12« til: »24«
+    versions:
+      - formula: if condition: 1 else: 0
+"""
+        generated.write_text(original)
+
+        repaired = _quote_unquoted_source_scalars(rules_file=generated)
+
+        assert repaired == []
+        assert generated.read_text() == original
+
+    def test_generated_yaml_source_evidence_repair_preserves_inline_comments(
+        self, tmp_path
+    ):
+        generated = tmp_path / "generated.yaml"
+        original = """excerpt: valid evidence # reviewer: note
+source: changes at age: 65 # source: note
+"""
+        generated.write_text(original)
+
+        repaired = _quote_unquoted_source_scalars(rules_file=generated)
+
+        assert repaired == ["source:2"]
+        assert generated.read_text() == (
+            "excerpt: valid evidence # reviewer: note\n"
+            "source: 'changes at age: 65' # source: note\n"
+        )
+        assert yaml.safe_load(generated.read_text()) == {
+            "excerpt": "valid evidence",
+            "source": "changes at age: 65",
+        }
 
     def test_encode_apply_blocks_non_validation_generation_failure(
         self, capsys, tmp_path

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1694"
+ENCODER_VERSION = "0.2.1695"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1694"
+ENCODER_VERSION = "0.2.1695"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1694"
+ENCODER_VERSION = "0.2.1695"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1694"
+ENCODER_VERSION = "0.2.1695"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1694"
+ENCODER_VERSION = "0.2.1695"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1694"
+ENCODER_VERSION = "0.2.1695"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1694"')
+        .startswith('__version__ = "0.2.1695"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1694"
+    assert encoder_package["version"] == "0.2.1695"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1694"
+    assert project["project"]["version"] == "0.2.1695"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1694"')
+        .startswith('__version__ = "0.2.1695"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1694"
+    assert encoder_package["version"] == "0.2.1695"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1694"
+    assert project["project"]["version"] == "0.2.1695"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1694"')
+        .startswith('__version__ = "0.2.1695"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1694"
+ENCODER_VERSION = "0.2.1695"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1694"
+version = "0.2.1695"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Four dk paragraf-1 targeted-signed-reencode runs (32087322836, 32088218084, 32090158600, 32093928177) each burned ~half their candidates on `[generated-yaml:scanner] invalid YAML … column 39: unexpected mapping`. Root cause: models keep emitting the amendment-operation excerpt `ændres »12« til: »24«` as an **unquoted** plain scalar — the `til: ` colon+space makes it genuinely invalid YAML. (The failure looked like position drift from the artifacts because the retry loop overwrites the rejected candidate at its destination; the trace-retained candidates carry the invalid line at exactly the reported mark. Column is the Unicode character position — byte column 42.)

No prompt-side discipline can guarantee scalar quoting, so the guarded pre-apply repair now covers it deterministically:

- extends the existing `source:` repair to `excerpt:` scalars;
- edits **only** at PyYAML's exact `problem_mark` for `mapping values are not allowed here`, after verifying the marked character is a `: ` inside an unquoted plain-scalar body — no blanket regex churn;
- preserves inline comments; loops until the complete document parses; **fails closed** (returns no repair) on any unexpected shape, so a truly malformed candidate still rejects;
- content untouched — only YAML quoting (`'` doubled per YAML single-quote rules).

Tests: the full trace-retained terra/sol rejected candidates as fixtures (repair at 288:39 / 351:39), Unicode char-vs-byte position, apply flow, rollback, comment preservation; 267 repair-suite tests green; ruff clean. Built by sol on the fresh lane; reviewed hands-on (diff, escaping, test run) before this PR.

Unblocks the dk wave-2 certified=yes burndown: paragraf-1's re-encode (temporal-interval split) kept losing candidates to this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
