### PR TITLE
Fix positive test repair with baseline failures

### DIFF
--- a/changelog.d/judgment-positive-baseline-failures.fixed.md
+++ b/changelog.d/judgment-positive-baseline-failures.fixed.md
@@ -1,0 +1,1 @@
+Allow deterministic positive Judgment companion-test repair to proceed when the generated test file already has unrelated failures, while still rejecting any failure introduced by the new test case.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1700"
+version = "0.2.1701"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1700"
+__version__ = "0.2.1701"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -45884,6 +45884,13 @@ def _append_generated_judgment_positive_tests_in_overlay(
         overlay_rules_file.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(rules_file, overlay_rules_file)
         overlay_test_file = _rulespec_test_path(overlay_rules_file)
+        shutil.copy2(test_file, overlay_test_file)
+        baseline_failures = _rulespec_companion_test_failures(
+            overlay_test_file,
+            root=overlay_content_root,
+            axiom_rules_path=axiom_rules_path,
+            rulespec_dependency_roots=staged_dependency_roots,
+        )
 
         def check_generated_test(
             generated_test_file: Path,
@@ -45896,11 +45903,14 @@ def _append_generated_judgment_positive_tests_in_overlay(
                     "Judgment test repair checker received an unexpected policy root"
                 )
             shutil.copy2(generated_test_file, overlay_test_file)
-            return _rulespec_companion_test_failures(
-                overlay_test_file,
-                root=overlay_content_root,
-                axiom_rules_path=axiom_rules_path,
-                rulespec_dependency_roots=staged_dependency_roots,
+            return _companion_test_failures_new_since_baseline(
+                baseline_failures=baseline_failures,
+                candidate_failures=_rulespec_companion_test_failures(
+                    overlay_test_file,
+                    root=overlay_content_root,
+                    axiom_rules_path=axiom_rules_path,
+                    rulespec_dependency_roots=staged_dependency_roots,
+                ),
             )
 
         return _append_generated_judgment_positive_tests_if_missing(
@@ -45912,6 +45922,25 @@ def _append_generated_judgment_positive_tests_in_overlay(
             issues=issues,
             test_failure_checker=check_generated_test,
         )
+
+
+def _companion_test_failures_new_since_baseline(
+    *,
+    baseline_failures: list[dict[str, str | None]],
+    candidate_failures: list[dict[str, str | None]],
+) -> list[dict[str, str | None]]:
+    """Return failures introduced by an appended companion test candidate."""
+    remaining_baseline = Counter(
+        json.dumps(failure, sort_keys=True) for failure in baseline_failures
+    )
+    introduced: list[dict[str, str | None]] = []
+    for failure in candidate_failures:
+        identity = json.dumps(failure, sort_keys=True)
+        if remaining_baseline[identity]:
+            remaining_baseline[identity] -= 1
+            continue
+        introduced.append(failure)
+    return introduced
 
 
 def _try_repair_generated_import_output_inputs_for_apply(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1700"
+ENCODER_VERSION = "0.2.1701"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ from axiom_encode.cli import (
     _changed_manifest_group_files,
     _closest_exact_source_excerpt,
     _collapse_additive_versioned_derived_formulas,
+    _companion_test_failures_new_since_baseline,
     _complete_missing_dependent_test_inputs,
     _complete_missing_imported_test_inputs,
     _complete_missing_local_test_inputs,
@@ -30631,8 +30632,10 @@ rules:
             )
             checked["test"] = staged_test_file.resolve()
             checked["root"] = root.resolve()
-            [case] = yaml.safe_load(staged_test_file.read_text())
-            assert case["output"] == {target: "holds"}
+            cases = yaml.safe_load(staged_test_file.read_text())
+            if cases:
+                [case] = cases
+                assert case["output"] == {target: "holds"}
             return []
 
         with patch(
@@ -30744,6 +30747,30 @@ rules:
 
         assert repaired == []
         stage.assert_not_called()
+
+    def test_judgment_positive_overlay_ignores_preexisting_companion_failures(self):
+        preexisting = {
+            "file": "/overlay/example.test.yaml",
+            "case": "preexisting_case",
+            "message": "missing input `existing_gate`",
+        }
+        introduced = {
+            "file": "/overlay/example.test.yaml",
+            "case": "auto_positive_target",
+            "message": "expected holds, got not_holds",
+        }
+
+        assert (
+            _companion_test_failures_new_since_baseline(
+                baseline_failures=[preexisting],
+                candidate_failures=[preexisting],
+            )
+            == []
+        )
+        assert _companion_test_failures_new_since_baseline(
+            baseline_failures=[preexisting],
+            candidate_failures=[preexisting, introduced],
+        ) == [introduced]
 
     def test_imported_output_repair_satisfies_positive_judgment_composition(
         self, tmp_path

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1700"
+ENCODER_VERSION = "0.2.1701"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1700"
+ENCODER_VERSION = "0.2.1701"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1700"
+ENCODER_VERSION = "0.2.1701"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1700"
+ENCODER_VERSION = "0.2.1701"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1700"
+ENCODER_VERSION = "0.2.1701"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1700"
+ENCODER_VERSION = "0.2.1701"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1700"')
+        .startswith('__version__ = "0.2.1701"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1700"
+    assert encoder_package["version"] == "0.2.1701"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1700"
+    assert project["project"]["version"] == "0.2.1701"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1700"')
+        .startswith('__version__ = "0.2.1701"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1700"
+    assert encoder_package["version"] == "0.2.1701"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1700"
+    assert project["project"]["version"] == "0.2.1701"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1700"')
+        .startswith('__version__ = "0.2.1701"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1700"
+ENCODER_VERSION = "0.2.1701"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1700"
+version = "0.2.1701"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- validate deterministic positive Judgment companion tests against the generated file's existing failure baseline
- reject any failure introduced by the appended candidate while allowing unrelated preexisting failures to proceed to later repair passes
- bump axiom-encode to 0.2.1701

## Validation
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused Judgment-positive and missing-local-input tests (16 passed)
- version and oracle registry tests
- exact immigration artifact replay against rulespec-us c557781 and axiom-rules-engine 48797e1
- full suite reached 719 passed / 10 skipped; the sole failure was the expected pre-commit version provenance guard, which passed after commit

## Review cycle
The user explicitly requested no Max or Nikhil review for this immigration unblock. Focused review-fix validation was performed locally; CI remains required before merge.