### PR TITLE
Notary verifier core (schema-frozen): canonicalization, manifests, comparator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1703"
+version = "0.2.1704"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,6 +31,7 @@ dependencies = [
     "pyyaml>=6.0",
     "receipt==0.5.1",
     "requests>=2.28",
+    "rfc8785>=0.1.4",
     "sqlite-utils>=3.30",
     "supabase>=2.0.0",
 ]

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1703"
+__version__ = "0.2.1704"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/notary/__init__.py
+++ b/src/axiom_encode/notary/__init__.py
@@ -1,0 +1,1 @@
+"""Schema-independent primitives for notary admission verification."""

--- a/src/axiom_encode/notary/canonical.py
+++ b/src/axiom_encode/notary/canonical.py
@@ -1,0 +1,109 @@
+"""Canonical JSON and digest helpers for notary bodies."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterable
+
+import rfc8785
+
+from .refusal import Refusal
+
+
+class _DuplicateMember(ValueError):
+    """Internal signal for a duplicate decoded JSON member name."""
+
+
+class _InvalidConstant(ValueError):
+    """Internal signal for a non-JSON numeric constant."""
+
+
+def jcs_dumps(obj: object) -> bytes:
+    """Serialize *obj* with RFC 8785 JSON Canonicalization Scheme rules."""
+    return rfc8785.dumps(obj)
+
+
+def sha256_hex(data: bytes) -> str:
+    """Return the lowercase hexadecimal SHA-256 digest of *data*."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def body_digest(obj: object) -> str:
+    """Return the SHA-256 digest of an object's JCS serialization."""
+    return sha256_hex(jcs_dumps(obj))
+
+
+def _unique_object(pairs: Iterable[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateMember
+        result[key] = value
+    return result
+
+
+def _reject_constant(_value: str) -> object:
+    raise _InvalidConstant
+
+
+def _invalid_value_detail(value: object) -> str | None:
+    pending = [value]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, str):
+            try:
+                current.encode("utf-8", errors="strict")
+            except UnicodeEncodeError:
+                return "invalid_unicode"
+        elif isinstance(current, float) and not math.isfinite(current):
+            return "number_out_of_range"
+        elif isinstance(current, dict):
+            pending.extend(current.keys())
+            pending.extend(current.values())
+        elif isinstance(current, list):
+            pending.extend(current)
+    return None
+
+
+def strict_parse(data: bytes) -> object | Refusal:
+    """Parse strict UTF-8 JSON, refusing duplicates and invalid Unicode."""
+    try:
+        text = data.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return Refusal("structural", None, "invalid_utf8")
+
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_unique_object,
+            parse_constant=_reject_constant,
+        )
+    except _DuplicateMember:
+        return Refusal("structural", None, "duplicate_json_member")
+    except _InvalidConstant:
+        return Refusal("structural", None, "non_json_number")
+    except (json.JSONDecodeError, RecursionError, ValueError):
+        return Refusal("structural", None, "invalid_json")
+
+    invalid_detail = _invalid_value_detail(value)
+    if invalid_detail is not None:
+        return Refusal("structural", None, invalid_detail)
+    return value
+
+
+def is_canonical(data: bytes) -> bool:
+    """Return whether *data* is its parsed value's exact JCS serialization."""
+    value = strict_parse(data)
+    if isinstance(value, Refusal):
+        return False
+    try:
+        return jcs_dumps(value) == data
+    except (
+        rfc8785.CanonicalizationError,
+        RecursionError,
+        TypeError,
+        UnicodeError,
+    ):
+        return False

