### PR TITLE
ci: bump signed-apply pin past the bump race (provisioner invariant)

### DIFF
--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -76,7 +76,7 @@ env:
   # wave pin 185b2457). The validate workflow's encode-ref is bumped to the
   # same sha in this PR so the signed PRs' CI verifies manifests with the
   # same encoder generation that produced them.
-  AXIOM_ENCODE_REF: 9cd88dee15c79f2c23b522b7fb17cfa522f15c3d
+  AXIOM_ENCODE_REF: 5c8e16891b39d400269ebd49d0ad3f88f77e9ec1
   AXIOM_RULES_ENGINE_REF: 05eac9d2f89dabe5c6673176260762cef3a58f47
 
 jobs:


### PR DESCRIPTION
Round-6 provisioning refused at pin 9cd88dee ('encoder files changed after the latest version bump' — the #1523/#1510 race unresolved in that commit's own history; #1526 fixed main after it). Pin to post-#1526 main. rulespec-de lockstep + round 7 follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)