### PR TITLE
Bind the validator engine binary to the toolchain-pinned engine ref

### DIFF
--- a/changelog.d/engine-pin-binding.fixed.md
+++ b/changelog.d/engine-pin-binding.fixed.md
@@ -1,0 +1,19 @@
+Validator engine resolution now binds deterministically to the policy repo's
+toolchain-pinned `axiom_rules_engine_ref` when one is declared: candidate
+binaries must carry a binding receipt matching the pinned commit and the
+binary's exact bytes, or the engine checkout must sit clean at the pin, in
+which case the release profile is built on demand (`cargo build --release
+--locked`) and receipted — instead of silently preferring whatever stale
+`target/debug` build exists. Unpinned resolution now prefers release over
+debug and logs an `engine_binding_unverified` event. `validate` and `compile`
+accept `--axiom-rules-engine-ref` to override the toolchain pin, and the new
+`engine-bind` subcommand verifies (or builds) and receipts a binary directly.
+
+Deployment note: the strict corpus toolchain loader
+(`load_rulespec_toolchain`) and the reviewed CI toolchain steps still require
+the exact 3-key `[toolchain]` table, so declaring `axiom_rules_engine_ref` in
+a strict repo's `.axiom/toolchain.toml` breaks corpus-bound commands and the
+pinned "Resolve RuleSpec toolchain" CI step until that schema and the
+workflow pins are widened in a coordinated bump. Until then, exercise the pin
+through `--axiom-rules-engine-ref` on `validate`/`compile` or
+`engine-bind --pin`.

--- a/docs/encodebench.md
+++ b/docs/encodebench.md
@@ -49,7 +49,10 @@ Prerequisites (all local):
   `releases/uk-rulespec-2026-07-14` (`scripts/materialize_corpus_release.py`
   against the rulespec-uk toolchain pin).
 - `rulespec-uk` checkout on the commit whose toolchain pins that release.
-- `axiom-rules-engine` checkout with a debug build.
+- `axiom-rules-engine` checkout with a release build (`cargo build --release
+  --locked`) or an `axiom-encode engine-bind` receipt. When no engine pin is
+  declared, resolution prefers release over debug; a debug-only build still
+  binds, with an unverified-binding warning.
 - A trusted supervisor attaching the signing broker (release verification
   reads the corpus-release public key from the broker; nothing here signs).
 - Backend CLIs logged in: `codex` (ChatGPT subscription) and `claude`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1704"
+version = "0.2.1705"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1704"
+__version__ = "0.2.1705"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -139,6 +139,15 @@ from .corpus_resolver import (
     split_proof_evidence_text,
     validate_corpus_release_name,
 )
+from .engine_binding import (
+    ENGINE_PIN_FIELD,
+    EngineBindingError,
+    EnginePin,
+    engine_binding_receipt_path,
+    load_declared_engine_pin,
+    require_engine_ref_sha,
+    resolve_pinned_engine_binary,
+)
 from .harness.dependency_stubs import (
     UnsafeRulespecContextPath,
     validate_rulespec_context_file,
@@ -1600,6 +1609,15 @@ def main():
         help="Exact axiom-rules-engine checkout (no workspace discovery)",
     )
     validate_parser.add_argument(
+        "--axiom-rules-engine-ref",
+        dest="axiom_rules_engine_ref",
+        default=None,
+        help=(
+            "Full 40-hex axiom-rules-engine commit that overrides the "
+            "toolchain-declared engine pin"
+        ),
+    )
+    validate_parser.add_argument(
         "--oracle",
         choices=["policyengine"],
         help="Run external validation against oracles",
@@ -2624,7 +2642,53 @@ def main():
         required=True,
         help="Exact axiom-rules-engine checkout (no sibling discovery)",
     )
+    compile_parser.add_argument(
+        "--axiom-rules-engine-ref",
+        dest="axiom_rules_engine_ref",
+        default=None,
+        help=(
+            "Full 40-hex axiom-rules-engine commit that overrides the "
+            "toolchain-declared engine pin"
+        ),
+    )
     _add_rulespec_dependency_root_argument(compile_parser)
+
+    # engine-bind command
+    engine_bind_parser = subparsers.add_parser(
+        "engine-bind",
+        help=(
+            "Verify (and build on demand) an axiom-rules-engine binary "
+            "against a declared engine pin, writing a binding receipt"
+        ),
+    )
+    engine_bind_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        required=True,
+        help="Exact axiom-rules-engine checkout (no sibling discovery)",
+    )
+    engine_bind_pin_source = engine_bind_parser.add_mutually_exclusive_group(
+        required=True
+    )
+    engine_bind_pin_source.add_argument(
+        "--policy-repo",
+        type=Path,
+        help=(
+            "Policy repo whose .axiom/toolchain.toml declares the "
+            f"{ENGINE_PIN_FIELD} engine pin"
+        ),
+    )
+    engine_bind_pin_source.add_argument(
+        "--pin",
+        help="Full 40-hex axiom-rules-engine commit SHA to bind against",
+    )
+    engine_bind_parser.add_argument(
+        "--no-build",
+        action="store_true",
+        help="Fail instead of building when no receipted binary matches the pin",
+    )
 
     # encode command - run the current RuleSpec generation path
     encode_parser = subparsers.add_parser(
@@ -3422,6 +3486,8 @@ def main():
         cmd_proof_validate(args)
     elif args.command == "compile":
         cmd_compile(args)
+    elif args.command == "engine-bind":
+        cmd_engine_bind(args)
     elif args.command == "test":
         cmd_test(args)
     elif args.command == "log":
@@ -3592,6 +3658,7 @@ def _cmd_validate_with_resolution_cache(args):
                 require_complete_source_unit=(
                     getattr(args, "require_complete_source_unit", False) is True
                 ),
+                axiom_rules_engine_ref=getattr(args, "axiom_rules_engine_ref", None),
             )
             pipelines[roots] = pipeline
             policyengine_runtimes[roots] = policyengine_runtime
@@ -5766,6 +5833,7 @@ def cmd_compile(args):
             local_corpus_release=None,
             enable_oracles=False,
             rulespec_dependency_roots=_rulespec_dependency_roots_from_args(args),
+            axiom_rules_engine_ref=getattr(args, "axiom_rules_engine_ref", None),
         )
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -5820,6 +5888,50 @@ def cmd_compile(args):
             print(f"Compilation failed: {e}")
 
         sys.exit(1)
+
+
+def cmd_engine_bind(args):
+    """Bind an engine binary to a declared pin and write its binding receipt."""
+    try:
+        engine_root = _resolve_explicit_existing_directory(
+            args.axiom_rules_path,
+            label="Axiom rules engine",
+        )
+        if args.pin is not None:
+            pin = EnginePin(
+                sha=require_engine_ref_sha(args.pin, description="--pin"),
+                source=Path("<cli>"),
+            )
+        else:
+            policy_repo = _resolve_explicit_existing_directory(
+                args.policy_repo,
+                label="RuleSpec checkout",
+            )
+            pin = load_declared_engine_pin(policy_repo)
+            if pin is None:
+                raise EngineBindingError(
+                    f"No [toolchain].{ENGINE_PIN_FIELD} engine pin is declared "
+                    f"at or above: {policy_repo}"
+                )
+        binary = resolve_pinned_engine_binary(
+            engine_root,
+            pin,
+            allow_build=not args.no_build,
+        )
+    except (ValueError, OSError) as e:
+        print(f"Engine binding failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(
+        json.dumps(
+            {
+                "binary": str(binary),
+                "engine_commit": pin.sha,
+                "receipt": str(engine_binding_receipt_path(binary)),
+            },
+            indent=2,
+        )
+    )
+    sys.exit(0)
 
 
 def cmd_log(args):