--- a/src/axiom_encode/notary/comparator.py
+++ b/src/axiom_encode/notary/comparator.py
@@ -1,0 +1,80 @@
+"""Universal bytewise comparator for named semantic arrays."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from .refusal import Refusal
+
+SEMANTIC_ARRAY_SORT_KEYS: dict[str, str | None] = {
+    "gates": "gate_id",
+    "required_gates": "gate_id",
+    "acceptable_outcomes": None,
+    "reasons": None,
+    "eligible_records": None,
+    "unused_eligible_records": None,
+    "ineligible_records": "store_name",
+    "coverage_assignment": "path",
+    "delta": "path",
+    "actions": "ref_spec",
+    "containers": "image",
+    "inventories": "path",
+}
+
+
+def _element_key(
+    name: str,
+    sort_key: str | None,
+    item: object,
+    index: int,
+) -> str | Refusal:
+    path = f"{name}[{index}]"
+    if sort_key is None:
+        if not isinstance(item, str):
+            return Refusal("structural", path, "semantic_array_key_not_string")
+        return item
+    if not isinstance(item, Mapping) or sort_key not in item:
+        return Refusal("structural", path, "semantic_array_key_missing")
+    value = item[sort_key]
+    if not isinstance(value, str):
+        return Refusal("structural", path, "semantic_array_key_not_string")
+    return value
+
+
+def validate_semantic_array(
+    name: str,
+    items: Sequence[object],
+) -> None | Refusal:
+    """Require the registered key to be strictly increasing in UTF-8 bytes."""
+    if name not in SEMANTIC_ARRAY_SORT_KEYS:
+        return Refusal("structural", name, "unknown_semantic_array")
+
+    sort_key = SEMANTIC_ARRAY_SORT_KEYS[name]
+    previous: bytes | None = None
+    for index, item in enumerate(items):
+        key = _element_key(name, sort_key, item, index)
+        if isinstance(key, Refusal):
+            return key
+        try:
+            encoded = key.encode("utf-8", errors="strict")
+        except UnicodeEncodeError:
+            return Refusal(
+                "structural",
+                f"{name}[{index}]",
+                "semantic_array_key_invalid_unicode",
+            )
+        if previous is not None:
+            if encoded == previous:
+                return Refusal(
+                    "structural",
+                    f"{name}[{index}]",
+                    "semantic_array_duplicate_key",
+                )
+            if encoded < previous:
+                return Refusal(
+                    "structural",
+                    f"{name}[{index}]",
+                    "semantic_array_out_of_order",
+                )
+        previous = encoded
+    return None

--- a/src/axiom_encode/notary/manifest.py
+++ b/src/axiom_encode/notary/manifest.py
@@ -1,0 +1,308 @@
+"""Raw-Git tree manifests for schema-independent notary verification."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NamedTuple, Sequence
+
+from .canonical import body_digest
+from .refusal import Refusal
+
+type ManifestEntry = tuple[str, str, str]
+type Manifest = list[ManifestEntry]
+
+_DIRECTORY_MODE = b"40000"
+_GITLINK_MODE = b"160000"
+_SYMLINK_MODE = b"120000"
+_TERMINAL_MODES = {b"100644", b"100755"}
+
+
+class ManifestDiffEntry(NamedTuple):
+    """One per-path manifest addition, deletion, or modification."""
+
+    path: str
+    before_mode: str | None
+    before_entry_sha256: str | None
+    after_mode: str | None
+    after_entry_sha256: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _RawTreeEntry:
+    mode: bytes
+    path: bytes
+    oid: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingTerminal:
+    path: bytes
+    mode: bytes
+    oid: bytes
+
+
+def _git(
+    repo: Path,
+    *args: str,
+    input_bytes: bytes | None = None,
+) -> subprocess.CompletedProcess[bytes] | None:
+    try:
+        return subprocess.run(
+            ["git", "--no-replace-objects", "-C", str(repo), *args],
+            input=input_bytes,
+            check=False,
+            capture_output=True,
+        )
+    except OSError:
+        return None
+
+
+def _read_raw_object(repo: Path, oid: bytes) -> tuple[bytes, bytes] | None:
+    result = _git(
+        repo,
+        "cat-file",
+        "--batch",
+        input_bytes=oid.hex().encode("ascii") + b"\n",
+    )
+    if result is None or result.returncode != 0:
+        return None
+
+    header_end = result.stdout.find(b"\n")
+    if header_end < 0:
+        return None
+    header = result.stdout[:header_end].split()
+    if len(header) != 3 or header[0] != oid.hex().encode("ascii"):
+        return None
+    try:
+        size = int(header[2])
+    except ValueError:
+        return None
+    if size < 0:
+        return None
+
+    content_start = header_end + 1
+    content_end = content_start + size
+    if result.stdout[content_end:] != b"\n":
+        return None
+    return header[1], result.stdout[content_start:content_end]
+
+
+def _parse_tree(raw: bytes, oid_size: int) -> list[_RawTreeEntry] | None:
+    entries: list[_RawTreeEntry] = []
+    position = 0
+    while position < len(raw):
+        mode_end = raw.find(b" ", position)
+        if mode_end < 0:
+            return None
+        mode = raw[position:mode_end]
+        if not mode or not mode.isdigit():
+            return None
+
+        path_end = raw.find(b"\0", mode_end + 1)
+        if path_end < 0:
+            return None
+        path = raw[mode_end + 1 : path_end]
+        oid_start = path_end + 1
+        oid_end = oid_start + oid_size
+        if oid_end > len(raw):
+            return None
+        entries.append(_RawTreeEntry(mode, path, raw[oid_start:oid_end]))
+        position = oid_end
+    return entries
+
+
+def _decoded_path(path: bytes) -> str | None:
+    if not path:
+        return None
+    try:
+        return path.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return None
+
+
+def _least_path(paths: Sequence[bytes]) -> bytes:
+    return min(paths)
+
+
+def _structural(path: bytes, detail: str) -> Refusal:
+    return Refusal("structural", _decoded_path(path), detail)
+
+
+def build_tree_manifest(repo: Path, tree_ish: str) -> Manifest | Refusal:
+    """Build a terminal-entry manifest by parsing reachable raw Git trees."""
+    resolved = _git(
+        repo,
+        "rev-parse",
+        "--verify",
+        "--end-of-options",
+        f"{tree_ish}^{{tree}}",
+    )
+    if resolved is None:
+        return Refusal("structural", None, "git_unavailable")
+    if resolved.returncode != 0:
+        return Refusal("structural", None, "tree_unresolvable")
+    try:
+        root_oid = bytes.fromhex(resolved.stdout.strip().decode("ascii"))
+    except (UnicodeDecodeError, ValueError):
+        return Refusal("structural", None, "tree_unresolvable")
+    if len(root_oid) not in {20, 32}:
+        return Refusal("structural", None, "unsupported_object_format")
+
+    oid_size = len(root_oid)
+    tree_cache: dict[bytes, list[_RawTreeEntry] | None] = {}
+    pending_trees: list[tuple[bytes, bytes]] = [(root_oid, b"")]
+    terminals: list[_PendingTerminal] = []
+    terminal_counts: dict[bytes, int] = {}
+    gitlinks: list[bytes] = []
+    non_utf8_paths: list[bytes] = []
+    symlinks: list[bytes] = []
+    bad_modes: list[tuple[bytes, bytes]] = []
+    empty_subtrees: list[bytes] = []
+    unreadable_trees: list[bytes] = []
+
+    while pending_trees:
+        tree_oid, prefix = pending_trees.pop()
+        if tree_oid not in tree_cache:
+            tree_object = _read_raw_object(repo, tree_oid)
+            if tree_object is None or tree_object[0] != b"tree":
+                tree_cache[tree_oid] = None
+            else:
+                tree_cache[tree_oid] = _parse_tree(tree_object[1], oid_size)
+        entries = tree_cache[tree_oid]
+        if entries is None:
+            unreadable_trees.append(prefix)
+            continue
+        if not entries:
+            empty_subtrees.append(prefix)
+
+        for entry in entries:
+            path = entry.path if not prefix else prefix + b"/" + entry.path
+            try:
+                path.decode("utf-8", errors="strict")
+            except UnicodeDecodeError:
+                non_utf8_paths.append(path)
+
+            if entry.mode == _GITLINK_MODE:
+                gitlinks.append(path)
+                continue
+            if entry.mode == _DIRECTORY_MODE:
+                pending_trees.append((entry.oid, path))
+                continue
+
+            terminal_counts[path] = terminal_counts.get(path, 0) + 1
+            terminals.append(_PendingTerminal(path, entry.mode, entry.oid))
+            if entry.mode == _SYMLINK_MODE:
+                symlinks.append(path)
+            elif entry.mode not in _TERMINAL_MODES:
+                bad_modes.append((path, entry.mode))
+
+    duplicate_paths = [path for path, count in terminal_counts.items() if count > 1]
+    if gitlinks:
+        return _structural(_least_path(gitlinks), "gitlink")
+    if non_utf8_paths:
+        return _structural(_least_path(non_utf8_paths), "non_utf8_path")
+    if symlinks:
+        return _structural(_least_path(symlinks), "symlink")
+    if bad_modes:
+        path, mode = min(bad_modes, key=lambda item: item[0])
+        return _structural(path, f"inadmissible_mode={mode.decode('ascii')}")
+    if empty_subtrees:
+        return _structural(_least_path(empty_subtrees), "empty_subtree")
+    if duplicate_paths:
+        return _structural(
+            _least_path(duplicate_paths),
+            "duplicate_flattened_terminal_path",
+        )
+    if unreadable_trees:
+        return _structural(_least_path(unreadable_trees), "tree_object_unreadable")
+
+    blob_digests: dict[bytes, str] = {}
+    manifest: Manifest = []
+    for terminal in terminals:
+        if terminal.oid not in blob_digests:
+            blob = _read_raw_object(repo, terminal.oid)
+            if blob is None or blob[0] != b"blob":
+                return _structural(terminal.path, "blob_object_unreadable")
+            blob_digests[terminal.oid] = hashlib.sha256(blob[1]).hexdigest()
+        manifest.append(
+            (
+                terminal.path.decode("utf-8"),
+                terminal.mode.decode("ascii"),
+                blob_digests[terminal.oid],
+            )
+        )
+    manifest.sort(key=lambda entry: entry[0].encode("utf-8"))
+    return manifest
+
+
+def validate_manifest(manifest: Sequence[ManifestEntry]) -> None | Refusal:
+    """Validate bytewise path order and uniqueness for a manifest."""
+    previous: bytes | None = None
+    for index, entry in enumerate(manifest):
+        try:
+            path = entry[0]
+            encoded = path.encode("utf-8", errors="strict")
+        except (IndexError, AttributeError, UnicodeEncodeError):
+            return Refusal(
+                "structural",
+                f"manifest[{index}]",
+                "invalid_manifest_path",
+            )
+        if previous is not None:
+            if encoded == previous:
+                return Refusal(
+                    "structural",
+                    path,
+                    "duplicate_flattened_terminal_path",
+                )
+            if encoded < previous:
+                return Refusal("structural", path, "manifest_out_of_order")
+        previous = encoded
+    return None
+
+
+def manifest_sha256(manifest: Sequence[ManifestEntry]) -> str:
+    """Return the JCS SHA-256 of the manifest's normatively sorted array."""
+    entries = sorted(manifest, key=lambda entry: entry[0].encode("utf-8"))
+    return body_digest([[path, mode, digest] for path, mode, digest in entries])
+
+
+def manifest_diff(
+    base: Sequence[ManifestEntry],
+    subject: Sequence[ManifestEntry],
+) -> list[ManifestDiffEntry]:
+    """Return sorted per-path additions, deletions, and modifications."""
+    base_entries = {path: (mode, digest) for path, mode, digest in base}
+    subject_entries = {path: (mode, digest) for path, mode, digest in subject}
+    paths = sorted(
+        base_entries.keys() | subject_entries.keys(),
+        key=lambda path: path.encode("utf-8"),
+    )
+
+    changes: list[ManifestDiffEntry] = []
+    for path in paths:
+        before = base_entries.get(path)
+        after = subject_entries.get(path)
+        if before == after:
+            continue
+        changes.append(
+            ManifestDiffEntry(
+                path=path,
+                before_mode=None if before is None else before[0],
+                before_entry_sha256=None if before is None else before[1],
+                after_mode=None if after is None else after[0],
+                after_entry_sha256=None if after is None else after[1],
+            )
+        )
+    return changes
+
+
+def fsck_clean(repo: Path) -> bool | Refusal:
+    """Return whether ``git fsck --strict`` reports a clean object database."""
+    result = _git(repo, "fsck", "--strict")
+    if result is None:
+        return Refusal("structural", None, "git_unavailable")
+    return result.returncode == 0

