### PR TITLE
Allow exact source-bundle repair replay

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -454,14 +454,15 @@ jobs:
              [ -n "$QUEUE_ID" ] || \
              ! jq -e 'type == "array" and length == 0' \
                <<< "$canonical_refresh_bundle_json" > /dev/null || \
-             ! jq -e 'type == "array" and length == 0' \
-               <<< "$source_bundle_json" > /dev/null || \
+             { jq -e 'length > 0' <<< "$source_bundle_json" > /dev/null && \
+               jq -e 'length > 0' <<< "$primary_required_test_cases_json" \
+                 > /dev/null; } || \
              ! jq -e 'type == "array" and length == 0' \
                <<< "${EXISTING_SIGNED_IMPORTS_JSON:-[]}" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
                <<< "${LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON:-[]}" \
                > /dev/null; then
-            echo "repair replay is limited to one non-legacy target without bundles, imports, dependents, or queue authorization" >&2
+            echo "repair replay is limited to one non-legacy target with at most one exact source or test bundle, without refreshes, imports, dependents, or queue authorization" >&2
             exit 1
           fi
 
@@ -532,6 +533,7 @@ jobs:
             --rules-engine-ref "$RULES_ENGINE_REF" \
             --rulespec-ref "$RULESPEC_REF" \
             --allow-rulespec-base-advance \
+            --atomic-source-json "$ATOMIC_SOURCE_JSON" \
             --replace-rulespec-path "$REPLACE_RULESPEC_PATH" \
             --workflow-run-id "$REPAIR_RUN_ID" \
             > "$RUNNER_TEMP/repair-candidate.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1696"
+version = "0.2.1697"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -163,7 +163,15 @@ def _expected_module_path(country: str, replace_rulespec_path: str) -> str:
     return PurePosixPath(*path.parts[1:]).as_posix()
 
 
-def _require_empty_atomic_source(metadata: dict[str, object]) -> None:
+def _repair_lane_for_atomic_source(
+    metadata: dict[str, object], expected_atomic_source: object
+) -> str:
+    try:
+        expected = SPLIT_ATOMIC_SOURCE_INPUT(expected_atomic_source)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("expected atomic source input is invalid") from exc
+    if expected["canonical_refresh_bundle"]:
+        raise ValueError("repair replay does not support canonical refresh bundles")
     has_atomic = "atomic_source_input" in metadata
     has_legacy_source = "source_bundle_input" in metadata
     has_legacy_refresh = "canonical_refresh_bundle_input" in metadata
@@ -181,16 +189,19 @@ def _require_empty_atomic_source(metadata: dict[str, object]) -> None:
                 "repair artifact is not a compatible single-target run: "
                 "atomic_source_input"
             ) from exc
-        if split != {
-            "canonical_refresh_bundle": [],
-            "primary_required_test_cases": [],
-            "source_bundle": [],
-        }:
+        if split != expected:
             raise ValueError(
-                "repair artifact is not a compatible single-target run: "
-                "atomic_source_input"
+                "repair artifact metadata mismatch: atomic_source_input"
             )
-        return
+        return "target-preflight" if expected["source_bundle"] else "target"
+    if expected != {
+        "canonical_refresh_bundle": [],
+        "primary_required_test_cases": [],
+        "source_bundle": [],
+    }:
+        raise ValueError(
+            "legacy repair metadata cannot bind a nonempty atomic source input"
+        )
     if not has_legacy_source or metadata["source_bundle_input"] != "[]":
         raise ValueError(
             "repair artifact is not a compatible single-target run: source_bundle_input"
@@ -200,6 +211,7 @@ def _require_empty_atomic_source(metadata: dict[str, object]) -> None:
             "repair artifact is not a compatible single-target run: "
             "canonical_refresh_bundle_input"
         )
+    return "target"
 
 
 def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
@@ -250,19 +262,24 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
                 raise ValueError(
                     f"repair artifact is not a compatible single-target run: {field}"
                 )
-        _require_empty_atomic_source(metadata)
+        repair_lane = _repair_lane_for_atomic_source(
+            metadata, args.atomic_source_json
+        )
         if metadata.get("workflow_run_attempt") != 1:
             raise ValueError("repair artifact must come from workflow attempt 1")
         if metadata.get("failed_steps") != ["encode_apply"]:
             raise ValueError(
                 "repair artifact is not an encode/apply validation failure"
             )