--- a/src/axiom_encode/engine_binding.py
+++ b/src/axiom_encode/engine_binding.py
@@ -1,0 +1,428 @@
+"""Deterministic binding of the Axiom rules engine binary to a declared pin.
+
+Binding receipts are unsigned local attestations: they protect against
+accidental drift (stale builds, tampered bytes, wrong-commit checkouts), not
+against an adversary — forging a receipt requires the same filesystem access
+as replacing the binary itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+import tomllib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .corpus_resolver import UnsafeCorpusPathError, read_bounded_regular_file
+
+ENGINE_PIN_FIELD = "axiom_rules_engine_ref"
+RECEIPT_SUFFIX = ".provenance.json"
+ENGINE_BINARY_NAME = "axiom-rules-engine"
+# Release-profile build CI runs for the engine (targeted-signed-reencode.yml).
+ENGINE_RELEASE_BUILD_COMMAND = ("cargo", "build", "--release", "--locked")
+# Mirrors toolchain.MAX_RULESPEC_TOOLCHAIN_BYTES without importing its loader.
+MAX_ENGINE_PIN_TOOLCHAIN_BYTES = 64 * 1024
+MAX_ENGINE_BINDING_RECEIPT_BYTES = 64 * 1024
+_ENGINE_BUILD_TIMEOUT_SECONDS = 3600
+_GIT_QUERY_TIMEOUT_SECONDS = 60
+_ENGINE_REF_RE = re.compile(r"^[0-9a-f]{40}$")
+_RECEIPT_VERIFIED = "verified receipt"
+# Mirrors validator_pipeline._SENSITIVE_ENV_NAME_MARKERS; PATH and HOME
+# survive so git and cargo resolve normally.
+_SENSITIVE_ENV_NAME_MARKERS = (
+    "AUTH",
+    "CREDENTIAL",
+    "KEY",
+    "PASSWORD",
+    "SECRET",
+    "TOKEN",
+)
+
+
+class EngineBindingError(ValueError):
+    """The engine binary cannot be provably bound to the declared engine pin."""
+
+
+@dataclass(frozen=True, slots=True)
+class EnginePin:
+    """One declared engine commit and the source that declared it."""
+
+    sha: str
+    source: Path
+
+
+def require_engine_ref_sha(value: object, *, description: str) -> str:
+    """Validate one caller-supplied engine ref as a full lowercase commit SHA."""
+
+    if not isinstance(value, str) or _ENGINE_REF_RE.fullmatch(value) is None:
+        raise EngineBindingError(
+            f"{description} must be a full lowercase 40-hex commit SHA: {value!r}"
+        )
+    return value
+
+
+def _declared_toolchain_file(policy_repo_path: Path) -> Path | None:
+    """Locate one ancestor .axiom/toolchain.toml, bounded at the first git root."""
+
+    raw = Path(os.path.abspath(Path(policy_repo_path).expanduser()))
+    if raw.is_symlink():
+        raise EngineBindingError(f"Policy repo path must not be a symlink: {raw}")
+    try:
+        root = raw.resolve(strict=True)
+    except OSError as exc:
+        raise EngineBindingError(
+            f"Policy repo path does not exist: {raw}; a missing path cannot "
+            f"prove that no {ENGINE_PIN_FIELD} pin is declared"
+        ) from exc
+    search_root = root.parent if root.is_file() else root
+    if not search_root.is_dir():
+        return None
+    search_chain = (search_root, *search_root.parents)
+    repository_root: Path | None = None
+    repository_root_index: int | None = None
+    for index, candidate in enumerate(search_chain):
+        git_marker = candidate / ".git"
+        if git_marker.is_symlink():
+            raise EngineBindingError(
+                f"Policy repo .git marker must not be a symlink: {git_marker}"
+            )
+        if git_marker.exists():
+            repository_root = candidate
+            repository_root_index = index
+            break
+    scoped_chain = (
+        search_chain
+        if repository_root_index is None
+        else search_chain[: repository_root_index + 1]
+    )
+    configured_roots = [
+        candidate
+        for candidate in scoped_chain
+        if (candidate / ".axiom" / "toolchain.toml").exists()
+        or (candidate / ".axiom" / "toolchain.toml").is_symlink()
+    ]
+    if not configured_roots:
+        return None
+    if repository_root is not None and configured_roots != [repository_root]:
+        raise EngineBindingError(
+            "Policy repo must declare exactly one .axiom/toolchain.toml at its "
+            f"repository root {repository_root}; found configuration under: "
+            + ", ".join(str(path) for path in configured_roots)
+        )
+    if len(configured_roots) > 1:
+        raise EngineBindingError(
+            "Policy repo path has multiple ancestor .axiom/toolchain.toml files: "
+            + ", ".join(str(path) for path in configured_roots)
+        )
+    config_path = configured_roots[0] / ".axiom" / "toolchain.toml"
+    if config_path.is_symlink():
+        raise EngineBindingError(
+            f"RuleSpec toolchain file must not be a symlink: {config_path}"
+        )
+    return config_path
+
+
+def load_declared_engine_pin(policy_repo_path: Path) -> EnginePin | None:
+    """Return the policy repo's declared engine pin, or None when undeclared.
+
+    Tolerates the legacy multi-key [toolchain] format: only the
+    axiom_rules_engine_ref field is read here, so strict 3-key repos parse
+    and yield None instead of erroring like the strict toolchain loader.
+    The reverse does not hold: the strict loader still rejects a table that
+    declares this field, so strict repos cannot declare the pin until that
+    schema is widened; the --axiom-rules-engine-ref override pins them
+    meanwhile.
+    """
+
+    config_path = _declared_toolchain_file(policy_repo_path)
+    if config_path is None:
+        return None
+    configured_root = config_path.parent.parent
+    try:
+        raw = read_bounded_regular_file(
+            configured_root,
+            config_path,
+            label="RuleSpec toolchain file",
+            max_bytes=MAX_ENGINE_PIN_TOOLCHAIN_BYTES,
+        )
+        payload = tomllib.loads(raw.decode("utf-8"))
+    except UnsafeCorpusPathError as exc:
+        raise EngineBindingError(str(exc)) from exc
+    except (UnicodeError, tomllib.TOMLDecodeError) as exc:
+        raise EngineBindingError(
+            f"RuleSpec toolchain is not valid UTF-8 TOML: {config_path}"
+        ) from exc
+    toolchain = payload.get("toolchain")
+    if toolchain is None:
+        return None
+    if not isinstance(toolchain, dict):
+        raise EngineBindingError(f"[toolchain] must be a TOML table: {config_path}")
+    if ENGINE_PIN_FIELD not in toolchain:
+        return None
+    declared = toolchain[ENGINE_PIN_FIELD]
+    if not isinstance(declared, str) or _ENGINE_REF_RE.fullmatch(declared) is None:
+        raise EngineBindingError(
+            f"[toolchain].{ENGINE_PIN_FIELD} must be a full lowercase 40-hex "
+            f"commit SHA in {config_path}: {declared!r}"
+        )
+    return EnginePin(sha=declared, source=config_path)
+
+
+def engine_binding_receipt_path(binary: Path) -> Path:
+    """Return the binding receipt path recorded beside one engine binary."""
+
+    binary = Path(binary)
+    return binary.with_name(binary.name + RECEIPT_SUFFIX)
+
+
+def read_engine_binding_receipt(binary: Path) -> dict[str, Any] | None:
+    """Return the parsed binding receipt beside a binary, or None if unusable."""
+
+    receipt_path = engine_binding_receipt_path(binary)
+    try:
+        if receipt_path.is_symlink() or not receipt_path.is_file():
+            return None
+        if receipt_path.stat().st_size > MAX_ENGINE_BINDING_RECEIPT_BYTES:
+            return None
+        raw = receipt_path.read_bytes()
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def write_engine_binding_receipt(
+    binary: Path,
+    engine_commit: str,
+    cargo_profile: str,
+) -> Path:
+    """Atomically record which engine commit produced one binary's exact bytes."""
+
+    from axiom_encode import __version__
+
+    binary = Path(binary)
+    receipt_path = engine_binding_receipt_path(binary)
+    sha = require_engine_ref_sha(engine_commit, description="engine_commit")
+    try:
+        payload = {
+            "engine_commit": sha,
+            "binary_sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+            "cargo_profile": str(cargo_profile),
+            "built_at": datetime.now(timezone.utc).isoformat(),
+            "written_by": f"axiom-encode {__version__}",
+        }
+        descriptor, staged_name = tempfile.mkstemp(
+            dir=str(receipt_path.parent),
+            prefix=receipt_path.name + ".",
+        )
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as staged:
+                json.dump(payload, staged, indent=2, sort_keys=True)
+                staged.write("\n")
+            os.replace(staged_name, receipt_path)
+        finally:
+            if os.path.exists(staged_name):
+                os.unlink(staged_name)
+    except OSError as exc:
+        raise EngineBindingError(
+            f"Failed to write the engine binding receipt {receipt_path}: {exc}"
+        ) from exc
+    return receipt_path
+
+
+def _engine_binary_candidates(engine_checkout: Path) -> tuple[Path, ...]:
+    return (
+        engine_checkout / "target" / "release" / ENGINE_BINARY_NAME,
+        engine_checkout / "target" / "debug" / ENGINE_BINARY_NAME,
+        engine_checkout / ENGINE_BINARY_NAME,
+    )
+
+
+def _receipt_status(binary: Path, pin: EnginePin) -> str:
+    receipt = read_engine_binding_receipt(binary)
+    if receipt is None:
+        return "no receipt"
+    commit = receipt.get("engine_commit")
+    digest = receipt.get("binary_sha256")
+    if not isinstance(commit, str) or not isinstance(digest, str):
+        return "malformed receipt"
+    if commit != pin.sha:
+        return f"receipt commit {commit} does not match the pin"
+    try:
+        actual = hashlib.sha256(binary.read_bytes()).hexdigest()
+    except OSError:
+        return "unreadable binary"
+    if actual != digest:
+        return "binary bytes do not match the receipt binary_sha256"
+    return _RECEIPT_VERIFIED
+
+
+def _describe_candidates(statuses: Sequence[tuple[Path, str]]) -> str:
+    if not statuses:
+        return "none"
+    return ", ".join(f"{path} ({status})" for path, status in statuses)
+
+
+def _binding_context(
+    pin: EnginePin,
+    engine_checkout: Path,
+    *,
+    head: str | None,
+    statuses: Sequence[tuple[Path, str]],
+) -> str:
+    remediation = (
+        f"run `{' '.join(ENGINE_RELEASE_BUILD_COMMAND)}` in {engine_checkout}, "
+        f"or `axiom-encode engine-bind --axiom-rules-engine-path "
+        f"{engine_checkout} --pin {pin.sha}`"
+    )
+    return (
+        f"; pin {pin.sha} declared by {pin.source}; "
+        f"engine checkout {engine_checkout} (HEAD {head or 'unknown'}); "
+        f"existing candidate binaries: {_describe_candidates(statuses)}; "
+        f"remediation: {remediation}"
+    )
+
+
+def _binding_subprocess_env() -> dict[str, str]:
+    """Copy the ambient environment without credential-named variables."""
+
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if not any(marker in name.upper() for marker in _SENSITIVE_ENV_NAME_MARKERS)
+    }
+
+
+def _git_output(
+    engine_checkout: Path,
+    *args: str,
+    pin: EnginePin,
+    statuses: Sequence[tuple[Path, str]],
+) -> str:
+    rendered = "git " + " ".join(args)
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(engine_checkout), *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_QUERY_TIMEOUT_SECONDS,
+            env=_binding_subprocess_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise EngineBindingError(
+            f"{rendered} failed in the engine checkout: {exc}"
+            + _binding_context(pin, engine_checkout, head=None, statuses=statuses)
+        ) from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise EngineBindingError(
+            f"{rendered} failed in the engine checkout: {detail}"
+            + _binding_context(pin, engine_checkout, head=None, statuses=statuses)
+        )
+    return result.stdout.strip()
+
+
+def _build_pinned_release_binary(
+    engine_checkout: Path,
+    pin: EnginePin,
+    *,
+    head: str,
+    statuses: Sequence[tuple[Path, str]],
+) -> Path:
+    rendered = " ".join(ENGINE_RELEASE_BUILD_COMMAND)
+    try:
+        result = subprocess.run(
+            list(ENGINE_RELEASE_BUILD_COMMAND),
+            capture_output=True,
+            text=True,
+            timeout=_ENGINE_BUILD_TIMEOUT_SECONDS,
+            cwd=str(engine_checkout),
+            env=_binding_subprocess_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise EngineBindingError(
+            f"`{rendered}` failed for the pinned engine: {exc}"
+            + _binding_context(pin, engine_checkout, head=head, statuses=statuses)
+        ) from exc
+    if result.returncode != 0:
+        detail = (result.stderr.strip() or result.stdout.strip())[-2000:]
+        raise EngineBindingError(
+            f"`{rendered}` failed for the pinned engine: {detail}"
+            + _binding_context(pin, engine_checkout, head=head, statuses=statuses)
+        )
+    release_binary = engine_checkout / "target" / "release" / ENGINE_BINARY_NAME
+    if not release_binary.exists():
+        raise EngineBindingError(
+            f"`{rendered}` succeeded but produced no {release_binary}"
+            + _binding_context(pin, engine_checkout, head=head, statuses=statuses)
+        )
+    write_engine_binding_receipt(release_binary, pin.sha, "release")
+    return release_binary
+
+
+def resolve_pinned_engine_binary(
+    engine_checkout: Path,
+    pin: EnginePin,
+    *,
+    allow_build: bool = True,
+) -> Path:
+    """Return a binary provably built from the pinned engine commit.
+
+    Receipted candidates bind first (release, debug, bare order); otherwise a
+    clean git checkout at the pin may build the release profile on demand and
+    receipt the result. Everything else fails closed.
+    """
+
+    engine_checkout = Path(engine_checkout)
+    statuses: list[tuple[Path, str]] = []
+    for candidate in _engine_binary_candidates(engine_checkout):
+        if not candidate.exists():
+            continue
+        status = _receipt_status(candidate, pin)
+        if status == _RECEIPT_VERIFIED:
+            return candidate
+        statuses.append((candidate, status))
+    if not (engine_checkout / ".git").exists():
+        raise EngineBindingError(
+            "Engine checkout is not a git repository and no candidate binary "
+            "carries a verified receipt for the pinned commit; use a git "
+            "checkout at the pin, or write a receipt with "
+            "'axiom-encode engine-bind'"
+            + _binding_context(pin, engine_checkout, head=None, statuses=statuses)
+        )
+    head = _git_output(engine_checkout, "rev-parse", "HEAD", pin=pin, statuses=statuses)
+    if head != pin.sha:
+        raise EngineBindingError(
+            f"Engine checkout HEAD {head} does not match the pinned commit "
+            f"{pin.sha}"
+            + _binding_context(pin, engine_checkout, head=head, statuses=statuses)
+        )
+    porcelain = _git_output(
+        engine_checkout, "status", "--porcelain", pin=pin, statuses=statuses
+    )
+    if porcelain:
+        raise EngineBindingError(
+            "Engine checkout is dirty at the pinned commit; binary provenance "
+            "is unprovable"
+            + _binding_context(pin, engine_checkout, head=head, statuses=statuses)
+        )
+    if not allow_build:
+        raise EngineBindingError(
+            "No candidate binary carries a verified receipt for the pinned "
+            "commit and building is disabled"
+            + _binding_context(pin, engine_checkout, head=head, statuses=statuses)
+        )
+    return _build_pinned_release_binary(
+        engine_checkout, pin, head=head, statuses=statuses
+    )

--- a/src/axiom_encode/engine_binding.py
+++ b/src/axiom_encode/engine_binding.py
@@ -188,12 +188,13 @@ def read_engine_binding_receipt(binary: Path) -> dict[str, Any] | None:
 
     receipt_path = engine_binding_receipt_path(binary)
     try:
-        if receipt_path.is_symlink() or not receipt_path.is_file():
-            return None
-        if receipt_path.stat().st_size > MAX_ENGINE_BINDING_RECEIPT_BYTES:
-            return None
-        raw = receipt_path.read_bytes()
-    except OSError:
+        raw = read_bounded_regular_file(
+            receipt_path.parent,
+            receipt_path,
+            label="engine binding receipt",
+            max_bytes=MAX_ENGINE_BINDING_RECEIPT_BYTES,
+        )
+    except (UnsafeCorpusPathError, OSError):
         return None
     try:
         payload = json.loads(raw.decode("utf-8"))
@@ -341,6 +342,11 @@ def _build_pinned_release_binary(
     statuses: Sequence[tuple[Path, str]],
 ) -> Path:
     rendered = " ".join(ENGINE_RELEASE_BUILD_COMMAND)
+    # Pin the build output location: an ambient CARGO_TARGET_DIR would send
+    # the build elsewhere and this function would then receipt whatever stale
+    # bytes already sat at the expected path.
+    build_env = _binding_subprocess_env()
+    build_env["CARGO_TARGET_DIR"] = str(engine_checkout / "target")
     try:
         result = subprocess.run(
             list(ENGINE_RELEASE_BUILD_COMMAND),
@@ -348,7 +354,7 @@ def _build_pinned_release_binary(
             text=True,
             timeout=_ENGINE_BUILD_TIMEOUT_SECONDS,
             cwd=str(engine_checkout),
-            env=_binding_subprocess_env(),
+            env=build_env,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise EngineBindingError(
@@ -366,6 +372,23 @@ def _build_pinned_release_binary(
         raise EngineBindingError(
             f"`{rendered}` succeeded but produced no {release_binary}"
             + _binding_context(pin, engine_checkout, head=head, statuses=statuses)
+        )
+    # The pre-build HEAD/cleanliness checks only prove what the checkout held
+    # when the build started; another writer can move it mid-build. Re-prove
+    # both before attesting the bytes.
+    rebuilt_head = _git_output(
+        engine_checkout, "rev-parse", "HEAD", pin=pin, statuses=statuses
+    )
+    rebuilt_porcelain = _git_output(
+        engine_checkout, "status", "--porcelain", pin=pin, statuses=statuses
+    )
+    if rebuilt_head != pin.sha or rebuilt_porcelain:
+        raise EngineBindingError(
+            "Engine checkout changed during the pinned build; refusing to "
+            "receipt the produced binary"
+            + _binding_context(
+                pin, engine_checkout, head=rebuilt_head, statuses=statuses
+            )
         )
     write_engine_binding_receipt(release_binary, pin.sha, "release")
     return release_binary
@@ -393,7 +416,13 @@ def resolve_pinned_engine_binary(
         if status == _RECEIPT_VERIFIED:
             return candidate
         statuses.append((candidate, status))
-    if not (engine_checkout / ".git").exists():
+    git_marker = engine_checkout / ".git"
+    if git_marker.is_symlink():
+        raise EngineBindingError(
+            f"Engine checkout .git marker must not be a symlink: {git_marker}"
+            + _binding_context(pin, engine_checkout, head=None, statuses=statuses)
+        )
+    if not git_marker.exists():
         raise EngineBindingError(
             "Engine checkout is not a git repository and no candidate binary "
             "carries a verified receipt for the pinned commit; use a git "

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -26664,6 +26664,7 @@ class ValidatorPipeline:
         self._axiom_rules_engine_pin_loaded = False
         self._axiom_rules_engine_pin: EnginePin | None = None
         self._axiom_rules_binary_path: Path | None = None
+        self._axiom_rules_binary_stat: tuple[int, int, int, int] | None = None
         self.validation_staging_root = (
             Path(validation_staging_root).resolve()
             if validation_staging_root is not None
@@ -27359,16 +27360,34 @@ class ValidatorPipeline:
         A declared axiom_rules_engine_ref pin binds deterministically (receipt
         or clean pinned checkout plus build-on-demand); unpinned checkouts fall
         back to a release-first candidate scan with an unverified-binding event.
+        The memoized binding holds only while the binary's bytes are unchanged
+        on disk (stat identity); a swapped or rebuilt binary re-resolves.
         """
         if self._axiom_rules_binary_path is not None:
-            return self._axiom_rules_binary_path
+            if self._axiom_rules_binary_stat is not None and (
+                self._binary_stat_signature(self._axiom_rules_binary_path)
+                == self._axiom_rules_binary_stat
+            ):
+                return self._axiom_rules_binary_path
+            self._axiom_rules_binary_path = None
+            self._axiom_rules_binary_stat = None
         pin = self._declared_engine_pin()
         if pin is not None:
             binary = resolve_pinned_engine_binary(self.axiom_rules_path, pin)
         else:
             binary = self._unverified_axiom_rules_binary()
         self._axiom_rules_binary_path = binary
+        self._axiom_rules_binary_stat = self._binary_stat_signature(binary)
         return binary
+
+    @staticmethod
+    def _binary_stat_signature(binary: Path) -> tuple[int, int, int, int] | None:
+        """Return a cheap on-disk identity for the bound engine binary."""
+        try:
+            stat = os.stat(binary)
+        except OSError:
+            return None
+        return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
 
     def _unverified_axiom_rules_binary(self) -> Path:
         """Resolve without a declared pin: prefer release, then debug, then bare."""

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -75,6 +75,13 @@ from axiom_encode.corpus_resolver import (
     require_canonical_corpus_citation_path,
     resolve_local_corpus_source,
 )
+from axiom_encode.engine_binding import (
+    ENGINE_PIN_FIELD,
+    EnginePin,
+    load_declared_engine_pin,
+    require_engine_ref_sha,
+    resolve_pinned_engine_binary,
+)
 from axiom_encode.repo_routing import (
     _path_identity_fingerprint,
     _path_mutation_stamp,
@@ -26639,9 +26646,24 @@ class ValidatorPipeline:
         rulespec_dependency_roots: Iterable[Path] = (),
         validation_staging_root: Path | None = None,
         existing_target_oracle_contract: ExistingTargetOracleContract | None = None,
+        axiom_rules_engine_ref: str | None = None,
     ):
         self.policy_repo_path = Path(policy_repo_path)
         self.axiom_rules_path = Path(axiom_rules_path)
+        self._axiom_rules_engine_pin_override = (
+            EnginePin(
+                sha=require_engine_ref_sha(
+                    axiom_rules_engine_ref,
+                    description="axiom_rules_engine_ref",
+                ),
+                source=Path("<constructor>"),
+            )
+            if axiom_rules_engine_ref is not None
+            else None
+        )
+        self._axiom_rules_engine_pin_loaded = False
+        self._axiom_rules_engine_pin: EnginePin | None = None
+        self._axiom_rules_binary_path: Path | None = None
         self.validation_staging_root = (
             Path(validation_staging_root).resolve()
             if validation_staging_root is not None
@@ -27320,20 +27342,71 @@ class ValidatorPipeline:
         """Return the companion RuleSpec test file path."""
         return rules_file.with_name(f"{rules_file.stem}.test.yaml")
 
+    def _declared_engine_pin(self) -> EnginePin | None:
+        """Load the declared engine pin once per pipeline instance."""
+        if not self._axiom_rules_engine_pin_loaded:
+            if self._axiom_rules_engine_pin_override is not None:
+                pin = self._axiom_rules_engine_pin_override
+            else:
+                pin = load_declared_engine_pin(self.policy_repo_path)
+            self._axiom_rules_engine_pin = pin
+            self._axiom_rules_engine_pin_loaded = True
+        return self._axiom_rules_engine_pin
+
     def _axiom_rules_binary(self) -> Path:
-        """Resolve the local Axiom rules engine CLI binary."""
+        """Resolve the local Axiom rules engine CLI binary.
+
+        A declared axiom_rules_engine_ref pin binds deterministically (receipt
+        or clean pinned checkout plus build-on-demand); unpinned checkouts fall
+        back to a release-first candidate scan with an unverified-binding event.
+        """
+        if self._axiom_rules_binary_path is not None:
+            return self._axiom_rules_binary_path
+        pin = self._declared_engine_pin()
+        if pin is not None:
+            binary = resolve_pinned_engine_binary(self.axiom_rules_path, pin)
+        else:
+            binary = self._unverified_axiom_rules_binary()
+        self._axiom_rules_binary_path = binary
+        return binary
+
+    def _unverified_axiom_rules_binary(self) -> Path:
+        """Resolve without a declared pin: prefer release, then debug, then bare."""
         candidates = [
-            self.axiom_rules_path / "target" / "debug" / "axiom-rules-engine",
             self.axiom_rules_path / "target" / "release" / "axiom-rules-engine",
+            self.axiom_rules_path / "target" / "debug" / "axiom-rules-engine",
             self.axiom_rules_path / "axiom-rules-engine",
         ]
-        for candidate in candidates:
-            if candidate.exists():
-                return candidate
-        raise FileNotFoundError(
-            "axiom-rules-engine binary not found in the explicitly declared "
-            f"checkout: {self.axiom_rules_path}"
+        existing = [candidate for candidate in candidates if candidate.exists()]
+        if not existing:
+            raise FileNotFoundError(
+                "axiom-rules-engine binary not found in the explicitly declared "
+                f"checkout: {self.axiom_rules_path}"
+            )
+        binary = existing[0]
+        # _log_event is a no-op without an encoding_db session, so also warn
+        # through the module logger for plain CLI invocations.
+        logger.warning(
+            "Bound %s without a declared %s engine pin; binary provenance is "
+            "unverified (other existing candidates: %s)",
+            binary,
+            ENGINE_PIN_FIELD,
+            ", ".join(str(candidate) for candidate in existing[1:]) or "none",
         )
+        self._log_event(
+            "engine_binding_unverified",
+            f"Bound {binary} without a declared {ENGINE_PIN_FIELD} engine pin; "
+            "binary provenance is unverified",
+            {
+                "binary": str(binary),
+                "other_existing_candidates": [
+                    str(candidate) for candidate in existing[1:]
+                ],
+                "engine_checkout": str(self.axiom_rules_path),
+                "declared_engine_pin": None,
+            },
+        )
+        return binary
 
     def _compile_rulespec_to_artifact(
         self,

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1704"
+ENCODER_VERSION = "0.2.1705"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6815,6 +6815,7 @@ rules:
         args.json = json_output
         args.as_of = None
         args.axiom_rules_path = self._require_axiom_rules_path()
+        args.axiom_rules_engine_ref = None
         args.rulespec_dependency_root = []
         return args
 

--- a/tests/test_engine_binding.py
+++ b/tests/test_engine_binding.py
@@ -437,3 +437,105 @@ def test_cli_compile_threads_engine_ref_override(tmp_path, monkeypatch, capsys):
 
     assert exit_info.value.code == 0
     assert captured["axiom_rules_engine_ref"] == "e" * 40
+
+
+def test_ambient_cargo_target_dir_is_pinned_to_the_checkout(tmp_path, monkeypatch):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    stale_release = checkout / "target" / "release" / "axiom-rules-engine"
+    stale_release.parent.mkdir(parents=True)
+    stale_release.write_bytes(b"stale release build")
+    elsewhere = tmp_path / "ambient-target"
+    monkeypatch.setenv("CARGO_TARGET_DIR", str(elsewhere))
+    shim_dir = tmp_path / "cargo-shim"
+    shim_dir.mkdir()
+    shim = shim_dir / "cargo"
+    shim.write_text(
+        "#!/bin/sh\n"
+        'mkdir -p "$CARGO_TARGET_DIR/release"\n'
+        'printf "release-built-from-pin" '
+        '> "$CARGO_TARGET_DIR/release/axiom-rules-engine"\n'
+        'chmod +x "$CARGO_TARGET_DIR/release/axiom-rules-engine"\n'
+        "exit 0\n"
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ['PATH']}")
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+
+    binary = resolve_pinned_engine_binary(checkout, pin)
+
+    assert binary == stale_release
+    assert binary.read_bytes() == b"release-built-from-pin"
+    assert not elsewhere.exists()
+    receipt = read_engine_binding_receipt(binary)
+    assert receipt is not None
+    assert (
+        receipt["binary_sha256"]
+        == hashlib.sha256(b"release-built-from-pin").hexdigest()
+    )
+
+
+def test_checkout_mutation_during_build_refuses_receipt(tmp_path, monkeypatch):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    shim_dir = tmp_path / "cargo-shim"
+    shim_dir.mkdir()
+    shim = shim_dir / "cargo"
+    shim.write_text(
+        "#!/bin/sh\n"
+        "mkdir -p target/release\n"
+        'printf "release-built-mid-mutation" > target/release/axiom-rules-engine\n'
+        "chmod +x target/release/axiom-rules-engine\n"
+        'printf "// mutated during build\\n" >> src.rs\n'
+        "exit 0\n"
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ['PATH']}")
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+
+    with pytest.raises(EngineBindingError, match="changed during the pinned build"):
+        resolve_pinned_engine_binary(checkout, pin)
+
+    release = checkout / "target" / "release" / "axiom-rules-engine"
+    assert not engine_binding_receipt_path(release).exists()
+
+
+def test_symlinked_receipt_is_ignored(tmp_path):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    stale = _stale_debug_binary(checkout)
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+    aside = tmp_path / "receipt-content.json"
+    aside.write_text(
+        json.dumps(
+            {
+                "engine_commit": pin_sha,
+                "binary_sha256": hashlib.sha256(stale.read_bytes()).hexdigest(),
+            }
+        )
+    )
+    engine_binding_receipt_path(stale).symlink_to(aside)
+
+    assert read_engine_binding_receipt(stale) is None
+    with pytest.raises(EngineBindingError, match="no receipt"):
+        resolve_pinned_engine_binary(checkout, pin, allow_build=False)
+
+
+def test_oversized_receipt_is_ignored(tmp_path):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    stale = _stale_debug_binary(checkout)
+    padding = json.dumps({"engine_commit": pin_sha, "pad": "x" * 70_000})
+    engine_binding_receipt_path(stale).write_text(padding)
+
+    assert read_engine_binding_receipt(stale) is None
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+    with pytest.raises(EngineBindingError, match="no receipt"):
+        resolve_pinned_engine_binary(checkout, pin, allow_build=False)
+
+
+def test_git_marker_symlink_is_rejected(tmp_path):
+    real_checkout, pin_sha = _engine_checkout(tmp_path)
+    shim = tmp_path / "shim-checkout"
+    shim.mkdir()
+    (shim / ".git").symlink_to(real_checkout / ".git")
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+
+    with pytest.raises(EngineBindingError, match=r"\.git marker must not be a symlink"):
+        resolve_pinned_engine_binary(shim, pin, allow_build=False)

--- a/tests/test_engine_binding.py
+++ b/tests/test_engine_binding.py
@@ -1,0 +1,439 @@
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from axiom_encode import cli
+from axiom_encode.engine_binding import (
+    ENGINE_PIN_FIELD,
+    EngineBindingError,
+    EnginePin,
+    engine_binding_receipt_path,
+    load_declared_engine_pin,
+    read_engine_binding_receipt,
+    resolve_pinned_engine_binary,
+    write_engine_binding_receipt,
+)
+
+_ZERO_SHA256 = "0" * 64
+
+
+def _git(path: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def _engine_checkout(tmp_path: Path) -> tuple[Path, str]:
+    """Create a committed engine checkout; return (checkout, pinned HEAD)."""
+
+    checkout = tmp_path / "axiom-rules-engine"
+    checkout.mkdir()
+    _git(checkout, "init", "-q")
+    _git(checkout, "config", "user.email", "t@t")
+    _git(checkout, "config", "user.name", "t")
+    (checkout / ".gitignore").write_text("target/\n")
+    (checkout / "src.rs").write_text("fn main() {}\n")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "pinned")
+    return checkout, _git(checkout, "rev-parse", "HEAD")
+
+
+def _drift_commit(checkout: Path) -> str:
+    """Advance HEAD one commit past the pin; return the new HEAD."""
+
+    (checkout / "src.rs").write_text("fn main() { /* drift */ }\n")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "drift")
+    return _git(checkout, "rev-parse", "HEAD")
+
+
+def _stale_debug_binary(checkout: Path) -> Path:
+    debug = checkout / "target" / "debug" / "axiom-rules-engine"
+    debug.parent.mkdir(parents=True, exist_ok=True)
+    debug.write_bytes(b"stale debug build")
+    debug.chmod(0o755)
+    return debug
+
+
+def _cargo_shim(tmp_path: Path, monkeypatch) -> Path:
+    """Put a fake cargo on PATH that writes a stub release binary and exits 0."""
+
+    shim_dir = tmp_path / "cargo-shim"
+    shim_dir.mkdir(exist_ok=True)
+    shim = shim_dir / "cargo"
+    shim.write_text(
+        "#!/bin/sh\n"
+        "mkdir -p target/release\n"
+        'printf "release-built-from-pin" > target/release/axiom-rules-engine\n'
+        "chmod +x target/release/axiom-rules-engine\n"
+        "exit 0\n"
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ['PATH']}")
+    return shim
+
+
+def _write_toolchain(checkout_root: Path, *, engine_ref: str | None) -> Path:
+    config_dir = checkout_root / ".axiom"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "[toolchain]",
+        'axiom_corpus_release = "test-release"',
+        f'axiom_corpus_release_content_sha256 = "{_ZERO_SHA256}"',
+        f'validation_waiver_set_sha256 = "{_ZERO_SHA256}"',
+    ]
+    if engine_ref is not None:
+        lines.append(f'{ENGINE_PIN_FIELD} = "{engine_ref}"')
+    config_path = config_dir / "toolchain.toml"
+    config_path.write_text("\n".join(lines) + "\n")
+    return config_path
+
+
+def test_stale_debug_is_not_bound_and_release_is_rebuilt_at_pin(tmp_path, monkeypatch):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    stale = _stale_debug_binary(checkout)
+    _cargo_shim(tmp_path, monkeypatch)
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+
+    binary = resolve_pinned_engine_binary(checkout, pin)
+
+    assert binary == checkout / "target" / "release" / "axiom-rules-engine"
+    assert binary.read_bytes() == b"release-built-from-pin"
+    receipt = read_engine_binding_receipt(binary)
+    assert receipt is not None
+    assert receipt["engine_commit"] == pin_sha
+    assert receipt["cargo_profile"] == "release"
+    assert (
+        receipt["binary_sha256"]
+        == hashlib.sha256(b"release-built-from-pin").hexdigest()
+    )
+    assert stale.read_bytes() == b"stale debug build"
+
+
+def test_no_build_raises_naming_the_stale_debug_candidate(tmp_path):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    stale = _stale_debug_binary(checkout)
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+
+    with pytest.raises(EngineBindingError) as error:
+        resolve_pinned_engine_binary(checkout, pin, allow_build=False)
+
+    message = str(error.value)
+    assert str(stale) in message
+    assert "no receipt" in message
+    assert pin_sha in message
+    assert "cargo build --release --locked" in message
+    assert "axiom-encode engine-bind" in message
+
+
+def test_wrong_commit_checkout_raises_naming_both_shas_and_pin_source(
+    tmp_path, monkeypatch
+):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    head = _drift_commit(checkout)
+    source = tmp_path / "rulespec-us" / ".axiom" / "toolchain.toml"
+    pin = EnginePin(sha=pin_sha, source=source)
+    _cargo_shim(tmp_path, monkeypatch)
+
+    with pytest.raises(EngineBindingError) as error:
+        resolve_pinned_engine_binary(checkout, pin)
+
+    message = str(error.value)
+    assert pin_sha in message
+    assert head in message
+    assert str(source) in message
+    # Skew fails before any build runs.
+    assert not (checkout / "target" / "release" / "axiom-rules-engine").exists()
+
+
+def test_forged_receipt_for_a_different_commit_does_not_bind(tmp_path):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    head = _drift_commit(checkout)
+    debug = _stale_debug_binary(checkout)
+    write_engine_binding_receipt(debug, head, "debug")
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+
+    with pytest.raises(EngineBindingError) as error:
+        resolve_pinned_engine_binary(checkout, pin, allow_build=False)
+
+    message = str(error.value)
+    assert f"receipt commit {head} does not match the pin" in message
+    assert str(debug) in message
+
+
+def test_tampered_binary_bytes_invalidate_the_receipt(tmp_path, monkeypatch):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    release = checkout / "target" / "release" / "axiom-rules-engine"
+    release.parent.mkdir(parents=True)
+    release.write_bytes(b"original")
+    write_engine_binding_receipt(release, pin_sha, "release")
+    release.write_bytes(b"tampered")
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+
+    with pytest.raises(EngineBindingError) as error:
+        resolve_pinned_engine_binary(checkout, pin, allow_build=False)
+    assert "binary bytes do not match the receipt binary_sha256" in str(error.value)
+
+    _cargo_shim(tmp_path, monkeypatch)
+    binary = resolve_pinned_engine_binary(checkout, pin)
+    assert binary == release
+    assert binary.read_bytes() == b"release-built-from-pin"
+    receipt = read_engine_binding_receipt(binary)
+    assert receipt is not None
+    assert (
+        receipt["binary_sha256"]
+        == hashlib.sha256(b"release-built-from-pin").hexdigest()
+    )
+
+
+def test_dirty_checkout_raises(tmp_path, monkeypatch):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    (checkout / "src.rs").write_text("fn main() { /* uncommitted */ }\n")
+    _cargo_shim(tmp_path, monkeypatch)
+    pin = EnginePin(sha=pin_sha, source=tmp_path / "toolchain.toml")
+
+    with pytest.raises(EngineBindingError, match="dirty"):
+        resolve_pinned_engine_binary(checkout, pin)
+
+
+def test_legacy_toolchain_with_extra_keys_yields_the_pin(tmp_path):
+    checkout_root = tmp_path / "rulespec-us"
+    content_root = checkout_root / "us"
+    content_root.mkdir(parents=True)
+    config_path = _write_toolchain(checkout_root, engine_ref="a" * 40)
+
+    pin = load_declared_engine_pin(content_root)
+
+    assert pin is not None
+    assert pin.sha == "a" * 40
+    assert pin.source == config_path
+
+
+def test_strict_three_key_toolchain_yields_no_pin(tmp_path):
+    checkout_root = tmp_path / "rulespec-us"
+    content_root = checkout_root / "us"
+    content_root.mkdir(parents=True)
+    _write_toolchain(checkout_root, engine_ref=None)
+
+    assert load_declared_engine_pin(content_root) is None
+
+
+def test_malformed_engine_ref_raises(tmp_path):
+    checkout_root = tmp_path / "rulespec-us"
+    content_root = checkout_root / "us"
+    content_root.mkdir(parents=True)
+    for bad_ref in ("HEAD", "abc123", "A" * 40):
+        _write_toolchain(checkout_root, engine_ref=bad_ref)
+        with pytest.raises(EngineBindingError, match=ENGINE_PIN_FIELD):
+            load_declared_engine_pin(content_root)
+
+
+def test_no_toolchain_anywhere_yields_no_pin(tmp_path):
+    content_root = tmp_path / "rulespec-us" / "us"
+    content_root.mkdir(parents=True)
+
+    assert load_declared_engine_pin(content_root) is None
+
+
+def test_nonexistent_policy_repo_path_raises(tmp_path):
+    # A path typo must not silently downgrade to unpinned binding.
+    with pytest.raises(EngineBindingError, match="does not exist"):
+        load_declared_engine_pin(tmp_path / "missing")
+
+
+def test_multiple_ancestor_toolchains_fail_closed(tmp_path):
+    checkout_root = tmp_path / "rulespec-us"
+    content_root = checkout_root / "us"
+    content_root.mkdir(parents=True)
+    _write_toolchain(checkout_root, engine_ref="a" * 40)
+    _write_toolchain(content_root, engine_ref="b" * 40)
+
+    with pytest.raises(EngineBindingError, match="multiple ancestor"):
+        load_declared_engine_pin(content_root)
+
+
+def test_toolchain_walk_is_bounded_at_the_git_root(tmp_path):
+    outer = tmp_path / "outer"
+    checkout_root = outer / "rulespec-us"
+    content_root = checkout_root / "us"
+    content_root.mkdir(parents=True)
+    _write_toolchain(outer, engine_ref="a" * 40)
+    _git(checkout_root, "init", "-q")
+
+    assert load_declared_engine_pin(content_root) is None
+
+
+def test_bare_binary_shim_binds_only_with_a_valid_receipt(tmp_path):
+    shim_checkout = tmp_path / "engine-shim"
+    shim_checkout.mkdir()
+    bare = shim_checkout / "axiom-rules-engine"
+    bare.write_bytes(b"prebuilt engine")
+    pin = EnginePin(sha="a" * 40, source=tmp_path / "toolchain.toml")
+
+    with pytest.raises(EngineBindingError, match="not a git repository") as error:
+        resolve_pinned_engine_binary(shim_checkout, pin)
+    assert str(bare) in str(error.value)
+
+    write_engine_binding_receipt(bare, "a" * 40, "prebuilt")
+    assert resolve_pinned_engine_binary(shim_checkout, pin) == bare
+
+
+def test_receipt_round_trip_and_malformed_reads(tmp_path):
+    binary = tmp_path / "axiom-rules-engine"
+    binary.write_bytes(b"bits")
+
+    receipt_path = write_engine_binding_receipt(binary, "b" * 40, "release")
+
+    assert receipt_path == engine_binding_receipt_path(binary)
+    receipt = read_engine_binding_receipt(binary)
+    assert receipt is not None
+    assert receipt["engine_commit"] == "b" * 40
+    assert receipt["binary_sha256"] == hashlib.sha256(b"bits").hexdigest()
+    assert receipt["cargo_profile"] == "release"
+    assert receipt["written_by"].startswith("axiom-encode ")
+    assert "built_at" in receipt
+
+    receipt_path.write_text("{not json")
+    assert read_engine_binding_receipt(binary) is None
+    receipt_path.write_text("[1, 2]")
+    assert read_engine_binding_receipt(binary) is None
+    receipt_path.unlink()
+    assert read_engine_binding_receipt(binary) is None
+    # The atomic write leaves no staged temp files behind.
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["axiom-rules-engine"]
+
+
+def test_write_receipt_wraps_os_errors_as_binding_errors(tmp_path):
+    with pytest.raises(EngineBindingError, match="binding receipt"):
+        write_engine_binding_receipt(tmp_path / "missing-binary", "b" * 40, "release")
+
+
+def test_cli_engine_bind_builds_and_reports_json(tmp_path, monkeypatch, capsys):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    _cargo_shim(tmp_path, monkeypatch)
+    policy_checkout = tmp_path / "rulespec-us"
+    (policy_checkout / "us").mkdir(parents=True)
+    _write_toolchain(policy_checkout, engine_ref=pin_sha)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "axiom-encode",
+            "engine-bind",
+            "--axiom-rules-engine-path",
+            str(checkout),
+            "--policy-repo",
+            str(policy_checkout / "us"),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
+
+    assert exit_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["binary"] == str(
+        checkout / "target" / "release" / "axiom-rules-engine"
+    )
+    assert payload["engine_commit"] == pin_sha
+    assert Path(payload["receipt"]).is_file()
+
+
+def test_cli_engine_bind_no_build_failure_exits_one(tmp_path, monkeypatch, capsys):
+    checkout, pin_sha = _engine_checkout(tmp_path)
+    _stale_debug_binary(checkout)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "axiom-encode",
+            "engine-bind",
+            "--axiom-rules-engine-path",
+            str(checkout),
+            "--pin",
+            pin_sha,
+            "--no-build",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
+
+    assert exit_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "Engine binding failed" in err
+    assert "no receipt" in err
+
+
+def test_cli_engine_bind_requires_a_declared_pin(tmp_path, monkeypatch, capsys):
+    checkout, _pin_sha = _engine_checkout(tmp_path)
+    policy_checkout = tmp_path / "rulespec-us"
+    (policy_checkout / "us").mkdir(parents=True)
+    _write_toolchain(policy_checkout, engine_ref=None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "axiom-encode",
+            "engine-bind",
+            "--axiom-rules-engine-path",
+            str(checkout),
+            "--policy-repo",
+            str(policy_checkout / "us"),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
+
+    assert exit_info.value.code == 1
+    assert ENGINE_PIN_FIELD in capsys.readouterr().err
+
+
+def test_cli_compile_threads_engine_ref_override(tmp_path, monkeypatch, capsys):
+    rules_file = tmp_path / "rulespec-us" / "us" / "statutes" / "1" / "1.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text("format: rulespec/v1\nrules: []\n")
+    engine_root = tmp_path / "axiom-rules-engine"
+    engine_root.mkdir()
+    captured: dict[str, object] = {}
+
+    class _RecordingPipeline:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def _compile_rulespec_to_artifact(self, rulespec_file, output_path):
+            output_path.write_text('{"program": {"derived": []}}')
+            return (
+                subprocess.CompletedProcess(["engine"], 0, stdout="", stderr=""),
+                {"program": {"derived": []}},
+            )
+
+    monkeypatch.setattr(cli, "ValidatorPipeline", _RecordingPipeline)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "axiom-encode",
+            "compile",
+            str(rules_file),
+            "--axiom-rules-engine-path",
+            str(engine_root),
+            "--axiom-rules-engine-ref",
+            "e" * 40,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
+
+    assert exit_info.value.code == 0
+    assert captured["axiom_rules_engine_ref"] == "e" * 40

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1704"
+ENCODER_VERSION = "0.2.1705"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1704"
+ENCODER_VERSION = "0.2.1705"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1704"
+ENCODER_VERSION = "0.2.1705"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1704"
+ENCODER_VERSION = "0.2.1705"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1704"
+ENCODER_VERSION = "0.2.1705"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1704"
+ENCODER_VERSION = "0.2.1705"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -28,6 +28,10 @@ from axiom_encode.corpus_resolver import (
     AmbiguousCorpusSourceError,
     LocalCorpusRelease,
 )
+from axiom_encode.engine_binding import (
+    EngineBindingError,
+    write_engine_binding_receipt,
+)
 from axiom_encode.harness import validator_pipeline
 from axiom_encode.harness.evals import _rulespec_validation_target
 from axiom_encode.harness.policyengine_runtime import (
@@ -1235,6 +1239,182 @@ def test_rulespec_validation_run_compiled_scrubs_ambient_root_env(
     assert "AXIOM_RULESPEC_REPO_ROOTS" not in captured_env
     assert "AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE" not in captured_env
     assert str(stale_root) not in captured_env.values()
+
+
+def _write_engine_pinned_toolchain(checkout_root: Path, engine_ref: str) -> Path:
+    """Write a legacy multi-key toolchain.toml declaring an engine pin."""
+
+    config_dir = checkout_root / ".axiom"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "toolchain.toml"
+    config_path.write_text(
+        "[toolchain]\n"
+        'axiom_corpus_release = "test-release"\n'
+        f'axiom_corpus_release_content_sha256 = "{"0" * 64}"\n'
+        f'validation_waiver_set_sha256 = "{"0" * 64}"\n'
+        f'axiom_rules_engine_ref = "{engine_ref}"\n'
+    )
+    return config_path
+
+
+def test_rulespec_engine_binary_prefers_release_and_warns_once_when_unpinned(
+    tmp_path,
+):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us")
+    engine_root = tmp_path / "axiom-rules-engine"
+    release = engine_root / "target" / "release" / "axiom-rules-engine"
+    debug = engine_root / "target" / "debug" / "axiom-rules-engine"
+    for candidate in (release, debug):
+        candidate.parent.mkdir(parents=True)
+        candidate.write_bytes(b"bin")
+    events: list[dict] = []
+
+    class _RecordingDB:
+        def log_event(self, **kwargs):
+            events.append(kwargs)
+
+    pipeline = _ValidatorPipeline(
+        policy_repo_path=policy_repo,
+        axiom_rules_path=engine_root,
+        local_corpus_release=None,
+        enable_oracles=False,
+        encoding_db=_RecordingDB(),
+        session_id="engine-binding-test",
+    )
+
+    assert pipeline._axiom_rules_binary() == release
+    assert pipeline._axiom_rules_binary() == release
+
+    unverified = [
+        event for event in events if event["event_type"] == "engine_binding_unverified"
+    ]
+    assert len(unverified) == 1
+    metadata = unverified[0]["metadata"]
+    assert metadata["binary"] == str(release)
+    assert str(debug) in metadata["other_existing_candidates"]
+    assert metadata["declared_engine_pin"] is None
+
+
+def test_rulespec_engine_binary_nonexistent_policy_repo_raises(tmp_path):
+    # A typo'd policy repo path must fail loudly, not downgrade to unpinned
+    # binding of whatever stale binary exists.
+    engine_root = tmp_path / "axiom-rules-engine"
+    debug = engine_root / "target" / "debug" / "axiom-rules-engine"
+    debug.parent.mkdir(parents=True)
+    debug.write_bytes(b"stale debug")
+
+    pipeline = _ValidatorPipeline(
+        policy_repo_path=tmp_path / "missing" / "us",
+        axiom_rules_path=engine_root,
+        local_corpus_release=None,
+        enable_oracles=False,
+    )
+
+    with pytest.raises(EngineBindingError, match="does not exist"):
+        pipeline._axiom_rules_binary()
+
+
+def test_rulespec_engine_binary_resolution_is_memoized_per_pipeline(
+    monkeypatch, tmp_path
+):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us")
+    engine_root = tmp_path / "axiom-rules-engine"
+    engine_root.mkdir()
+    resolved = engine_root / "target" / "release" / "axiom-rules-engine"
+    calls = {"load": 0, "resolve": 0}
+
+    def fake_load(path):
+        calls["load"] += 1
+        return validator_pipeline.EnginePin(
+            sha="a" * 40,
+            source=tmp_path / "toolchain.toml",
+        )
+
+    def fake_resolve(checkout, pin, *, allow_build=True):
+        calls["resolve"] += 1
+        return resolved
+
+    monkeypatch.setattr(validator_pipeline, "load_declared_engine_pin", fake_load)
+    monkeypatch.setattr(
+        validator_pipeline, "resolve_pinned_engine_binary", fake_resolve
+    )
+    pipeline = _ValidatorPipeline(
+        policy_repo_path=policy_repo,
+        axiom_rules_path=engine_root,
+        local_corpus_release=None,
+        enable_oracles=False,
+    )
+
+    assert pipeline._axiom_rules_binary() == resolved
+    assert pipeline._axiom_rules_binary() == resolved
+    assert calls == {"load": 1, "resolve": 1}
+
+
+def test_rulespec_engine_ref_override_wins_over_toolchain_pin(monkeypatch, tmp_path):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us")
+    _write_engine_pinned_toolchain(policy_repo.parent, "c" * 40)
+    captured: dict[str, object] = {}
+
+    def fake_resolve(checkout, pin, *, allow_build=True):
+        captured["pin"] = pin
+        return checkout / "target" / "release" / "axiom-rules-engine"
+
+    monkeypatch.setattr(
+        validator_pipeline, "resolve_pinned_engine_binary", fake_resolve
+    )
+    pipeline = _ValidatorPipeline(
+        policy_repo_path=policy_repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        local_corpus_release=None,
+        enable_oracles=False,
+        axiom_rules_engine_ref="d" * 40,
+    )
+
+    pipeline._axiom_rules_binary()
+
+    pin = captured["pin"]
+    assert pin.sha == "d" * 40
+    assert str(pin.source) == "<constructor>"
+
+
+def test_rulespec_compile_uses_pinned_receipted_binary(monkeypatch, tmp_path):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us")
+    rules_file = policy_repo / "statutes" / "1" / "1.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text("format: rulespec/v1\nrules: []\n")
+    pin_sha = "f" * 40
+    _write_engine_pinned_toolchain(policy_repo.parent, pin_sha)
+    engine_root = tmp_path / "axiom-rules-engine"
+    release = engine_root / "target" / "release" / "axiom-rules-engine"
+    debug = engine_root / "target" / "debug" / "axiom-rules-engine"
+    for candidate, payload in ((release, b"pinned release"), (debug, b"stale debug")):
+        candidate.parent.mkdir(parents=True)
+        candidate.write_bytes(payload)
+    write_engine_binding_receipt(release, pin_sha, "release")
+
+    pipeline = ValidatorPipeline(
+        policy_repo_path=policy_repo,
+        axiom_rules_path=engine_root,
+        enable_oracles=False,
+    )
+    output_path = tmp_path / "compiled.json"
+    captured: dict[str, object] = {}
+    original_run = validator_pipeline.subprocess.run
+
+    def fake_run(command, **kwargs):
+        if command[0] == "git":
+            return original_run(command, **kwargs)
+        captured["command"] = command
+        output_path.write_text('{"program": {"derived": []}}')
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(validator_pipeline.subprocess, "run", fake_run)
+
+    result, payload = pipeline._compile_rulespec_to_artifact(rules_file, output_path)
+
+    assert result.returncode == 0
+    assert payload == {"program": {"derived": []}}
+    assert captured["command"][0] == str(release)
 
 
 def test_rulespec_target_resolution_uses_explicit_dependency_root(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1321,6 +1321,9 @@ def test_rulespec_engine_binary_resolution_is_memoized_per_pipeline(
     engine_root = tmp_path / "axiom-rules-engine"
     engine_root.mkdir()
     resolved = engine_root / "target" / "release" / "axiom-rules-engine"
+    # Memoization is stat-guarded: it only holds for a real, unchanged binary.
+    resolved.parent.mkdir(parents=True)
+    resolved.write_bytes(b"pinned release")
     calls = {"load": 0, "resolve": 0}
 
     def fake_load(path):
@@ -1415,6 +1418,32 @@ def test_rulespec_compile_uses_pinned_receipted_binary(monkeypatch, tmp_path):
     assert result.returncode == 0
     assert payload == {"program": {"derived": []}}
     assert captured["command"][0] == str(release)
+
+
+def test_rulespec_engine_binary_swap_after_binding_is_rebound_not_reused(tmp_path):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us")
+    pin_sha = "f" * 40
+    _write_engine_pinned_toolchain(policy_repo.parent, pin_sha)
+    engine_root = tmp_path / "axiom-rules-engine"
+    release = engine_root / "target" / "release" / "axiom-rules-engine"
+    release.parent.mkdir(parents=True)
+    release.write_bytes(b"pinned release")
+    write_engine_binding_receipt(release, pin_sha, "release")
+    pipeline = ValidatorPipeline(
+        policy_repo_path=policy_repo,
+        axiom_rules_path=engine_root,
+        local_corpus_release=None,
+        enable_oracles=False,
+    )
+
+    assert pipeline._axiom_rules_binary() == release
+
+    release.write_bytes(b"swapped bytes that no receipt attests")
+    with pytest.raises(EngineBindingError):
+        pipeline._axiom_rules_binary()
+
+    write_engine_binding_receipt(release, pin_sha, "release")
+    assert pipeline._axiom_rules_binary() == release
 
 
 def test_rulespec_target_resolution_uses_explicit_dependency_root(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1704"')
+        .startswith('__version__ = "0.2.1705"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1704"
+    assert encoder_package["version"] == "0.2.1705"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1704"
+    assert project["project"]["version"] == "0.2.1705"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1704"')
+        .startswith('__version__ = "0.2.1705"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1704"
+    assert encoder_package["version"] == "0.2.1705"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1704"
+    assert project["project"]["version"] == "0.2.1705"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1704"')
+        .startswith('__version__ = "0.2.1705"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1704"
+ENCODER_VERSION = "0.2.1705"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1704"
+version = "0.2.1705"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- bind the validator's engine binary deterministically to the policy repo's declared `[toolchain].axiom_rules_engine_ref`: receipted binaries (commit + binary sha256 sidecar) bind first, then a clean git checkout at the pin may build the release profile on demand and receipt the result; everything else fails closed naming the pin, its source file, the checkout HEAD, every candidate binary's receipt status, and the exact remediation
- stop silently preferring stale debug builds: unpinned checkouts now scan release before debug and emit an unverified-binding warning (logger + session event) naming the bound binary and the other existing candidates
- add an `engine-bind` CLI verb (verify + build-on-demand + receipt, for prebuilt/shim layouts) and an `--axiom-rules-engine-ref` override on `validate` and `compile`
- tolerant pin reader: legacy multi-key toolchain.toml files yield the pin; strict 3-key files yield none (unpinned mode); malformed refs, symlinked or ambiguous toolchain files, and nonexistent policy-repo paths fail closed
- hardening from the cross-family review round: the on-demand build pins `CARGO_TARGET_DIR` to the checkout (an ambient redirect would leave stale bytes to be receipted), HEAD and cleanliness are re-proven after the build before the receipt is written, receipts are read through the bounded no-follow opener (symlinked receipts rejected), a symlinked `.git` marker is rejected, and the pipeline's memoized binding is stat-guarded so a swapped or rebuilt binary re-resolves instead of silently reusing the verified path
- release 0.2.1705

Incident (2026-08-19, tariff lane): the debug-first, pin-unverified resolution bound a stale Aug-1 debug build (string-keyed tables accepted, strict roots required) instead of the rulespec-us pinned v0.1.0 engine (`ffd82132`), producing a false G4 PASS in one lane and 102 false failures in another. Both failure modes are now closed: a stale debug build cannot bind in pinned mode by any route, and a wrong-commit checkout hard-fails naming both SHAs.

## Deployment note
Binding engages wherever a `ValidatorPipeline` is constructed against a policy repo that declares the pin — the `compile` command and every embedded pipeline flow honor it immediately for legacy multi-key toolchains (rulespec-us today). Two boundaries, both fail-closed and tracked in #1527:
- the `validate` command loads the strict corpus toolchain (`load_rulespec_toolchain`, exactly three corpus/waiver keys) before constructing the pipeline, so strict-format repos cannot declare the engine pin in toolchain.toml yet; on that command the pin arrives via `--axiom-rules-engine-ref` until the strict schema and reviewed workflow pins are widened in dedicated gated PRs
- eval-suite and `test` flows take the toolchain-declared pin but have no override flag yet

Binding receipts are unsigned local attestations: they protect against accidental drift (stale builds, tampered bytes, wrong-commit checkouts, mid-build checkout movement), not adversarial receipt forgery.

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests` — clean; `ruff format --check src/ tests/` — clean
- `python -m compileall -q src/axiom_encode scripts` — clean
- `pytest -q tests/test_engine_binding.py` (25 passed) + encoder-version guard test (1 passed)
- `pytest -q tests/test_cli.py tests/test_rulespec_validation.py tests/test_evals.py -k "rulespec or EncoderPrompt"` (2628 passed)
- `pytest -q tests/test_validation_waiver_audit_cli.py` (33 passed)
- independent end-to-end sandbox reproductions of both incident modes against the real `ValidatorPipeline` (real git repos + cargo PATH shim): the stale-debug scenario binds the freshly built, receipted release binary — never the stale debug — and fails closed without cargo, naming the stale candidate; the wrong-commit scenario hard-fails naming both SHAs and the pin source

## Cycle
Round 1 (fable, multi-agent): four mapping agents enumerated every engine-resolution call site; one implementer; five independent adversarial verifiers (stale-debug reproduction, wrong-commit reproduction, 52-probe edge-case attack battery, regression + test-quality audit with mutation reasoning, org-rules/conventions compliance) — all five PASS with runnable receipts. Actionable findings fixed and re-checked: docs/encodebench.md debug-build drift, an OSError leak in receipt writing, nonexistent policy-repo paths silently downgrading to unpinned mode, and the unpinned warning being invisible on plain CLI runs.

Round 2 (sol, gpt-5.6-sol blind adversarial review; fable adjudicated): five findings. Accepted and fixed in the hardening commit: ambient `CARGO_TARGET_DIR` could redirect the build and receipt stale bytes; no post-build HEAD/cleanliness recheck (mid-build checkout movement); memoized binding trusted a path, not the bytes later executed; symlinked receipts/`.git` markers unhandled; receipt reads not race-bounded. Adjudicated as disclosure + follow-up rather than in-diff changes (org provenance regime forbids toolchain-schema and reviewed-workflow changes in feature PRs): the strict-loader interaction on `validate` (now stated precisely in the deployment note; #1527), and adversarial receipt forgery (out of the receipts' stated threat model; signing tracked in #1527).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
