### PR TITLE
Repair missing test inputs among mixed findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1699"
+version = "0.2.1700"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1699"
+__version__ = "0.2.1700"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -48225,7 +48225,10 @@ def _try_repair_generated_test_input_assignments_for_apply(
             case_names=set(_indexed_parameter_key_zero_issue_cases(issues)),
         )
 
-    if not _only_pending_test_input_assignment_issues(issues):
+    missing_input_issues = [
+        issue for issue in issues if "Test input assignment missing:" in issue
+    ]
+    if not missing_input_issues:
         return []
 
     try:
@@ -48242,7 +48245,7 @@ def _try_repair_generated_test_input_assignments_for_apply(
         test_file=test_file,
         policy_repo_path=policy_repo_path,
         relative_output=relative_output,
-        issues=issues,
+        issues=missing_input_issues,
     )
 
 
@@ -57827,7 +57830,10 @@ def _complete_missing_local_test_inputs(
         error = getattr(validator_result, "error", None)
         if isinstance(error, str) and error:
             issues.append(error)
-    if not _only_pending_test_input_assignment_issues(issues):
+    missing_input_issues = [
+        issue for issue in issues if "Test input assignment missing:" in issue
+    ]
+    if not missing_input_issues:
         return False
     return bool(
         _fill_missing_test_input_assignments(
@@ -57835,7 +57841,7 @@ def _complete_missing_local_test_inputs(
             test_file=test_file,
             policy_repo_path=repo_path,
             relative_output=relative_output,
-            issues=issues,
+            issues=missing_input_issues,
         )
     )
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1699"
+ENCODER_VERSION = "0.2.1700"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29340,7 +29340,7 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
-    def test_encode_apply_auto_repairs_missing_test_input_assignments(
+    def test_encode_apply_auto_repairs_missing_inputs_among_mixed_issues(
         self, capsys, tmp_path
     ):
         args = self._make_args(tmp_path, backend="codex", sync=False)
@@ -29403,7 +29403,9 @@ rules:
                             "#input.tin_included_on_return. Every test for a "
                             "proof-required RuleSpec module must set all local "
                             "factual inputs, including false facts, so tests "
-                            "cannot pass through implicit defaults."
+                            "cannot pass through implicit defaults.",
+                            "statutes/26/151.yaml: ci: A distinct source "
+                            "condition is not encoded.",
                         ],
                         {},
                     ),
@@ -43565,7 +43567,7 @@ rules:
             is False
         )
 
-    def test_complete_missing_local_test_inputs_refuses_mixed_target_issues(
+    def test_complete_missing_local_test_inputs_repairs_assignment_among_mixed_issues(
         self, tmp_path
     ):
         policy_repo = tmp_path / "rulespec-us" / "us"
@@ -43573,8 +43575,7 @@ rules:
         target_test = target.with_name("4.test.yaml")
         target.parent.mkdir(parents=True)
         target.write_text("format: rulespec/v1\nrules: []\n")
-        original_tests = "- name: case_one\n  input: {}\n  output: {}\n"
-        target_test.write_text(original_tests)
+        target_test.write_text("- name: case_one\n  input: {}\n  output: {}\n")
         validation = SimpleNamespace(
             results={
                 "ci": SimpleNamespace(
@@ -43598,8 +43599,11 @@ rules:
             validation=validation,
         )
 
-        assert changed is False
-        assert target_test.read_text() == original_tests
+        assert changed is True
+        [test_case] = yaml.safe_load(target_test.read_text())
+        assert test_case["input"] == {
+            "us:regulations/7-cfr/273/4#input.member_is_refugee": False
+        }
 
     def test_rulespec_base_for_file_uses_country_content_root(self, tmp_path):
         policy_repo = _canonical_rulespec_content_root(tmp_path)

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1699"
+ENCODER_VERSION = "0.2.1700"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1699"
+ENCODER_VERSION = "0.2.1700"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1699"
+ENCODER_VERSION = "0.2.1700"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1699"
+ENCODER_VERSION = "0.2.1700"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1699"
+ENCODER_VERSION = "0.2.1700"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1699"
+ENCODER_VERSION = "0.2.1700"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1699"')
+        .startswith('__version__ = "0.2.1700"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1699"
+    assert encoder_package["version"] == "0.2.1700"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1699"
+    assert project["project"]["version"] == "0.2.1700"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1699"')
+        .startswith('__version__ = "0.2.1700"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1699"
+    assert encoder_package["version"] == "0.2.1700"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1699"
+    assert project["project"]["version"] == "0.2.1700"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1699"')
+        .startswith('__version__ = "0.2.1700"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1699"
+ENCODER_VERSION = "0.2.1700"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1699"
+version = "0.2.1700"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- repair validator-reported missing local test inputs even when unrelated findings are present
- keep unrelated findings intact for the immediate revalidation pass
- cover both overlay-level and full encode/apply behavior
- bump encoder to 0.2.1700

## Validation
- focused mixed-finding and overlay tests: 3 passed
- full tests/test_cli.py before commit: 1,296 passed, 10 skipped; sole failure was the expected uncommitted-version provenance check
- provenance check after commit: passed
- ruff: passed
- compileall: passed

## Review cycle
User explicitly requested continuation without Max or Nikhil review; no reviewer was requested. The change is constrained to validator-named test input assignments and always revalidates afterward.