-        if metadata.get("generated_lanes") != ["target"]:
-            raise ValueError("repair artifact must contain only the target lane")
+        if metadata.get("generated_lanes") != [repair_lane]:
+            raise ValueError(
+                f"repair artifact must contain only the {repair_lane} lane"
+            )
 
         files = _metadata_file_map(metadata)
         repair_pattern = re.compile(
-            rf"target/({RUNNER_PATTERN.pattern})/{re.escape(expected_module[:-5])}\.repair\.json"
+            rf"{re.escape(repair_lane)}/({RUNNER_PATTERN.pattern})/"
+            rf"{re.escape(expected_module[:-5])}\.repair\.json"
         )
         repair_matches = [
             (path, repair_pattern.fullmatch(path))
@@ -287,7 +304,7 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
         ):
             raise ValueError("final repair manifest identity is invalid")
 
-        candidate_path = f"target/{runner}/{expected_module}"
+        candidate_path = f"{repair_lane}/{runner}/{expected_module}"
         test_path = candidate_path.removesuffix(".yaml") + ".test.yaml"
         candidate = _verified_generated_file(bundle, members, files, candidate_path)
         tests = _verified_generated_file(bundle, members, files, test_path)
@@ -329,6 +346,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--rules-engine-ref", required=True)
     parser.add_argument("--rulespec-ref", required=True)
     parser.add_argument("--allow-rulespec-base-advance", action="store_true")
+    parser.add_argument("--atomic-source-json", required=True)
     parser.add_argument("--replace-rulespec-path", required=True)
     parser.add_argument("--workflow-run-id", required=True)
     return parser

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1696"
+__version__ = "0.2.1697"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1696"
+ENCODER_VERSION = "0.2.1697"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -99,6 +99,7 @@ def _args(tmp_path: Path, archive: Path, **overrides) -> Namespace:
         "rules_engine_ref": "c" * 40,
         "rulespec_ref": "d" * 40,
         "allow_rulespec_base_advance": False,
+        "atomic_source_json": "[]",
         "replace_rulespec_path": "us/statutes/42/1437c-1.yaml",
         "workflow_run_id": "1234",
     }
@@ -174,6 +175,110 @@ def test_extracts_new_atomic_source_metadata(tmp_path, atomic_source_input):
     result = extract_candidate(_args(tmp_path, replacement))
 
     assert result["source_rulespec_ref"] == "d" * 40
