### PR TITLE
Fix parent chapeau source gate ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Axiom Encode will be documented here.
 
+- Bound proof-owned parent chapeaux at their first structural child so a colon-
+  terminated eligibility list does not make every alternative satisfy the
+  first child branch's factual gates.
+
 - Carry bounded, source-specific review findings through each canonical-refresh
   lane and bind their exact content in signed context evidence. Louisiana
   external-dependency validation now recognizes narrowly scoped executable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1701"
+version = "0.2.1702"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1701"
+__version__ = "0.2.1702"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -13124,7 +13124,24 @@ def _source_condition_clauses_owned_by_excerpt(
     for match, branch in selected:
         branch_path = branch.path if branch is not None else ()
         container_start = branch.start if branch is not None else 0
-        container_text = branch.text if branch is not None else source_text
+        container_end = branch.end if branch is not None else len(source_text)
+        if branch is not None:
+            # A parent chapeau commonly ends with a colon rather than sentence
+            # punctuation.  Keep its proposition local to the parent instead
+            # of absorbing the first structural child into the same condition.
+            # A proof excerpt located inside a child already resolves to that
+            # more-specific branch above, so this only bounds true chapeaux.
+            container_end = min(
+                (
+                    candidate.start
+                    for candidate in ownership_branches
+                    if len(candidate.path) == len(branch.path) + 1
+                    and candidate.path[: len(branch.path)] == branch.path
+                    and match.end() <= candidate.start < branch.end
+                ),
+                default=container_end,
+            )
+        container_text = source_text[container_start:container_end]
         local_start = match.start() - container_start
         local_end = match.end() - container_start
         proposition_start, proposition_end = _source_proposition_bounds(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1701"
+ENCODER_VERSION = "0.2.1702"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1701"
+ENCODER_VERSION = "0.2.1702"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1701"
+ENCODER_VERSION = "0.2.1702"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1701"
+ENCODER_VERSION = "0.2.1702"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1701"
+ENCODER_VERSION = "0.2.1702"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1701"
+ENCODER_VERSION = "0.2.1702"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1701"
+ENCODER_VERSION = "0.2.1702"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1701"')
+        .startswith('__version__ = "0.2.1702"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1701"
+    assert encoder_package["version"] == "0.2.1702"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1701"
+    assert project["project"]["version"] == "0.2.1702"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1701"')
+        .startswith('__version__ = "0.2.1702"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1701"
+    assert encoder_package["version"] == "0.2.1702"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1701"
+    assert project["project"]["version"] == "0.2.1702"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1701"')
+        .startswith('__version__ = "0.2.1702"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1701"
+ENCODER_VERSION = "0.2.1702"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -485,6 +485,58 @@ def test_flattened_inline_dotted_items_disambiguate_spouse_credit_proof():
     assert [clause.branch_path for clause in blindness_clauses] == [("3", "a", "7")]
 
 
+def test_parent_chapeau_proof_does_not_absorb_first_structural_child():
+    source = """(ii) A qualified alien is immediately eligible if the individual meets at least one criterion:
+(A) An adult lawful permanent resident has forty qualifying quarters based on the sum of quarters the alien worked and quarters credited from a parent.
+(B) An alien admitted as a refugee.
+"""
+    child_a_start = source.index("(A)")
+    child_b_start = source.index("(B)")
+    branches = (
+        completeness_module.SourceStructureBranch(
+            ("a", "6", "ii"), "number", "(ii)", source, 0, len(source)
+        ),
+        completeness_module.SourceStructureBranch(
+            ("a", "6", "ii", "a"),
+            "letter",
+            "(A)",
+            source[child_a_start:child_b_start],
+            child_a_start,
+            child_b_start,
+        ),
+        completeness_module.SourceStructureBranch(
+            ("a", "6", "ii", "b"),
+            "letter",
+            "(B)",
+            source[child_b_start:],
+            child_b_start,
+            len(source),
+        ),
+    )
+    excerpt = "meets at least one criterion"
+    rule = _ky_derived_rule(
+        "qualified_alien_immediately_eligible",
+        source="7 CFR 273.4(a)(6)(ii)",
+        dtype="Judgment",
+        formula="qualified_alien and (forty_quarters_path or refugee_status)",
+        excerpt=excerpt,
+    )
+
+    clauses, ambiguous = completeness_module._source_condition_clauses_owned_by_excerpt(
+        excerpt,
+        rule=rule,
+        source_text=source,
+        branches=branches,
+        corpus_citation_path="us/regulation/7/273/4",
+    )
+
+    assert not ambiguous
+    assert [clause.branch_path for clause in clauses] == [("a", "6", "ii")]
+    assert clauses[0].text.rstrip().endswith("criterion:")
+    assert "forty qualifying quarters" not in clauses[0].text
+    assert not completeness_module._source_conjunctive_fact_gates(clauses[0].text)
+
+
 def test_flattened_inline_dotted_items_keep_wrong_leaf_gate_fail_closed():
     payload = _ky_spouse_credit_payload(decomposed=True)
     age_rule = next(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1701"
+version = "0.2.1702"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- bound proof-owned parent chapeaux at the first direct structural child
- prevent colon-terminated alternative lists from treating the first child as a conjunctive parent gate
- add a SNAP immigration-shaped regression test and release 0.2.1702

## Validation
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `ruff format --check src/axiom_encode/harness/source_completeness.py tests/test_source_completeness.py`
- `python -m compileall -q src/axiom_encode scripts`
- `pytest -q tests/test_source_completeness.py` (5818 passed)
- exact failed 7 CFR 273.4 artifact reproduction no longer emits `source-explicit-conditions`

## Cycle
The defect and fix were reviewed against the exact failed production artifact and the full source-completeness suite. Per the user direction for this incident, no Max or Nikhil review was requested; merge remains gated on green CI.