--- a/src/axiom_encode/notary/refusal.py
+++ b/src/axiom_encode/notary/refusal.py
@@ -1,0 +1,14 @@
+"""Typed refusal values shared by notary verification primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Refusal:
+    """A deterministic refusal produced instead of a prose exception."""
+
+    code: str
+    path: str | None
+    detail: str

--- a/tests/notary/__init__.py
+++ b/tests/notary/__init__.py
@@ -1,0 +1,1 @@
+"""Focused tests for schema-independent notary primitives."""

--- a/tests/notary/conftest.py
+++ b/tests/notary/conftest.py
@@ -1,0 +1,170 @@
+"""Tiny Git repository builders, including deliberately malformed trees."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+type MktreeEntry = tuple[str, str, str, bytes]
+type RawTreeEntry = tuple[str, bytes, str]
+
+
+@dataclass(slots=True)
+class GitRepoBuilder:
+    """Build ordinary commits and raw pathological Git objects."""
+
+    path: Path
+
+    def git(
+        self,
+        *args: str,
+        input_bytes: bytes | None = None,
+        check: bool = True,
+    ) -> bytes:
+        result = subprocess.run(
+            ["git", "-C", str(self.path), *args],
+            input=input_bytes,
+            check=False,
+            capture_output=True,
+        )
+        if check and result.returncode != 0:
+            raise AssertionError(
+                f"git {' '.join(args)} failed: {result.stderr.decode(errors='replace')}"
+            )
+        return result.stdout
+
+    def rev_parse(self, revision: str) -> str:
+        return self.git("rev-parse", "--verify", revision).decode().strip()
+
+    def commit(
+        self,
+        changes: Mapping[str, bytes | None],
+        *,
+        message: str,
+        executable: Iterable[str] = (),
+    ) -> str:
+        executable_paths = set(executable)
+        for relative, contents in changes.items():
+            destination = self.path / relative
+            if contents is None:
+                if destination.exists():
+                    destination.unlink()
+                continue
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(contents)
+            destination.chmod(0o755 if relative in executable_paths else 0o644)
+
+        self.git("add", "-A")
+        for relative in executable_paths:
+            self.git("update-index", "--chmod=+x", "--", relative)
+        self.git("commit", "--quiet", "-m", message)
+        return self.rev_parse("HEAD")
+
+    def hash_blob(self, contents: bytes) -> str:
+        return (
+            self.git(
+                "hash-object",
+                "-w",
+                "--stdin",
+                input_bytes=contents,
+            )
+            .decode()
+            .strip()
+        )
+
+    def mktree(self, entries: Sequence[MktreeEntry]) -> str:
+        payload = b"".join(
+            f"{mode} {object_type} {oid}\t".encode() + path + b"\0"
+            for mode, object_type, oid, path in entries
+        )
+        return self.git("mktree", "-z", input_bytes=payload).decode().strip()
+
+    def raw_tree(self, entries: Sequence[RawTreeEntry]) -> str:
+        payload = b"".join(
+            mode.encode() + b" " + path + b"\0" + bytes.fromhex(oid)
+            for mode, path, oid in entries
+        )
+        return (
+            self.git(
+                "hash-object",
+                "-w",
+                "--literally",
+                "-t",
+                "tree",
+                "--stdin",
+                input_bytes=payload,
+            )
+            .decode()
+            .strip()
+        )
+
+    def gitlink_tree(self, target: str | None = None) -> str:
+        target = target or self.rev_parse("HEAD")
+        inner = self.mktree([("160000", "commit", target, b"dependency")])
+        return self.mktree([("040000", "tree", inner, b"nested")])
+
+    def non_utf8_tree(
+        self,
+        contents: bytes = b"invalid path contents\n",
+        *,
+        stable_contents: bytes = b"stable\n",
+    ) -> str:
+        invalid_blob = self.hash_blob(contents)
+        stable_blob = self.hash_blob(stable_contents)
+        return self.mktree(
+            [
+                ("100644", "blob", invalid_blob, b"bad-\xff"),
+                ("100644", "blob", stable_blob, b"stable.txt"),
+            ]
+        )
+
+    def symlink_tree(self) -> str:
+        target = self.hash_blob(b"target.txt")
+        inner = self.mktree([("120000", "blob", target, b"link")])
+        return self.mktree([("040000", "tree", inner, b"nested")])
+
+    def empty_subtree_tree(self) -> str:
+        empty_tree = self.mktree([])
+        regular_blob = self.hash_blob(b"visible\n")
+        return self.mktree(
+            [
+                ("040000", "tree", empty_tree, b"empty"),
+                ("100644", "blob", regular_blob, b"visible.txt"),
+            ]
+        )
+
+    def inadmissible_mode_tree(self) -> str:
+        blob = self.hash_blob(b"bad mode\n")
+        return self.raw_tree([("100600", b"mode.txt", blob)])
+
+    def duplicate_flattened_path_tree(self) -> str:
+        blob = self.hash_blob(b"duplicate\n")
+        subtree = self.mktree([("100644", "blob", blob, b"leaf")])
+        return self.raw_tree(
+            [
+                ("40000", b"dir", subtree),
+                ("100644", b"dir/leaf", blob),
+            ]
+        )
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> GitRepoBuilder:
+    repo = tmp_path / "repo"
+    subprocess.run(
+        ["git", "init", "--quiet", "--object-format=sha1", str(repo)],
+        check=True,
+        capture_output=True,
+    )
+    builder = GitRepoBuilder(repo)
+    builder.git("config", "user.name", "Notary Test")
+    builder.git("config", "user.email", "notary@example.test")
+    builder.git("config", "commit.gpgsign", "false")
+    builder.git("config", "core.autocrlf", "false")
+    builder.git("config", "core.filemode", "true")
+    builder.commit({"seed.txt": b"seed\n"}, message="seed")
+    return builder

