### PR TITLE
Bound parenthetical source conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Axiom Encode will be documented here.
 
+- Keep parenthetical source conditions bounded to their closing parenthesis so
+  later descriptive conjunctions cannot be misclassified as additional legal
+  eligibility gates.
+
 - Bound proof-owned parent chapeaux at their first structural child so a colon-
   terminated eligibility list does not make every alternative satisfy the
   first child branch's factual gates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1702"
+version = "0.2.1703"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1702"
+__version__ = "0.2.1703"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -12762,6 +12762,27 @@ def _source_conjunctive_fact_gates(
     if conditional is None:
         return ()
     body = conditional.group("body")
+    # A parenthetical condition modifies only the text inside its parentheses.
+    # Do not let later sentence-level conjunctions (for example "earned and
+    # unearned income") masquerade as additional factual gates.
+    open_parentheses: list[int] = []
+    for index, character in enumerate(text[: conditional.start()]):
+        if character == "(":
+            open_parentheses.append(index)
+        elif character == ")" and open_parentheses:
+            open_parentheses.pop()
+    if open_parentheses:
+        depth = 1
+        body_start = conditional.start("body")
+        for index in range(body_start, len(text)):
+            character = text[index]
+            if character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+                if depth == 0:
+                    body = text[body_start:index]
+                    break
     segments = _source_gate_split_conjunctive_conditions(body)
     if len(segments) < 2:
         return ()

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6217,7 +6217,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1702"')
+        .startswith('__version__ = "0.2.1703"')
     )
 
 
@@ -6449,13 +6449,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1702"
+    assert encoder_package["version"] == "0.2.1703"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1702"
+    assert project["project"]["version"] == "0.2.1703"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1702"')
+        .startswith('__version__ = "0.2.1703"')
     )
 
 
@@ -6717,13 +6717,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1702"
+    assert encoder_package["version"] == "0.2.1703"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1702"
+    assert project["project"]["version"] == "0.2.1703"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1702"')
+        .startswith('__version__ = "0.2.1703"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1702"
+ENCODER_VERSION = "0.2.1703"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -537,6 +537,27 @@ def test_parent_chapeau_proof_does_not_absorb_first_structural_child():
     assert not completeness_module._source_conjunctive_fact_gates(clauses[0].text)
 
 
+def test_parenthetical_condition_does_not_absorb_later_conjunctions():
+    text = (
+        "The monthly income of the sponsor and sponsor's spouse (if he or she has "
+        "executed USCIS Form I-864 or I-864A) deemed as that of the eligible "
+        "sponsored alien must be the total monthly earned and unearned income, "
+        "with the exclusions of the sponsor and sponsor's spouse at the time the "
+        "household applies or is recertified for participation, reduced by:"
+    )
+
+    assert not completeness_module._source_conjunctive_fact_gates(text)
+
+
+def test_parenthetical_conjunctive_condition_retains_its_own_gates():
+    text = (
+        "The credit applies (if the spouse is eligible and the spouse has filed "
+        "the required form) and is included in the final calculation."
+    )
+
+    assert len(completeness_module._source_conjunctive_fact_gates(text)) == 2
+
+
 def test_flattened_inline_dotted_items_keep_wrong_leaf_gate_fail_closed():
     payload = _ky_spouse_credit_payload(decomposed=True)
     age_rule = next(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1702"
+version = "0.2.1703"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- bound source-condition parsing to the closing parenthesis when `if`, `when`, `unless`, or `provided that` appears inside a parenthetical
- prevent later descriptive conjunctions from becoming fake factual gates
- retain validation of genuine conjunctive gates inside the same parenthetical
- bump encoder to 0.2.1703

## Immigration replay evidence
The exact failed 7 CFR 273.4 artifact from run 32306408733 no longer emits `source-explicit-conditions` for `sponsored_alien_monthly_deemed_income`. The prior diagnostic incorrectly treated `earned and unearned income` and later sentence text as additional conditions of the parenthetical Form I-864 clause.

## Checks
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `ruff format --check src/axiom_encode/harness/source_completeness.py tests/test_source_completeness.py`
- `python -m compileall -q src/axiom_encode scripts`
- `pytest -q tests/test_source_completeness.py` (5820 passed)
- exact failed immigration artifact: no `source-explicit-conditions` issue

## Review cycle
The user explicitly overrode independent Max/Nikhil review for this immigration continuation. No review was requested from either adviser. CI must still be green before merge.