### PR TITLE
Count only model-reaching re-encode failures

### DIFF
--- a/scripts/enforce_attempt_budget.py
+++ b/scripts/enforce_attempt_budget.py
@@ -52,6 +52,7 @@ RUNS_PER_PAGE = 100
 # guard itself blocked conclude "failure" with the encode job skipped and
 # must not feed back into the streak.
 ENCODE_JOB_NAME = "Queue protected signed RuleSpec re-encode"
+ENCODE_STEP_NAME = "Encode, review, validate, and apply"
 # At most this many per-run jobs lookups per evaluation; beyond the cap a
 # failure is counted without verification (conservative toward blocking).
 MAX_JOB_LOOKUPS = 10
@@ -145,12 +146,15 @@ def make_encode_job_checker(
     *,
     max_lookups: int = MAX_JOB_LOOKUPS,
     encode_job_name: str = ENCODE_JOB_NAME,
+    encode_step_name: str = ENCODE_STEP_NAME,
 ) -> Callable[[dict], bool]:
     """Build a ``spent_model_tokens`` classifier backed by the jobs API.
 
-    A run counts as model-spending only when its encode job exists with a
-    non-skipped conclusion. Past ``max_lookups`` (or on lookup errors)
-    the classification is conservative toward blocking in both
+    A run counts as model-spending only when its encode job contains the
+    actual encode step with a non-skipped conclusion. Looking only at the
+    enclosing job is insufficient: trusted-repair and other preflight steps
+    can fail that job before the model runs. Past ``max_lookups`` (or on
+    lookup errors) the classification is conservative toward blocking in both
     directions: unverified failures count against the budget and
     unverified successes stay neutral rather than resetting the streak.
     Bounded so a long history cannot stall the guard.
@@ -177,7 +181,13 @@ def make_encode_job_checker(
         ]
         if not encode_jobs:
             return False
-        return any(job.get("conclusion") != "skipped" for job in encode_jobs)
+        encode_steps = [
+            step
+            for job in encode_jobs
+            for step in (job.get("steps") or [])
+            if isinstance(step, dict) and step.get("name") == encode_step_name
+        ]
+        return any(step.get("conclusion") != "skipped" for step in encode_steps)
 
     return spent_model_tokens
 

--- a/tests/test_attempt_budget.py
+++ b/tests/test_attempt_budget.py
@@ -241,10 +241,7 @@ class TestEncodeJobChecker:
 
     def test_real_failures_still_count(self) -> None:
         fetch, _ = self._jobs_fixture(
-            {
-                run_id: [self._encode_job("failure")]
-                for run_id in (1, 2, 3)
-            }
+            {run_id: [self._encode_job("failure")] for run_id in (1, 2, 3)}
         )
         runs = [
             _run(1, "2026-08-12T01:00:00Z", "failure"),

--- a/tests/test_attempt_budget.py
+++ b/tests/test_attempt_budget.py
@@ -7,6 +7,7 @@ import pytest
 import scripts.enforce_attempt_budget as budget_mod
 from scripts.enforce_attempt_budget import (
     ENCODE_JOB_NAME,
+    ENCODE_STEP_NAME,
     evaluate_attempt_budget,
     make_encode_job_checker,
     run_citation,
@@ -180,8 +181,8 @@ class TestEncodeJobChecker:
         # encode job skipped. Only run 1 actually reached the model.
         fetch, _ = self._jobs_fixture(
             {
-                1: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
-                2: [{"name": ENCODE_JOB_NAME, "conclusion": "skipped"}],
+                1: [self._encode_job("failure")],
+                2: [self._encode_job("skipped")],
                 3: [{"name": "Enforce failed-attempt budget", "conclusion": "failure"}],
             }
         )
@@ -200,10 +201,48 @@ class TestEncodeJobChecker:
         assert decision.streak == 1
         assert not decision.exhausted
 
+    @staticmethod
+    def _encode_job(step_conclusion: str, *, job_conclusion: str = "failure") -> dict:
+        return {
+            "name": ENCODE_JOB_NAME,
+            "conclusion": job_conclusion,
+            "steps": [
+                {"name": ENCODE_STEP_NAME, "conclusion": step_conclusion},
+            ],
+        }
+
+    def test_preflight_failure_inside_encode_job_is_neutral(self) -> None:
+        fetch, _ = self._jobs_fixture(
+            {
+                1: [
+                    {
+                        "name": ENCODE_JOB_NAME,
+                        "conclusion": "failure",
+                        "steps": [
+                            {
+                                "name": "Resolve trusted prior-run repair candidate",
+                                "conclusion": "failure",
+                            },
+                            {"name": ENCODE_STEP_NAME, "conclusion": "skipped"},
+                        ],
+                    }
+                ]
+            }
+        )
+        decision = evaluate_attempt_budget(
+            [_run(1, "2026-08-12T01:00:00Z", "failure")],
+            citation=CITATION,
+            budget=1,
+            current_run_id=99,
+            spent_model_tokens=make_encode_job_checker(fetch),
+        )
+        assert decision.streak == 0
+        assert not decision.exhausted
+
     def test_real_failures_still_count(self) -> None:
         fetch, _ = self._jobs_fixture(
             {
-                run_id: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}]
+                run_id: [self._encode_job("failure")]
                 for run_id in (1, 2, 3)
             }
         )
@@ -225,7 +264,7 @@ class TestEncodeJobChecker:
     def test_lookup_cap_counts_conservatively(self) -> None:
         fetch, calls = self._jobs_fixture(
             {
-                run_id: [{"name": ENCODE_JOB_NAME, "conclusion": "skipped"}]
+                run_id: [self._encode_job("skipped", job_conclusion="skipped")]
                 for run_id in range(1, 6)
             }
         )
@@ -264,7 +303,7 @@ class TestEncodeJobChecker:
         # cap; an unverifiable phantom success below them must not reset
         # the streak fed by genuine failures further down.
         jobs_by_run: dict[int, list[dict]] = {
-            run_id: [{"name": ENCODE_JOB_NAME, "conclusion": "skipped"}]
+            run_id: [self._encode_job("skipped", job_conclusion="skipped")]
             for run_id in range(5, 15)
         }
         fetch, calls = self._jobs_fixture(jobs_by_run)
@@ -302,10 +341,10 @@ class TestEncodeJobChecker:
         # without any encode having succeeded. It must not lift the block.
         fetch, _ = self._jobs_fixture(
             {
-                1: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
-                2: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
-                3: [{"name": ENCODE_JOB_NAME, "conclusion": "skipped"}],
-                4: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
+                1: [self._encode_job("failure")],
+                2: [self._encode_job("failure")],
+                3: [self._encode_job("skipped", job_conclusion="skipped")],
+                4: [self._encode_job("failure")],
             }
         )
         runs = [
@@ -327,9 +366,9 @@ class TestEncodeJobChecker:
     def test_real_success_still_resets_streak(self) -> None:
         fetch, _ = self._jobs_fixture(
             {
-                1: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
-                2: [{"name": ENCODE_JOB_NAME, "conclusion": "success"}],
-                3: [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}],
+                1: [self._encode_job("failure")],
+                2: [self._encode_job("success", job_conclusion="success")],
+                3: [self._encode_job("failure")],
             }
         )
         runs = [
@@ -385,7 +424,7 @@ class TestMainExitContract:
             lambda **kwargs: (
                 jobs
                 if jobs is not None
-                else [{"name": ENCODE_JOB_NAME, "conclusion": "failure"}]
+                else [TestEncodeJobChecker._encode_job("failure")]
             ),
         )
 


### PR DESCRIPTION
## Summary
- classify attempt-budget history at the actual encode step, not only its enclosing protected job
- treat repair/preflight failures with a skipped encode step as neutral
- preserve conservative behavior when GitHub job history cannot be verified

## Why
A failed trusted-repair preflight currently marks the protected job failed even though `Encode, review, validate, and apply` is skipped. That incorrectly consumes a model-attempt slot and can make the guard block itself.

## Checks
- `python -m pytest tests/test_attempt_budget.py -q` (29 passed)
- `ruff check scripts/enforce_attempt_budget.py tests/test_attempt_budget.py`
- `python -m compileall -q scripts/enforce_attempt_budget.py`
- repository-wide ruff/compileall/pytest in progress

## Review-cycle override
The user explicitly directed this work to continue without waiting for Max review. No Max or Nikhil review is requested; merge remains gated on green CI and tests.