+
+
+def _rewrite_as_source_preflight(
+    source_archive: Path,
+    destination: Path,
+    metadata: dict,
+    atomic_source_input: str,
+) -> Path:
+    metadata.pop("source_bundle_input")
+    metadata["atomic_source_input"] = atomic_source_input
+    metadata["generated_lanes"] = ["target-preflight"]
+    metadata["files"] = [
+        {**entry, "path": entry["path"].replace("target/", "target-preflight/", 1)}
+        for entry in metadata["files"]
+    ]
+    with (
+        tarfile.open(source_archive, "r") as source,
+        tarfile.open(destination, "w") as target,
+    ):
+        for member in source.getmembers():
+            extracted = source.extractfile(member)
+            assert extracted is not None
+            body = extracted.read()
+            if member.name == "metadata.json":
+                body = json.dumps(metadata).encode()
+            name = member.name.replace(
+                "generated/target/", "generated/target-preflight/", 1
+            )
+            info = tarfile.TarInfo(name)
+            info.size = len(body)
+            target.addfile(info, io.BytesIO(body))
+    return destination
+
+
+def test_extracts_exactly_bound_source_preflight_candidate(tmp_path):
+    atomic_source_input = json.dumps(
+        {
+            "schema": "axiom-encode/atomic-source-transaction/v2",
+            "source_bundle": ["us/statute/7/2015/f"],
+            "canonical_refresh_bundle": [],
+            "primary_required_test_cases": [],
+        }
+    )
+    archive, metadata = _archive(tmp_path)
+    replacement = _rewrite_as_source_preflight(
+        archive, tmp_path / "source-preflight.tar", metadata, atomic_source_input
+    )
+
+    result = extract_candidate(
+        _args(tmp_path, replacement, atomic_source_json=atomic_source_input)
+    )
+
+    assert result["runner"] == "openai-gpt-5.6-sol"
+
+
+def test_rejects_source_preflight_candidate_for_different_bundle(tmp_path):
+    atomic_source_input = json.dumps(
+        {
+            "schema": "axiom-encode/atomic-source-transaction/v2",
+            "source_bundle": ["us/statute/7/2015/f"],
+            "canonical_refresh_bundle": [],
+            "primary_required_test_cases": [],
+        }
+    )
+    archive, metadata = _archive(tmp_path)
+    replacement = _rewrite_as_source_preflight(
+        archive, tmp_path / "source-preflight.tar", metadata, atomic_source_input
+    )
+
+    with pytest.raises(ValueError, match="metadata mismatch: atomic_source_input"):
+        extract_candidate(
+            _args(
+                tmp_path,
+                replacement,
+                atomic_source_json=json.dumps(
+                    {
+                        "schema": "axiom-encode/atomic-source-transaction/v2",
+                        "source_bundle": ["us/guidance/different"],
+                        "canonical_refresh_bundle": [],
+                        "primary_required_test_cases": [],
+                    }
+                ),
+            )
+        )
+
+
+def test_rejects_source_preflight_lane_without_expected_source(tmp_path):
+    archive, metadata = _archive(tmp_path)
+    replacement = _rewrite_as_source_preflight(
+        archive,
+        tmp_path / "source-preflight.tar",
+        metadata,
+        json.dumps(
+            {
+                "schema": "axiom-encode/atomic-source-transaction/v2",
+                "source_bundle": [],
+                "canonical_refresh_bundle": [],
+                "primary_required_test_cases": [],
+            }
+        ),
+    )
+
+    with pytest.raises(ValueError, match="only the target lane"):
+        extract_candidate(_args(tmp_path, replacement))
 
 
 def test_rejects_metadata_identity_mismatch(tmp_path):
@@ -293,14 +398,27 @@ def test_rejects_incompatible_prior_run_mode(tmp_path, field, value):
 
 
 @pytest.mark.parametrize(
-    ("field", "value"),
+    ("field", "value", "message"),
     [
-        ("source_bundle_input", '["us/statute/42/source"]'),
-        ("canonical_refresh_bundle_input", '[{"citation":"x"}]'),
-        ("atomic_source_input", '["us/statute/42/source"]'),
+        (
+            "source_bundle_input",
+            '["us/statute/42/source"]',
+            "single-target run: source_bundle_input",
+        ),
+        (
+            "canonical_refresh_bundle_input",
+            '[{"citation":"x"}]',
+            "single-target run: canonical_refresh_bundle_input",
+        ),
+        (
+            "atomic_source_input",
+            '["us/statute/42/source"]',
+            "metadata mismatch: atomic_source_input",
+        ),
         (
             "atomic_source_input",
             '{"canonical_refresh_bundle":[{"citation":"x"}]}',
+            "metadata mismatch: atomic_source_input",
         ),
         (
             "atomic_source_input",
@@ -323,10 +441,13 @@ def test_rejects_incompatible_prior_run_mode(tmp_path, field, value):
                     ],
                 }
             ),
+            "metadata mismatch: atomic_source_input",
         ),
     ],
 )
-def test_rejects_nonempty_atomic_source_metadata(tmp_path, field, value):
+def test_rejects_unbound_nonempty_atomic_source_metadata(
+    tmp_path, field, value, message
+):
     archive, metadata = _archive(tmp_path)
     if field == "atomic_source_input":
         del metadata["source_bundle_input"]
@@ -337,8 +458,59 @@ def test_rejects_nonempty_atomic_source_metadata(tmp_path, field, value):
         metadata,
     )
 
-    with pytest.raises(ValueError, match=f"single-target run: {field}"):
+    with pytest.raises(ValueError, match=message):
         extract_candidate(_args(tmp_path, replacement))
