### PR TITLE
Accept result-attached input-fed rounding evidence (closes the §66 loop)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1702"
+version = "0.2.1703"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1702"
+__version__ = "0.2.1703"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -15386,7 +15386,10 @@ def _rounding_text_refers_to_result(text: str) -> bool:
             r"\s*(?:"
             r"das\s+ergebnis|"
             r"the\s+result|"
-            r"der\s+sich\s+ergebende\s+steuerbetrag"
+            r"der\s+sich\s+ergebende\s+steuerbetrag|"
+            # German statutes also repeat the affected noun and use
+            # "dabei" to attach it to the immediately preceding computation.
+            r"d(?:as|er|ie)\s+[\wÄÖÜäöüß-]+\s+(?:ist|sind)\s+dabei"
             r")\b",
             unmarked,
             flags=re.IGNORECASE,

--- a/tests/fixtures/source_completeness/estg_66_rounding_input_stage/minimally_fixed/66.test.yaml
+++ b/tests/fixtures/source_completeness/estg_66_rounding_input_stage/minimally_fixed/66.test.yaml
@@ -1,0 +1,45 @@
+- name: payable during inclusive payment period
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.month_is_on_or_after_first_qualifying_month: true
+    de:statutes/estg/66#input.month_is_on_or_before_last_qualifying_month: true
+  output:
+    de:statutes/estg/66#kindergeld_payable_for_month: holds
+- name: not payable before first qualifying month
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.month_is_on_or_after_first_qualifying_month: false
+    de:statutes/estg/66#input.month_is_on_or_before_last_qualifying_month: true
+  output:
+    de:statutes/estg/66#kindergeld_payable_for_month: not_holds
+- name: not payable after last qualifying month
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.month_is_on_or_after_first_qualifying_month: true
+    de:statutes/estg/66#input.month_is_on_or_before_last_qualifying_month: false
+  output:
+    de:statutes/estg/66#kindergeld_payable_for_month: not_holds
+- name: increased kindergeld rounds down below half euro
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.child_allowances_under_sections_31_and_32_6_1_are_increased: true
+    de:statutes/estg/66#input.correspondingly_increased_kindergeld_amount: 100.49
+  output:
+    de:statutes/estg/66#kindergeld_before_whole_euro_rounding: 100.49
+    de:statutes/estg/66#kindergeld_after_whole_euro_rounding: 100
+- name: increased kindergeld rounds up from half euro
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.child_allowances_under_sections_31_and_32_6_1_are_increased: true
+    de:statutes/estg/66#input.correspondingly_increased_kindergeld_amount: 100.5
+  output:
+    de:statutes/estg/66#kindergeld_before_whole_euro_rounding: 100.5
+    de:statutes/estg/66#kindergeld_after_whole_euro_rounding: 101
+- name: unchanged kindergeld uses monthly statutory amount
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.child_allowances_under_sections_31_and_32_6_1_are_increased: false
+    de:statutes/estg/66#input.correspondingly_increased_kindergeld_amount: 100.5
+  output:
+    de:statutes/estg/66#kindergeld_before_whole_euro_rounding: 259
+    de:statutes/estg/66#kindergeld_after_whole_euro_rounding: 259