--- a/tests/notary/test_canonical.py
+++ b/tests/notary/test_canonical.py
@@ -1,0 +1,100 @@
+"""Tests for strict JSON parsing and RFC 8785 serialization."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from axiom_encode.notary.canonical import (
+    body_digest,
+    is_canonical,
+    jcs_dumps,
+    sha256_hex,
+    strict_parse,
+)
+from axiom_encode.notary.refusal import Refusal
+
+RFC_SERIALIZATION = r"""{"literals":[null,true,false],"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],"string":"€$\u000f\nA'B\"\\\"/"}""".encode()
+RFC_PROPERTY_ORDER = (
+    '{"\\r":"Carriage Return","1":"One",'
+    '"\u0080":"Control","ö":"Latin Small Letter O With Diaeresis",'
+    '"€":"Euro Sign","😀":"Emoji: Grinning Face",'
+    '"דּ":"Hebrew Letter Dalet With Dagesh"}'
+).encode()
+
+
+def test_digest_helpers_use_jcs_bytes() -> None:
+    obj = {"z": 1, "a": [True, None]}
+    canonical = b'{"a":[true,null],"z":1}'
+
+    assert jcs_dumps(obj) == canonical
+    assert sha256_hex(canonical) == hashlib.sha256(canonical).hexdigest()
+    assert body_digest(obj) == hashlib.sha256(canonical).hexdigest()
+
+
+@pytest.mark.parametrize("data", [RFC_SERIALIZATION, RFC_PROPERTY_ORDER])
+def test_rfc_8785_vectors_are_canonical(data: bytes) -> None:
+    assert is_canonical(data)
+    assert jcs_dumps(strict_parse(data)) == data
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b'{"member":1,"member":2}',
+        b'{"member":1,"\\u006dember":2}',
+        b'{"outer":{"member":1,"member":2}}',
+    ],
+)
+def test_duplicate_json_member_is_refused(data: bytes) -> None:
+    assert strict_parse(data) == Refusal(
+        "structural",
+        None,
+        "duplicate_json_member",
+    )
+
+
+@pytest.mark.parametrize(
+    ("data", "detail"),
+    [
+        (b'"\xff"', "invalid_utf8"),
+        (rb'"\ud800"', "invalid_unicode"),
+        (rb'"\ude00"', "invalid_unicode"),
+        (rb'{"\ud800":"value"}', "invalid_unicode"),
+    ],
+)
+def test_invalid_unicode_is_refused(data: bytes, detail: str) -> None:
+    assert strict_parse(data) == Refusal("structural", None, detail)
+    assert not is_canonical(data)
+
+
+def test_valid_escaped_surrogate_pair_is_accepted() -> None:
+    assert strict_parse(rb'"\ud83d\ude00"') == "😀"
+
+
+@pytest.mark.parametrize("data", [b"1e999", b"[1e999]", b'{"value":1e999}'])
+def test_out_of_range_number_is_refused_at_every_depth(data: bytes) -> None:
+    assert strict_parse(data) == Refusal(
+        "structural",
+        None,
+        "number_out_of_range",
+    )
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b'{ "a":1}',
+        b'{"b":2,"a":1}',
+        b"1.0",
+        b'{"a":1}\n',
+    ],
+)
+def test_noncanonical_bytes_are_detected(data: bytes) -> None:
+    assert not is_canonical(data)
+
+
+def test_jcs_preserves_array_order() -> None:
+    assert jcs_dumps(["z", "a"]) == b'["z","a"]'
+    assert is_canonical(b'["z","a"]')