+
+
+def test_rejects_expected_canonical_refresh_bundle(tmp_path):
+    archive, _ = _archive(tmp_path)
+
+    with pytest.raises(ValueError, match="does not support canonical refresh"):
+        extract_candidate(
+            _args(
+                tmp_path,
+                archive,
+                atomic_source_json=json.dumps(
+                    {
+                        "schema": "axiom-encode/atomic-source-transaction/v2",
+                        "source_bundle": [],
+                        "canonical_refresh_bundle": [{"citation": "x"}],
+                        "primary_required_test_cases": [],
+                    }
+                ),
+            )
+        )
+
+
+def test_rejects_expected_source_bundle_mixed_with_required_tests(tmp_path):
+    archive, _ = _archive(tmp_path)
+
+    with pytest.raises(ValueError, match="expected atomic source input is invalid"):
+        extract_candidate(
+            _args(
+                tmp_path,
+                archive,
+                atomic_source_json=json.dumps(
+                    {
+                        "schema": "axiom-encode/atomic-source-transaction/v2",
+                        "source_bundle": ["us/statute/7/2015/f"],
+                        "canonical_refresh_bundle": [],
+                        "primary_required_test_cases": [
+                            {
+                                "name": "control",
+                                "period": {
+                                    "period_kind": "tax_year",
+                                    "start": "2025-01-01",
+                                    "end": "2025-12-31",
+                                },
+                                "input": {"us:test#input": True},
+                                "required_output": {"us:test#output": 1},
+                            }
+                        ],
+                    }
+                ),
+            )
+        )
 
 
 def test_rejects_missing_legacy_and_atomic_source_metadata(tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1696"
+ENCODER_VERSION = "0.2.1697"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1696"
+ENCODER_VERSION = "0.2.1697"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1696"
+ENCODER_VERSION = "0.2.1697"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1696"
+ENCODER_VERSION = "0.2.1697"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1696"
+ENCODER_VERSION = "0.2.1697"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1696"
+ENCODER_VERSION = "0.2.1697"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1696"')
+        .startswith('__version__ = "0.2.1697"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1696"
+    assert encoder_package["version"] == "0.2.1697"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1696"
+    assert project["project"]["version"] == "0.2.1697"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1696"')
+        .startswith('__version__ = "0.2.1697"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1696"
+    assert encoder_package["version"] == "0.2.1697"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1696"
+    assert project["project"]["version"] == "0.2.1697"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1696"')
+        .startswith('__version__ = "0.2.1697"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1696"
+ENCODER_VERSION = "0.2.1697"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2337,6 +2337,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'test -n "$REPLACE_RULESPEC_PATH"' not in repair_command
     assert "targeted-reencode-failure-${REPAIR_RUN_ID}-1" in repair_command
     assert "extract_repair_candidate.py" in repair_command
+    assert '--atomic-source-json "$ATOMIC_SOURCE_JSON"' in repair_command
     for immutable_argument in (
         "--citation",
         "--country",
@@ -2888,6 +2889,17 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     ("atomic_source_json", "expected_tests_only"),
     [
         ("[]", "false"),
+        (
+            json.dumps(
+                {
+                    "schema": "axiom-encode/atomic-source-transaction/v2",
+                    "source_bundle": ["us/statute/7/2015/f"],
+                    "canonical_refresh_bundle": [],
+                    "primary_required_test_cases": [],
+                }
+            ),
+            "false",
+        ),
         (
             json.dumps(
                 {

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1696"
+version = "0.2.1697"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- allow repair replay to consume a checksum-bound `target-preflight` candidate when the current source bundle exactly matches the failed run metadata
- keep canonical refreshes, mixed source/test transactions, dependents, imports, legacy migrations, and queue modes excluded
- bind the workflow input into candidate extraction and preserve ordinary `target` repair behavior
- bump axiom-encode to 0.2.1697

## Validation

- `uv run --active ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- Full suite before commit: 13,418 passed, 126 skipped; sole failure was the expected uncommitted version-provenance check
- After commit: provenance plus focused repair/workflow suite: 63 passed
- Exact extraction against failed immigration run 32201076681 reproduced the bound RuleSpec/test hashes

## Review cycle

The user explicitly waived Max/Nikhil review for this continuation. Self-review found no actionable issues; focused and full local checks above are complete. Hosted CI must be green before merge.