--- a/tests/fixtures/source_completeness/estg_66_rounding_input_stage/minimally_fixed/66.yaml
+++ b/tests/fixtures/source_completeness/estg_66_rounding_input_stage/minimally_fixed/66.yaml
@@ -1,0 +1,148 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: de/statute/estg/66
+    source_sha256: 2ac3c9ff2d11aa23e6850d0a8e81abd612034582a571c036627c8b689293871e
+  summary: '§ 66 Abs. 1: „Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.“
+
+    Abs. 2 umfasst den Monat, in dem die Anspruchsvoraussetzungen erfüllt sind, bis
+    einschließlich des Monats ihres Wegfalls.
+
+    Abs. 3 erhöht das Kindergeld bei Anhebung der Kinderfreibeträge entsprechend und
+    verlangt kaufmännische Rundung auf volle Euro.'
+rules:
+- name: monthly_kindergeld_per_child
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: EUR
+  source: § 66 Abs. 1 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: In § 66 Absatz 1 wird die Angabe „250 Euro“ durch die Angabe „255
+            Euro“ ersetzt.
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Dieses Gesetz tritt vorbehaltlich des Absatzes 2 am 1. Januar 2025
+            in Kraft.
+      - path: versions[1].formula
+        kind: amount
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.
+      - path: versions[1].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Die Artikel 2, 4 und 6 treten am 1. Januar 2026 in Kraft.
+  versions:
+  - effective_from: '2025-01-01'
+    formula: '255'
+  - effective_from: '2026-01-01'
+    formula: '259'
+- name: whole_euro_rounding_multiple
+  kind: parameter
+  dtype: Money
+  unit: EUR
+  source: § 66 Abs. 3 Satz 2 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: unit
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Das Kindergeld ist dabei auf volle Euro kaufmännisch zu runden.
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Die Artikel 2, 4 und 6 treten am 1. Januar 2026 in Kraft.
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '1'
+- name: kindergeld_payable_for_month
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: § 66 Abs. 2 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: vom Beginn des Monats an gezahlt, in dem die Anspruchsvoraussetzungen
+            erfüllt sind, bis zum Ende des Monats, in dem die Anspruchsvoraussetzungen
+            wegfallen
+  versions:
+  - effective_from: '2025-01-01'
+    formula: 'month_is_on_or_after_first_qualifying_month
+
+      and month_is_on_or_before_last_qualifying_month'
+- name: kindergeld_before_whole_euro_rounding
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: EUR
+  source: § 66 Abs. 3 Satz 1 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Werden die Freibeträge für Kinder nach § 31 Satz 1 in Verbindung
+            mit § 32 Absatz 6 Satz 1 angehoben, wird das Kindergeld entsprechend erhöht.
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Die Artikel 2, 4 und 6 treten am 1. Januar 2026 in Kraft.
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if child_allowances_under_sections_31_and_32_6_1_are_increased: correspondingly_increased_kindergeld_amount
+      else: monthly_kindergeld_per_child'
+- name: kindergeld_after_whole_euro_rounding
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: EUR
+  source: § 66 Abs. 3 Sätze 1 und 2 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Werden die Freibeträge für Kinder nach § 31 Satz 1 in Verbindung
+            mit § 32 Absatz 6 Satz 1 angehoben, wird das Kindergeld entsprechend erhöht.
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Das Kindergeld ist dabei auf volle Euro kaufmännisch zu runden.
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Die Artikel 2, 4 und 6 treten am 1. Januar 2026 in Kraft.
+  versions:
+  - effective_from: '2026-01-01'
+    formula: floor((kindergeld_before_whole_euro_rounding / whole_euro_rounding_multiple)
+      + 0.5) * whole_euro_rounding_multiple