--- a/tests/notary/test_comparator.py
+++ b/tests/notary/test_comparator.py
@@ -1,0 +1,66 @@
+"""Tests for every registered semantic-array comparator."""
+
+from __future__ import annotations
+
+import pytest
+
+from axiom_encode.notary.comparator import (
+    SEMANTIC_ARRAY_SORT_KEYS,
+    validate_semantic_array,
+)
+from axiom_encode.notary.refusal import Refusal
+
+EXPECTED_REGISTRY = {
+    "gates": "gate_id",
+    "required_gates": "gate_id",
+    "acceptable_outcomes": None,
+    "reasons": None,
+    "eligible_records": None,
+    "unused_eligible_records": None,
+    "ineligible_records": "store_name",
+    "coverage_assignment": "path",
+    "delta": "path",
+    "actions": "ref_spec",
+    "containers": "image",
+    "inventories": "path",
+}
+
+
+def _items(name: str, keys: list[str]) -> list[object]:
+    sort_key = SEMANTIC_ARRAY_SORT_KEYS[name]
+    if sort_key is None:
+        return list(keys)
+    return [{sort_key: key, "non_key_payload": index} for index, key in enumerate(keys)]
+
+
+def test_semantic_array_registry_is_exact() -> None:
+    assert SEMANTIC_ARRAY_SORT_KEYS == EXPECTED_REGISTRY
+
+
+@pytest.mark.parametrize("name", EXPECTED_REGISTRY)
+def test_each_semantic_array_accepts_utf8_byte_order(name: str) -> None:
+    assert validate_semantic_array(name, _items(name, ["\ue000", "\U00010000"])) is None
+
+
+@pytest.mark.parametrize("name", EXPECTED_REGISTRY)
+def test_each_semantic_array_refuses_out_of_order_keys(name: str) -> None:
+    result = validate_semantic_array(name, _items(name, ["\U00010000", "\ue000"]))
+
+    assert isinstance(result, Refusal)
+    assert result.detail == "semantic_array_out_of_order"
+
+
+@pytest.mark.parametrize("name", EXPECTED_REGISTRY)
+def test_each_semantic_array_refuses_duplicate_keys(name: str) -> None:
+    result = validate_semantic_array(name, _items(name, ["same", "same"]))
+
+    assert isinstance(result, Refusal)
+    assert result.detail == "semantic_array_duplicate_key"
+
+
+def test_unknown_semantic_array_is_refused() -> None:
+    assert validate_semantic_array("unknown", []) == Refusal(
+        "structural",
+        "unknown",
+        "unknown_semantic_array",
+    )

