### PR TITLE
Route repair replays past attempt budget

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -151,6 +151,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CITATION: ${{ inputs.citation }}
           QUEUE_ID: ${{ inputs.queue_id }}
+          REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
           ATTEMPT_BUDGET: ${{ vars.ATTEMPT_BUDGET }}
           ATTEMPT_BUDGET_OVERRIDE: ${{ vars.ATTEMPT_BUDGET_OVERRIDE }}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1697"
+version = "0.2.1698"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/enforce_attempt_budget.py
+++ b/scripts/enforce_attempt_budget.py
@@ -14,6 +14,11 @@ attempt_budget job's own condition skips them so the guard can never
 stall a tranche. The ``queue_id`` report-only branch below survives as
 defense in depth for odd dispatch paths and local use.
 
+Repair replays are report-only here. Their prior-run identity and preserved
+candidate are authenticated by the protected resolver before any model call,
+so they must be able to reach that resolver even when fresh attempts are
+exhausted.
+
 The guard is a cost damper, not a security gate: if the GitHub API cannot
 be reached it fails open with a loud warning. Stdlib-only because it runs
 on a bare runner before any toolchain setup.
@@ -291,7 +296,8 @@ def _render_summary(
         )
     elif not enforced:
         lines.append(
-            "- Report-only: queue-driven dispatch, or override was set; not blocking."
+            "- Report-only: queue dispatch, authenticated repair path, or override; "
+            "not blocking."
         )
     return lines
 
@@ -302,6 +308,7 @@ def main() -> int:
     token = os.environ.get("GH_TOKEN", "")
     workflow_file = os.environ.get("WORKFLOW_FILE", "targeted-signed-reencode.yml")
     queue_id = os.environ.get("QUEUE_ID", "").strip()
+    repair_run_id = os.environ.get("REPAIR_RUN_ID", "").strip()
     override = os.environ.get("ATTEMPT_BUDGET_OVERRIDE", "").strip().lower()
     try:
         budget = int(os.environ.get("ATTEMPT_BUDGET", str(DEFAULT_BUDGET)))
@@ -349,7 +356,7 @@ def main() -> int:
             lambda run_id: _fetch_run_jobs(repo=repo, token=token, run_id=run_id)
         ),
     )
-    enforced = queue_id == "" and override != "true"
+    enforced = queue_id == "" and repair_run_id == "" and override != "true"
     blocked = enforced and decision.exhausted
     print(
         f"attempt-budget: citation={citation} streak={decision.streak} "
@@ -363,6 +370,11 @@ def main() -> int:
         )
     if override == "true":
         print("attempt-budget: override set by dispatcher; not blocking.")
+    if repair_run_id:
+        print(
+            "attempt-budget: repair replay is authenticated by the protected "
+            "resolver; not blocking."
+        )
     return 1 if blocked else 0
 
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1697"
+__version__ = "0.2.1698"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1697"
+ENCODER_VERSION = "0.2.1698"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_attempt_budget.py
+++ b/tests/test_attempt_budget.py
@@ -396,6 +396,7 @@ class TestMainExitContract:
         monkeypatch: pytest.MonkeyPatch,
         *,
         queue_id: str = "",
+        repair_run_id: str = "",
         override: str = "",
         budget: str = "",
     ) -> None:
@@ -404,6 +405,7 @@ class TestMainExitContract:
         monkeypatch.setenv("GH_TOKEN", "test-token")
         monkeypatch.setenv("GITHUB_RUN_ID", "99")
         monkeypatch.setenv("QUEUE_ID", queue_id)
+        monkeypatch.setenv("REPAIR_RUN_ID", repair_run_id)
         monkeypatch.setenv("ATTEMPT_BUDGET_OVERRIDE", override)
         monkeypatch.setenv("ATTEMPT_BUDGET", budget)
         monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
@@ -432,6 +434,11 @@ class TestMainExitContract:
 
     def test_queue_dispatch_reports_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._set_env(monkeypatch, queue_id="q-123")
+        self._stub_api(monkeypatch, self.FAILING_HISTORY)
+        assert budget_mod.main() == 0
+
+    def test_repair_replay_reports_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._set_env(monkeypatch, repair_run_id="32201076681")
         self._stub_api(monkeypatch, self.FAILING_HISTORY)
         assert budget_mod.main() == 0
 
@@ -465,6 +472,7 @@ class TestMainExitContract:
             "GITHUB_REPOSITORY",
             "GH_TOKEN",
             "QUEUE_ID",
+            "REPAIR_RUN_ID",
             "ATTEMPT_BUDGET",
             "ATTEMPT_BUDGET_OVERRIDE",
         ):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1697"
+ENCODER_VERSION = "0.2.1698"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1697"
+ENCODER_VERSION = "0.2.1698"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1697"
+ENCODER_VERSION = "0.2.1698"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1697"
+ENCODER_VERSION = "0.2.1698"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1697"
+ENCODER_VERSION = "0.2.1698"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1697"
+ENCODER_VERSION = "0.2.1698"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1697"')
+        .startswith('__version__ = "0.2.1698"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1697"
+    assert encoder_package["version"] == "0.2.1698"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1697"
+    assert project["project"]["version"] == "0.2.1698"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1697"')
+        .startswith('__version__ = "0.2.1698"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1697"
+    assert encoder_package["version"] == "0.2.1698"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1697"
+    assert project["project"]["version"] == "0.2.1698"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1697"')
+        .startswith('__version__ = "0.2.1698"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1697"
+ENCODER_VERSION = "0.2.1698"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2163,6 +2163,12 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "github.ref == 'refs/heads/main'" in job["if"]
     assert "github.actor == 'github-actions[bot]'" in job["if"]
     assert "github.run_attempt == 1" in job["if"]
+    attempt_step = next(
+        step
+        for step in workflow["jobs"]["attempt_budget"]["steps"]
+        if step.get("name") == "Enforce failed-attempt budget"
+    )
+    assert attempt_step["env"]["REPAIR_RUN_ID"] == "${{ inputs.repair_run_id }}"
     steps = job["steps"]
     country_step = next(
         step for step in steps if step.get("name") == "Validate country routing input"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1697"
+version = "0.2.1698"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- make repair replays report-only in the failed-attempt cost damper
- pass `repair_run_id` into the guard; the existing protected resolver still authenticates the failed run and checksum-bound candidate before any model call
- preserve normal ad hoc enforcement and queue behavior
- bump axiom-encode to 0.2.1698

## Validation

- `uv run --active ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- attempt-budget and workflow routing tests: 31 passed
- committed version-provenance plus focused routing tests: 32 passed
- preceding full suite on this exact main lineage: 13,418 passed, 126 skipped; only pre-commit version-provenance failed and passed after commit

## Review cycle

The user explicitly waived Max/Nikhil review for this continuation. Self-review found no actionable issues. Hosted CI must be green before merge.