--- a/tests/fixtures/source_completeness/estg_66_rounding_input_stage/rejected/66.test.yaml
+++ b/tests/fixtures/source_completeness/estg_66_rounding_input_stage/rejected/66.test.yaml
@@ -1,0 +1,45 @@
+- name: payable during inclusive payment period
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.month_is_on_or_after_first_qualifying_month: true
+    de:statutes/estg/66#input.month_is_on_or_before_last_qualifying_month: true
+  output:
+    de:statutes/estg/66#kindergeld_payable_for_month: holds
+- name: not payable before first qualifying month
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.month_is_on_or_after_first_qualifying_month: false
+    de:statutes/estg/66#input.month_is_on_or_before_last_qualifying_month: true
+  output:
+    de:statutes/estg/66#kindergeld_payable_for_month: not_holds
+- name: not payable after last qualifying month
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.month_is_on_or_after_first_qualifying_month: true
+    de:statutes/estg/66#input.month_is_on_or_before_last_qualifying_month: false
+  output:
+    de:statutes/estg/66#kindergeld_payable_for_month: not_holds
+- name: increased kindergeld rounds down below half euro
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.child_allowances_under_sections_31_and_32_6_1_are_increased: true
+    de:statutes/estg/66#input.correspondingly_increased_kindergeld_amount: 100.49
+  output:
+    de:statutes/estg/66#kindergeld_before_whole_euro_rounding: 100.49
+    de:statutes/estg/66#kindergeld_after_child_allowance_increase: 100
+- name: increased kindergeld rounds up from half euro
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.child_allowances_under_sections_31_and_32_6_1_are_increased: true
+    de:statutes/estg/66#input.correspondingly_increased_kindergeld_amount: 100.5
+  output:
+    de:statutes/estg/66#kindergeld_before_whole_euro_rounding: 100.5
+    de:statutes/estg/66#kindergeld_after_child_allowance_increase: 101
+- name: unchanged kindergeld uses monthly statutory amount
+  period: 2026-03
+  input:
+    de:statutes/estg/66#input.child_allowances_under_sections_31_and_32_6_1_are_increased: false
+    de:statutes/estg/66#input.correspondingly_increased_kindergeld_amount: 100.5
+  output:
+    de:statutes/estg/66#kindergeld_before_whole_euro_rounding: 259
+    de:statutes/estg/66#kindergeld_after_child_allowance_increase: 259

--- a/tests/fixtures/source_completeness/estg_66_rounding_input_stage/rejected/66.yaml
+++ b/tests/fixtures/source_completeness/estg_66_rounding_input_stage/rejected/66.yaml
@@ -1,0 +1,148 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: de/statute/estg/66
+    source_sha256: 2ac3c9ff2d11aa23e6850d0a8e81abd612034582a571c036627c8b689293871e
+  summary: '§ 66 Abs. 1: „Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.“
+
+    Abs. 2 umfasst den Monat, in dem die Anspruchsvoraussetzungen erfüllt sind, bis
+    einschließlich des Monats ihres Wegfalls.
+
+    Abs. 3 erhöht das Kindergeld bei Anhebung der Kinderfreibeträge entsprechend und
+    verlangt kaufmännische Rundung auf volle Euro.'
+rules:
+- name: monthly_kindergeld_per_child
+  kind: parameter
+  dtype: Money
+  period: Month
+  unit: EUR
+  source: § 66 Abs. 1 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: In § 66 Absatz 1 wird die Angabe „250 Euro“ durch die Angabe „255
+            Euro“ ersetzt.
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Dieses Gesetz tritt vorbehaltlich des Absatzes 2 am 1. Januar 2025
+            in Kraft.
+      - path: versions[1].formula
+        kind: amount
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.
+      - path: versions[1].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Die Artikel 2, 4 und 6 treten am 1. Januar 2026 in Kraft.
+  versions:
+  - effective_from: '2025-01-01'
+    formula: '255'
+  - effective_from: '2026-01-01'
+    formula: '259'
+- name: whole_euro_rounding_multiple
+  kind: parameter
+  dtype: Money
+  unit: EUR
+  source: § 66 Abs. 3 Satz 2 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: unit
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Das Kindergeld ist dabei auf volle Euro kaufmännisch zu runden.
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Die Artikel 2, 4 und 6 treten am 1. Januar 2026 in Kraft.
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '1'
+- name: kindergeld_payable_for_month
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: § 66 Abs. 2 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: vom Beginn des Monats an gezahlt, in dem die Anspruchsvoraussetzungen
+            erfüllt sind, bis zum Ende des Monats, in dem die Anspruchsvoraussetzungen
+            wegfallen
+  versions:
+  - effective_from: '2025-01-01'
+    formula: 'month_is_on_or_after_first_qualifying_month
+
+      and month_is_on_or_before_last_qualifying_month'
+- name: kindergeld_before_whole_euro_rounding
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: EUR
+  source: § 66 Abs. 3 Satz 1 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Werden die Freibeträge für Kinder nach § 31 Satz 1 in Verbindung
+            mit § 32 Absatz 6 Satz 1 angehoben, wird das Kindergeld entsprechend erhöht.
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Die Artikel 2, 4 und 6 treten am 1. Januar 2026 in Kraft.
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if child_allowances_under_sections_31_and_32_6_1_are_increased: correspondingly_increased_kindergeld_amount
+      else: monthly_kindergeld_per_child'
+- name: kindergeld_after_child_allowance_increase
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: EUR
+  source: § 66 Abs. 3 Sätze 1 und 2 EStG
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Werden die Freibeträge für Kinder nach § 31 Satz 1 in Verbindung
+            mit § 32 Absatz 6 Satz 1 angehoben, wird das Kindergeld entsprechend erhöht.
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: de/statute/estg/66
+          excerpt: Das Kindergeld ist dabei auf volle Euro kaufmännisch zu runden.
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1
+          excerpt: Die Artikel 2, 4 und 6 treten am 1. Januar 2026 in Kraft.
+  versions:
+  - effective_from: '2026-01-01'
+    formula: floor((kindergeld_before_whole_euro_rounding / whole_euro_rounding_multiple)
+      + 0.5) * whole_euro_rounding_multiple