--- a/tests/notary/test_manifest.py
+++ b/tests/notary/test_manifest.py
@@ -1,0 +1,309 @@
+"""Tests for raw-Git tree manifest construction and differencing."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from axiom_encode.notary.canonical import jcs_dumps, sha256_hex
+from axiom_encode.notary.manifest import (
+    ManifestDiffEntry,
+    build_tree_manifest,
+    fsck_clean,
+    manifest_diff,
+    manifest_sha256,
+    validate_manifest,
+)
+from axiom_encode.notary.refusal import Refusal
+
+
+def _digest(contents: bytes) -> str:
+    return hashlib.sha256(contents).hexdigest()
+
+
+def _assert_refusal(result: object, detail: str) -> Refusal:
+    assert isinstance(result, Refusal)
+    assert result.code == "structural"
+    assert result.detail == detail
+    return result
+
+
+def test_clean_repo_manifest_and_digest_are_stable(git_repo) -> None:
+    git_repo.commit({"added.txt": b"added\n"}, message="second clean commit")
+    first = build_tree_manifest(git_repo.path, "HEAD")
+    second = build_tree_manifest(git_repo.path, "HEAD")
+
+    assert (
+        first
+        == second
+        == [
+            ("added.txt", "100644", _digest(b"added\n")),
+            ("seed.txt", "100644", _digest(b"seed\n")),
+        ]
+    )
+    assert manifest_sha256(first) == manifest_sha256(second)
+    assert manifest_sha256(first) == sha256_hex(
+        jcs_dumps([list(entry) for entry in first])
+    )
+    assert fsck_clean(git_repo.path) is True
+
+
+def test_manifest_reads_referenced_bytes_without_replace_objects(git_repo) -> None:
+    original_oid = git_repo.rev_parse("HEAD:seed.txt")
+    replacement_oid = git_repo.hash_blob(b"replacement bytes\n")
+    git_repo.git("replace", original_oid, replacement_oid)
+
+    assert build_tree_manifest(git_repo.path, "HEAD") == [
+        ("seed.txt", "100644", _digest(b"seed\n"))
+    ]
+
+
+def test_manifest_refuses_tag_object_in_regular_file_entry(git_repo) -> None:
+    blob = git_repo.hash_blob(b"tag target\n")
+    git_repo.git("tag", "-a", "blob-tag", blob, "-m", "tag a blob")
+    tag = git_repo.rev_parse("refs/tags/blob-tag")
+    tree = git_repo.raw_tree([("100644", b"tagged", tag)])
+
+    _assert_refusal(
+        build_tree_manifest(git_repo.path, tree),
+        "blob_object_unreadable",
+    )
+
+
+def test_manifest_refuses_commit_object_in_directory_entry(git_repo) -> None:
+    commit = git_repo.rev_parse("HEAD")
+    tree = git_repo.raw_tree([("40000", b"not-a-tree", commit)])
+
+    _assert_refusal(
+        build_tree_manifest(git_repo.path, tree),
+        "tree_object_unreadable",
+    )
+
+
+def test_manifest_refuses_tag_object_in_directory_entry(git_repo) -> None:
+    actual_tree = git_repo.rev_parse("HEAD^{tree}")
+    git_repo.git("tag", "-a", "tree-tag", actual_tree, "-m", "tag a tree")
+    tag = git_repo.rev_parse("refs/tags/tree-tag")
+    tree = git_repo.raw_tree([("40000", b"tagged-tree", tag)])
+
+    _assert_refusal(
+        build_tree_manifest(git_repo.path, tree),
+        "tree_object_unreadable",
+    )
+
+
+@pytest.mark.parametrize(
+    ("factory", "detail"),
+    [
+        ("gitlink_tree", "gitlink"),
+        ("non_utf8_tree", "non_utf8_path"),
+        ("symlink_tree", "symlink"),
+        ("inadmissible_mode_tree", "inadmissible_mode=100600"),
+        ("empty_subtree_tree", "empty_subtree"),
+        ("duplicate_flattened_path_tree", "duplicate_flattened_terminal_path"),
+    ],
+)
+def test_pathological_tree_is_refused(git_repo, factory: str, detail: str) -> None:
+    tree = getattr(git_repo, factory)()
+
+    _assert_refusal(build_tree_manifest(git_repo.path, tree), detail)
+
+
+@pytest.mark.parametrize("changed", [False, True], ids=["unchanged", "changed"])
+def test_non_utf8_path_is_refused_whether_changed_or_unchanged(
+    git_repo,
+    changed: bool,
+) -> None:
+    base = git_repo.non_utf8_tree(b"base invalid bytes\n")
+    subject = git_repo.non_utf8_tree(
+        b"subject invalid bytes\n" if changed else b"base invalid bytes\n",
+        stable_contents=b"subject stable bytes\n",
+    )
+
+    _assert_refusal(build_tree_manifest(git_repo.path, base), "non_utf8_path")
+    _assert_refusal(build_tree_manifest(git_repo.path, subject), "non_utf8_path")
+
+
+def test_non_utf8_directory_name_is_refused(git_repo) -> None:
+    blob = git_repo.hash_blob(b"nested\n")
+    subtree = git_repo.mktree([("100644", "blob", blob, b"file.txt")])
+    tree = git_repo.mktree([("040000", "tree", subtree, b"bad-\xff")])
+
+    _assert_refusal(build_tree_manifest(git_repo.path, tree), "non_utf8_path")
+
+
+def test_root_empty_tree_is_refused(git_repo) -> None:
+    tree = git_repo.mktree([])
+
+    refusal = _assert_refusal(
+        build_tree_manifest(git_repo.path, tree),
+        "empty_subtree",
+    )
+    assert refusal.path is None
+
+
+def test_two_trees_differing_only_by_gitlink_are_both_refused(git_repo) -> None:
+    first_target = git_repo.rev_parse("HEAD")
+    second_target = git_repo.commit(
+        {"seed.txt": b"second commit\n"},
+        message="second gitlink target",
+    )
+    first_tree = git_repo.mktree([("160000", "commit", first_target, b"dependency")])
+    second_tree = git_repo.mktree([("160000", "commit", second_target, b"dependency")])
+
+    _assert_refusal(build_tree_manifest(git_repo.path, first_tree), "gitlink")
+    _assert_refusal(build_tree_manifest(git_repo.path, second_tree), "gitlink")
+
+
+def test_tree_wide_refusal_precedence_is_in_required_order(git_repo) -> None:
+    blob = git_repo.hash_blob(b"entry\n")
+    commit = git_repo.rev_parse("HEAD")
+    empty_tree = git_repo.mktree([])
+    cases = [
+        (
+            [("100644", b"bad-\xff", blob), ("160000", b"z", commit)],
+            "gitlink",
+        ),
+        (
+            [("120000", b"a", blob), ("100644", b"bad-\xff", blob)],
+            "non_utf8_path",
+        ),
+        (
+            [("100600", b"a", blob), ("120000", b"z", blob)],
+            "symlink",
+        ),
+        (
+            [("40000", b"a", empty_tree), ("100600", b"z", blob)],
+            "inadmissible_mode=100600",
+        ),
+        (
+            [
+                ("100644", b"a", blob),
+                ("100644", b"a", blob),
+                ("40000", b"z", empty_tree),
+            ],
+            "empty_subtree",
+        ),
+    ]
+
+    for entries, expected_detail in cases:
+        tree = git_repo.raw_tree(entries)
+        _assert_refusal(
+            build_tree_manifest(git_repo.path, tree),
+            expected_detail,
+        )
+
+
+def test_manifest_validation_refuses_sort_order_violation() -> None:
+    manifest = [
+        ("z", "100644", "0" * 64),
+        ("a", "100644", "1" * 64),
+    ]
+
+    assert validate_manifest(manifest) == Refusal(
+        "structural",
+        "a",
+        "manifest_out_of_order",
+    )
+
+
+def test_manifest_build_sorts_paths_by_utf8_bytes(git_repo) -> None:
+    blob = git_repo.hash_blob(b"same bytes\n")
+    first = "\ue000"
+    second = "\U00010000"
+    tree = git_repo.raw_tree(
+        [
+            ("100644", second.encode(), blob),
+            ("100644", first.encode(), blob),
+        ]
+    )
+
+    assert build_tree_manifest(git_repo.path, tree) == [
+        (first, "100644", _digest(b"same bytes\n")),
+        (second, "100644", _digest(b"same bytes\n")),
+    ]
+
+
+def test_manifest_diff_is_exact_for_all_change_kinds(git_repo) -> None:
+    base = git_repo.commit(
+        {
+            "delete.txt": b"delete me\n",
+            "mode.txt": b"same bytes\n",
+            "modify.txt": b"before\n",
+            "stay.txt": b"stay\n",
+        },
+        message="base",
+    )
+    subject = git_repo.commit(
+        {
+            "add.txt": b"added\n",
+            "delete.txt": None,
+            "mode.txt": b"same bytes\n",
+            "modify.txt": b"after\n",
+        },
+        message="subject",
+        executable={"mode.txt"},
+    )
+    base_manifest = build_tree_manifest(git_repo.path, base)
+    subject_manifest = build_tree_manifest(git_repo.path, subject)
+    assert not isinstance(base_manifest, Refusal)
+    assert not isinstance(subject_manifest, Refusal)
+
+    assert manifest_diff(base_manifest, subject_manifest) == [
+        ManifestDiffEntry(
+            "add.txt",
+            None,
+            None,
+            "100644",
+            _digest(b"added\n"),
+        ),
+        ManifestDiffEntry(
+            "delete.txt",
+            "100644",
+            _digest(b"delete me\n"),
+            None,
+            None,
+        ),
+        ManifestDiffEntry(
+            "mode.txt",
+            "100644",
+            _digest(b"same bytes\n"),
+            "100755",
+            _digest(b"same bytes\n"),
+        ),
+        ManifestDiffEntry(
+            "modify.txt",
+            "100644",
+            _digest(b"before\n"),
+            "100644",
+            _digest(b"after\n"),
+        ),
+    ]
+
+
+def test_manifest_diff_represents_rename_as_addition_and_deletion() -> None:
+    digest = "0" * 64
+
+    assert manifest_diff(
+        [("old.txt", "100644", digest)],
+        [("new.txt", "100644", digest)],
+    ) == [
+        ManifestDiffEntry("new.txt", None, None, "100644", digest),
+        ManifestDiffEntry("old.txt", "100644", digest, None, None),
+    ]
+
+
+def test_fsck_clean_reports_dirty_raw_tree(git_repo) -> None:
+    assert fsck_clean(git_repo.path) is True
+    git_repo.duplicate_flattened_path_tree()
+
+    assert fsck_clean(git_repo.path) is False
+
+
+def test_unresolvable_tree_is_typed_refusal(git_repo) -> None:
+    assert build_tree_manifest(git_repo.path, "does-not-exist") == Refusal(
+        "structural",
+        None,
+        "tree_unresolvable",
+    )

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1703"
+ENCODER_VERSION = "0.2.1704"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1703"
+ENCODER_VERSION = "0.2.1704"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1703"
+ENCODER_VERSION = "0.2.1704"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1703"
+ENCODER_VERSION = "0.2.1704"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1703"
+ENCODER_VERSION = "0.2.1704"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1703"
+ENCODER_VERSION = "0.2.1704"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1703"
+ENCODER_VERSION = "0.2.1704"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1703"')
+        .startswith('__version__ = "0.2.1704"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1703"
+    assert encoder_package["version"] == "0.2.1704"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1703"
+    assert project["project"]["version"] == "0.2.1704"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1703"')
+        .startswith('__version__ = "0.2.1704"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1703"
+    assert encoder_package["version"] == "0.2.1704"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1703"
+    assert project["project"]["version"] == "0.2.1704"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1703"')
+        .startswith('__version__ = "0.2.1704"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1703"
+ENCODER_VERSION = "0.2.1704"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1703"
+version = "0.2.1704"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -63,6 +63,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "receipt" },
     { name = "requests" },
+    { name = "rfc8785" },
     { name = "sqlite-utils" },
     { name = "supabase" },
 ]
@@ -115,6 +116,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "receipt", specifier = "==0.5.1" },
     { name = "requests", specifier = ">=2.28" },
+    { name = "rfc8785", specifier = ">=0.1.4" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sqlite-utils", specifier = ">=3.30" },
     { name = "supabase", specifier = ">=2.0.0" },
@@ -1461,6 +1463,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rfc8785"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da", size = 14321, upload-time = "2024-09-27T16:33:31.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48", size = 9240, upload-time = "2024-09-27T16:33:29.683Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The schema-frozen first code of the notary admission design (#1507, review-converged at v32) — the parts no §11 sign-off decision or schema adjustment can move:

- **`notary/canonical.py`** — RFC 8785 canonicalization (via the `rfc8785` package, not hand-rolled), strict I-JSON parsing (duplicate-member, invalid-Unicode, non-JSON-number refusals), digest helpers, and `is_canonical` reserialize-equality.
- **`notary/manifest.py`** — §2.1 tree manifests by raw tree-object parsing (exact modes, raw path bytes, sha1 and sha256 repos): terminal entries `[path, mode, entry_sha256]` with `entry_sha256` over raw blob bytes; the tree-wide totality refusals in listed order — gitlink, non-UTF-8 path, symlink, inadmissible mode, empty subtree, duplicate flattened path — each reporting the bytewise-least offending path (null when non-representable); manifest digest; set-difference diff including mode-only changes; `validate_manifest`; `fsck_clean` (`--strict`, which is also what catches a crafted file/directory name collision inside one tree — callers pair it with the builder, as the §10 harness does).
- **`notary/comparator.py`** — the universal semantic-array rule as an exact named registry (gates, records, assignment, delta, inventories…), bytewise-UTF-8 order with strict key uniqueness.
- **`notary/refusal.py`** — typed refusal values (`code`, `path`, `detail`), no prose exceptions.
- **`tests/notary/`** — 80 tests with hand-crafted pathological trees via `hash-object`/`mktree`: gitlinks, non-UTF-8 paths (changed and unchanged), tag/commit objects in file and directory entries, duplicate flattened paths, refusal-precedence order, `--no-replace-objects` protection, RFC 8785 vectors, JCS array-order preservation, per-registry-entry comparator cases, rename-as-add+delete.

Deliberately **excludes every schema-dependent surface** (artifact schemas, refusal-report variants, coverage predicate, key registry, chain/bundles) pending Max's #1507 sign-off with the §11 decisions.

Version 0.2.1696 (pins swept across the oracle-registry and validation tests).

**Cycle record:** built by a sol lane (gpt-5.6-sol, ultra) against the design doc with an internal review-fix cycle; independently re-verified before commit — `pytest tests/notary` (80 passed), `ruff check` clean, `compileall` clean, all five modules read line-by-line against §2.1.

Draft until #1507 signs off; CI green is still required before it leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
