### PR TITLE
Pass review findings to source-bundle preflight

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1624,7 +1624,7 @@ jobs:
                [ -n "$REPLACE_RULESPEC_PATH" ] && \
                [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
               run_signed_encode \
-                "$CITATION" "" false target-preflight \
+                "$CITATION" "$REVIEW_FINDING" false target-preflight \
                 "$REPLACE_RULESPEC_PATH" "" false
               "$workflow_python" "$backfill_helper" \
                 reconcile-retired-manifest-inventory \

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2525,7 +2525,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '> "$RUNNER_TEMP/source-bundle-citations.txt"' in command
     assert 'source_lane="$(printf \'source-%02d\' "$source_index")"' in command
     assert '"$source_citation" "" true "$source_lane" "" "" false' in command
-    assert '"$CITATION" "" false target-preflight \\' in command
+    assert '"$CITATION" "$REVIEW_FINDING" false target-preflight \\' in command
     assert '"$REPLACE_RULESPEC_PATH" "" false' in command
     assert "source bundles require legacy replacements to merge first" in command
     assert "source-bundle replacements cannot include dependent migrations" in command
@@ -2545,7 +2545,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert 'commit -m "$message"' in command
     source_loop = "while IFS= read -r source_citation; do"
-    assert command.rindex(source_loop) < command.index('"$CITATION" "$REVIEW_FINDING"')
+    assert command.rindex(source_loop) < command.rindex('"$CITATION" "$REVIEW_FINDING"')
     assert "Compose signed source bundle for ${CITATION}" in command
     assert (
         "queue-authorized re-encodes cannot add source inputs until queue "
@@ -4629,7 +4629,10 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     preflight_args = encode_args[0]
     assert preflight_args[-1] == primary
     assert "--apply-target-only" not in preflight_args
-    assert "--review-findings" not in preflight_args
+    review_index = preflight_args.index("--review-findings")
+    assert Path(preflight_args[review_index + 1]).read_text(encoding="utf-8") == (
+        "Preserve the composed target semantics.\n"
+    )
     replacement_index = preflight_args.index("--replace-rulespec-path")
     assert preflight_args[replacement_index + 1] == replacement_path
     assert "--replace-legacy-rulespec-path" not in preflight_args


### PR DESCRIPTION
## Summary
- pass the supplied target review finding into replacement preflight generation for atomic source-bundle runs
- update workflow simulation assertions to verify the exact finding reaches preflight

## Checks
- `uv run --active pytest tests/test_signing_supervisor.py -q --no-cov --tb=short`: 99 passed, 58 skipped; 5 pre-existing macOS AppleDouble tar-member failures
- `uv run --active ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `git diff --check`

## Review-cycle override
Per Pavel Makarchuk’s explicit instruction for the SNAP immigration work, do not request or wait for Max or Nikhil; hosted CI is the merge gate.