--- a/tests/fixtures/source_completeness/estg_66_rounding_input_stage/rejected/issues.json
+++ b/tests/fixtures/source_completeness/estg_66_rounding_input_stage/rejected/issues.json
@@ -1,0 +1,12 @@
+{
+  "attempt_count": 6,
+  "citation": "de/statute/estg/66",
+  "encoder_version": "0.2.1694",
+  "issues": [
+    "statutes/estg/66.yaml: ci: [complete-source-unit:tests] Companion tests do not demonstrate every source-stated rounding rule with distinct fractional input evidence on its affected principal output; missing at de/statute/estg/66(3) [Absatz 3]. A satisfying nearest/kaufmännisch shape is same-period paired cases with otherwise-identical inputs that drive the executed pre-rounding derived amount to 100.49 -> 100 and 100.50 -> 101; assert both the reached unrounded intermediate and the affected principal output in each case. Alternative: when the rounded computation depends on outputs that are not yet available (for example a cross-module base this module cannot compute), a PRECISE typed deferral of that branch removes this demand — declare `module.deferred_outputs: [{output: <namespaced branch output>, reason: <names the exact missing dependency citations>}]` instead of encoding a speculative mechanism."
+  ],
+  "path": "statutes/estg/66.yaml",
+  "rulespec_sha256": "7c1545d20f21bcdaba0abd7b8af324b3747148f84d7593e4f358ec726a57396b",
+  "schema": "axiom-encode/failed-encode-candidate/v1",
+  "tests_sha256": "4198cb7116c0c34717354a29a30da6884cb5e31964911af3a9a68815d003a31b"
+}

--- a/tests/fixtures/source_completeness/estg_66_rounding_input_stage/source.txt
+++ b/tests/fixtures/source_completeness/estg_66_rounding_input_stage/source.txt
@@ -1,0 +1,3 @@
+(1) Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.
+(2) Das Kindergeld wird monatlich vom Beginn des Monats an gezahlt, in dem die Anspruchsvoraussetzungen erfüllt sind, bis zum Ende des Monats, in dem die Anspruchsvoraussetzungen wegfallen.
+(3) Werden die Freibeträge für Kinder nach § 31 Satz 1 in Verbindung mit § 32 Absatz 6 Satz 1 angehoben, wird das Kindergeld entsprechend erhöht. Das Kindergeld ist dabei auf volle Euro kaufmännisch zu runden.

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1702"')
+        .startswith('__version__ = "0.2.1703"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1702"
+    assert encoder_package["version"] == "0.2.1703"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1702"
+    assert project["project"]["version"] == "0.2.1703"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1702"')
+        .startswith('__version__ = "0.2.1703"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1702"
+    assert encoder_package["version"] == "0.2.1703"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1702"
+    assert project["project"]["version"] == "0.2.1703"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1702"')
+        .startswith('__version__ = "0.2.1703"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -32832,12 +32832,10 @@ def test_estg_66_rounding_input_stage_specimen_bytes_are_pinned():
     assert hashlib.sha256(rejected_tests).hexdigest() == (
         "4198cb7116c0c34717354a29a30da6884cb5e31964911af3a9a68815d003a31b"
     )
-    assert recorded_issue["rulespec_sha256"] == hashlib.sha256(
-        rejected_rules
-    ).hexdigest()
-    assert recorded_issue["tests_sha256"] == hashlib.sha256(
-        rejected_tests
-    ).hexdigest()
+    assert (
+        recorded_issue["rulespec_sha256"] == hashlib.sha256(rejected_rules).hexdigest()
+    )
+    assert recorded_issue["tests_sha256"] == hashlib.sha256(rejected_tests).hexdigest()
     assert hashlib.sha256(fixed_rules).hexdigest() == (
         "6787c5c50520320292b1438ef9d45cf349d4ecbbf981b1c908a11f9278350d5e"
     )
@@ -32860,9 +32858,10 @@ def test_estg_66_rounding_input_stage_specimen_bytes_are_pinned():
 def test_estg_66_accepts_asserted_input_fed_rounding_stage(variant: str):
     fixture = ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE / variant
     source = (
-        ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE
-        / "source.txt"
-    ).read_text().removesuffix("\n")
+        (ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE / "source.txt")
+        .read_text()
+        .removesuffix("\n")
+    )
 
     result = _analyze(
         (fixture / "66.yaml").read_text(),
@@ -32877,15 +32876,14 @@ def test_estg_66_accepts_asserted_input_fed_rounding_stage(variant: str):
 def test_estg_66_input_fed_rounding_stage_must_be_asserted():
     fixture = ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE / "rejected"
     test_cases = yaml.safe_load((fixture / "66.test.yaml").read_text())
-    intermediate = (
-        "de:statutes/estg/66#kindergeld_before_whole_euro_rounding"
-    )
+    intermediate = "de:statutes/estg/66#kindergeld_before_whole_euro_rounding"
     for case in test_cases:
         case["output"].pop(intermediate, None)
     source = (
-        ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE
-        / "source.txt"
-    ).read_text().removesuffix("\n")
+        (ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE / "source.txt")
+        .read_text()
+        .removesuffix("\n")
+    )
 
     result = _analyze(
         (fixture / "66.yaml").read_text(),

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -32809,6 +32809,106 @@ rules:
     assert not result.issues
 
 
+ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "source_completeness"
+    / "estg_66_rounding_input_stage"
+)
+
+
+def test_estg_66_rounding_input_stage_specimen_bytes_are_pinned():
+    rejected = ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE / "rejected"
+    minimally_fixed = ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE / "minimally_fixed"
+    rejected_rules = (rejected / "66.yaml").read_bytes()
+    rejected_tests = (rejected / "66.test.yaml").read_bytes()
+    fixed_rules = (minimally_fixed / "66.yaml").read_bytes()
+    fixed_tests = (minimally_fixed / "66.test.yaml").read_bytes()
+    recorded_issue = yaml.safe_load((rejected / "issues.json").read_text())
+
+    assert hashlib.sha256(rejected_rules).hexdigest() == (
+        "7c1545d20f21bcdaba0abd7b8af324b3747148f84d7593e4f358ec726a57396b"
+    )
+    assert hashlib.sha256(rejected_tests).hexdigest() == (
+        "4198cb7116c0c34717354a29a30da6884cb5e31964911af3a9a68815d003a31b"
+    )
+    assert recorded_issue["rulespec_sha256"] == hashlib.sha256(
+        rejected_rules
+    ).hexdigest()
+    assert recorded_issue["tests_sha256"] == hashlib.sha256(
+        rejected_tests
+    ).hexdigest()
+    assert hashlib.sha256(fixed_rules).hexdigest() == (
+        "6787c5c50520320292b1438ef9d45cf349d4ecbbf981b1c908a11f9278350d5e"
+    )
+    assert hashlib.sha256(fixed_tests).hexdigest() == (
+        "0603e164a4f6eb2c96d57fc78964e98e5e0ff9099289cc5795dafa73bb8b834d"
+    )
+
+    old_name = b"kindergeld_after_child_allowance_increase"
+    new_name = b"kindergeld_after_whole_euro_rounding"
+    assert fixed_rules == rejected_rules.replace(old_name, new_name)
+    assert fixed_tests == rejected_tests.replace(old_name, new_name)
+
+    source = (ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE / "source.txt").read_bytes()
+    assert hashlib.sha256(source.removesuffix(b"\n")).hexdigest() == (
+        "2ac3c9ff2d11aa23e6850d0a8e81abd612034582a571c036627c8b689293871e"
+    )
+
+
+@pytest.mark.parametrize("variant", ["rejected", "minimally_fixed"])
+def test_estg_66_accepts_asserted_input_fed_rounding_stage(variant: str):
+    fixture = ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE / variant
+    source = (
+        ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE
+        / "source.txt"
+    ).read_text().removesuffix("\n")
+
+    result = _analyze(
+        (fixture / "66.yaml").read_text(),
+        source,
+        corpus_citation_path="de/statute/estg/66",
+        test_cases=yaml.safe_load((fixture / "66.test.yaml").read_text()),
+    )
+
+    assert not result.issues
+
+
+def test_estg_66_input_fed_rounding_stage_must_be_asserted():
+    fixture = ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE / "rejected"
+    test_cases = yaml.safe_load((fixture / "66.test.yaml").read_text())
+    intermediate = (
+        "de:statutes/estg/66#kindergeld_before_whole_euro_rounding"
+    )
+    for case in test_cases:
+        case["output"].pop(intermediate, None)
+    source = (
+        ESTG_66_ROUNDING_INPUT_STAGE_FIXTURE
+        / "source.txt"
+    ).read_text().removesuffix("\n")
+
+    result = _analyze(
+        (fixture / "66.yaml").read_text(),
+        source,
+        corpus_citation_path="de/statute/estg/66",
+        test_cases=test_cases,
+    )
+
+    assert _has_issue(result, "rounding", "fractional")
+
+
+@pytest.mark.parametrize(
+    "directive",
+    [
+        "Das Kindergeld ist dabei auf volle Euro kaufmännisch zu runden.",
+        "Der Betrag ist dabei auf volle Euro abzurunden.",
+        "Die Beträge sind dabei auf volle Euro aufzurunden.",
+    ],
+)
+def test_german_dabei_rounding_refers_to_preceding_result(directive: str):
+    assert completeness_module._rounding_text_refers_to_result(directive)
+
+
 def test_estg_66_rounding_retry_shows_and_accepts_paired_half_boundary_shape():
     source = """\
 (3) Werden die Freibeträge für Kinder nach § 31 Satz 1 in Verbindung mit § 32 Absatz 6 Satz 1 angehoben, wird das Kindergeld entsprechend erhöht. Das Kindergeld ist dabei auf volle Euro kaufmännisch zu runden.

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1702"
+version = "0.2.1703"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
The last blocker on rulespec-de's first certified policy, adjudicated from a real specimen: after 16 sol attempts, round-5's candidate carried EXACTLY the prescribed paired rounding tests (100.49→100 / 100.5→101, intermediate + principal asserted) yet the demand still fired — the witness predicate required the pre-rounding amount be formula-derived, rejecting input-fed intermediates. For a mechanism whose source states NO formula (§66 Abs. 3 'wird … entsprechend erhöht'), the input-fed shape is the honest encoding. The checker now accepts result-attached input-fed evidence; the formula-derived path stays valid; the exact rejected specimen is pinned as a regression (fixture incl. its source). Completeness suite 5,823 passed (3 first-run env flakes reproduce on clean rerun as 0). Version bump + pin sweep.

Seeded round-6 dispatch follows the pin pair — the specimen that produced this fix should sign as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)