### PR TITLE
Retain best RuleSpec candidate across encode retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Axiom Encode will be documented here.
 
+- Retain the validator-rejected RuleSpec candidate with the fewest full
+  validation findings across model retries, keep its bounded feedback attached
+  to that exact candidate, and emit the same best candidate for cross-run
+  repair instead of allowing a later regression to overwrite stronger work.
+
 - Keep parenthetical source conditions bounded to their closing parenthesis so
   later descriptive conjunctions cannot be misclassified as additional legal
   eligibility gates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1705"
+version = "0.2.1706"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1705"
+__version__ = "0.2.1706"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26240,6 +26240,8 @@ class _FailedEncodeAttempt(NamedTuple):
     error: str
     candidate: ValidationRetryCandidate | None = None
     validation_issues: Sequence[str] = ()
+    validation_issue_count: int | None = None
+    full_validation_issues: Sequence[str] = ()
 
 
 _FAILED_ENCODE_CANDIDATE_SCHEMA = "axiom-encode/failed-encode-candidate/v1"
@@ -26380,14 +26382,19 @@ def _emit_final_rejected_candidate(
     citation: str,
     validation_issues: Sequence[str],
     attempt_count: int,
+    candidate_override: ValidationRetryCandidate | None = None,
 ) -> Path:
-    """Materialize exactly one final rejected pair and its bounded issue metadata."""
+    """Materialize exactly one selected rejected pair and its issue metadata."""
 
     resolved_destination = _resolve_final_rejected_candidate_destination(destination)
     _generated_root, _output_file, relative_output = (
         _validation_retry_candidate_location(result, output_root=output_root)
     )
-    candidate = _capture_validation_retry_candidate(result, output_root=output_root)
+    candidate = (
+        candidate_override
+        if candidate_override is not None
+        else _capture_validation_retry_candidate(result, output_root=output_root)
+    )
     if (
         not isinstance(attempt_count, int)
         or isinstance(attempt_count, bool)
@@ -26664,12 +26671,34 @@ def _validate_tests_only_repair_contract(
         raise ValueError("tests-only repair replacement path mismatch")
 
 
-def _latest_validation_retry_candidate(
+def _best_validation_retry_attempt(
     prior_attempts: Sequence[_FailedEncodeAttempt],
-) -> ValidationRetryCandidate | None:
-    """Return only the immediately preceding candidate, when safely captured."""
+) -> _FailedEncodeAttempt | None:
+    """Return the least-regressed candidate with its matching feedback."""
 
-    return prior_attempts[-1].candidate if prior_attempts else None
+    if not prior_attempts:
+        return None
+    if any(attempt.validation_issue_count is None for attempt in prior_attempts):
+        # Historical and unit-test callers without comparable full counts retain
+        # the original immediately-preceding-candidate behavior.
+        return prior_attempts[-1]
+
+    def score(indexed: tuple[int, _FailedEncodeAttempt]) -> tuple[int, int, int]:
+        index, attempt = indexed
+        unsafe_candidate = (
+            any(
+                "[generated-yaml:" in issue or "compile validation" in issue.casefold()
+                for issue in attempt.validation_issues
+                if isinstance(issue, str)
+            )
+            or "compile validation" in attempt.error.casefold()
+        )
+        assert attempt.validation_issue_count is not None
+        # Parser/compile failures cannot outrank a source-complete candidate.
+        # On an exact deterministic tie, keep forward progress by using newer.
+        return (int(unsafe_candidate), attempt.validation_issue_count, -index)
+
+    return min(enumerate(prior_attempts), key=score)[1]
 
 
 def _full_validation_issue_list(*issue_groups: object) -> tuple[str, ...]:
@@ -26865,7 +26894,8 @@ def _encode_validation_retry_feedback(
         feedback.append(item)
         feedback_chars += len(item)
 
-    failed_attempt = prior_attempts[-1]
+    failed_attempt = _best_validation_retry_attempt(prior_attempts)
+    assert failed_attempt is not None
     add(failed_attempt.error)
     issues = failed_attempt.validation_issues
     if isinstance(issues, Sequence) and not isinstance(issues, (str, bytes)):
@@ -26898,7 +26928,8 @@ def _encode_validation_retry_context(
         return _encode_validation_retry_feedback(
             prior_attempts
         ), initial_retry_candidate
-    candidate = _latest_validation_retry_candidate(prior_attempts)
+    selected_attempt = _best_validation_retry_attempt(prior_attempts)
+    candidate = selected_attempt.candidate if selected_attempt is not None else None
     if candidate is None:
         raise RuntimeError(
             "Immediately preceding validator-rejected candidate is unavailable"
@@ -29285,6 +29316,8 @@ def _run_encode_attempts_with_retries(
                     error=retry_error,
                     candidate=candidate,
                     validation_issues=execution.validation_retry_issues,
+                    validation_issue_count=len(execution.validation_issues),
+                    full_validation_issues=execution.validation_issues,
                 )
         if next_model is not None:
             action = "retrying" if next_model == current_model else "escalating"
@@ -29320,13 +29353,35 @@ def _run_encode_attempts_with_retries(
             final_issues = execution.validation_issues or (
                 _encode_outcome_issue(execution.result, outcome),
             )
+            terminal_candidate = _capture_validation_retry_candidate(
+                execution.result,
+                output_root=args.output,
+            )
+            terminal_failure = _FailedEncodeAttempt(
+                result=execution.result,
+                error=_encode_outcome_issue(execution.result, outcome),
+                candidate=terminal_candidate,
+                validation_issues=execution.validation_retry_issues,
+                validation_issue_count=len(final_issues),
+                full_validation_issues=final_issues,
+            )
+            selected_failure = _best_validation_retry_attempt(
+                (*failed_attempts, terminal_failure)
+            )
+            assert selected_failure is not None
+            selected_issues = (
+                selected_failure.full_validation_issues
+                or selected_failure.validation_issues
+                or (selected_failure.error,)
+            )
             emitted_candidate = _emit_final_rejected_candidate(
                 execution.result,
                 output_root=args.output,
                 destination=emit_destination,
                 citation=str(args.citation),
-                validation_issues=final_issues,
+                validation_issues=selected_issues,
                 attempt_count=len(failed_attempts) + 1,
+                candidate_override=selected_failure.candidate,
             )
             print(f"  final_rejected_candidate={emitted_candidate}")
         escalated = (

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1705"
+ENCODER_VERSION = "0.2.1706"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13857,6 +13857,74 @@ class TestCmdEncode:
             "escalation_model": DEFAULT_OPENAI_ESCALATION_MODEL,
         }
 
+    def test_encode_retries_from_best_candidate_when_later_attempt_regresses(
+        self, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+        )
+
+        _exit_code, _generated, _validated, mock_run, _validate, _apply = (
+            self._run_validator_escalation_case(
+                args,
+                [
+                    (False, ["best issue 1", "best issue 2"]),
+                    (False, [f"regression issue {index}" for index in range(9)]),
+                    (False, [f"later issue {index}" for index in range(6)]),
+                    (True, []),
+                ],
+            )
+        )
+
+        retry_candidates = [
+            call.kwargs["validation_retry_candidate"]
+            for call in mock_run.call_args_list
+        ]
+        assert retry_candidates[0] is None
+        for candidate in retry_candidates[1:]:
+            assert "rejected-attempt-1" in candidate.rulespec
+        assert mock_run.call_args_list[2].kwargs["validation_retry_feedback"] == (
+            "best issue 1",
+            "best issue 2",
+        )
+
+    def test_best_retry_candidate_penalizes_generated_yaml_failure(self):
+        import axiom_encode.cli as cli_module
+
+        source_candidate = cli_module._FailedEncodeAttempt(
+            result=SimpleNamespace(),
+            error="Generated RuleSpec failed CI validation",
+            candidate=cli_module.ValidationRetryCandidate(
+                rulespec="format: rulespec/v1\n# source-candidate\nrules: []\n",
+                tests="[]\n",
+            ),
+            validation_issues=tuple(f"source issue {index}" for index in range(8)),
+            validation_issue_count=8,
+        )
+        malformed_candidate = cli_module._FailedEncodeAttempt(
+            result=SimpleNamespace(),
+            error="Generated RuleSpec failed compile validation",
+            candidate=cli_module.ValidationRetryCandidate(
+                rulespec="malformed: [\n",
+                tests="[]\n",
+            ),
+            validation_issues=("[generated-yaml:parser] invalid YAML",),
+            validation_issue_count=1,
+        )
+
+        feedback, candidate = cli_module._encode_validation_retry_context(
+            [source_candidate, malformed_candidate],
+            initial_retry_candidate=None,
+        )
+
+        assert candidate is source_candidate.candidate
+        assert feedback[0] == source_candidate.error
+        assert "source issue 0" in feedback
+
     def test_encode_retry_scans_full_overlay_issue_list_for_actionable_feedback(
         self, tmp_path
     ):
@@ -14686,7 +14754,7 @@ rules:
         assert len(feedback) == 12
         assert all(issue in feedback for issue in actionable_seeded_issues)
 
-    def test_encode_emits_only_final_validator_rejected_candidate(self, tmp_path):
+    def test_encode_emits_best_validator_rejected_candidate(self, tmp_path):
         failed_candidate_root = tmp_path / "failed-encode"
         args = self._make_args(
             tmp_path,
@@ -14705,9 +14773,9 @@ rules:
             self._run_validator_escalation_case(
                 args,
                 [
-                    (False, ["terra attempt one"]),
-                    (False, ["terra attempt two"]),
-                    (False, ["sol attempt one"]),
+                    (False, ["best issue one", "best issue two"]),
+                    (False, [f"terra regression {index}" for index in range(9)]),
+                    (False, [f"sol regression {index}" for index in range(6)]),
                     (False, final_issues),
                 ],
             )
@@ -14728,19 +14796,19 @@ rules:
             relative_tests.as_posix(),
         }
         assert (
-            "rejected-attempt-4"
+            "rejected-attempt-1"
             in (failed_candidate_root / relative_rulespec).read_text()
         )
         assert (
-            "deterministic-post-repair-4"
+            "deterministic-post-repair-1"
             in (failed_candidate_root / relative_rulespec).read_text()
         )
         assert (
-            "historical-and-current-cases-4"
+            "historical-and-current-cases-1"
             in (failed_candidate_root / relative_tests).read_text()
         )
         assert (
-            "deterministic-post-repair-tests-4"
+            "deterministic-post-repair-tests-1"
             in (failed_candidate_root / relative_tests).read_text()
         )
         issues = json.loads((failed_candidate_root / "issues.json").read_text())
@@ -14748,7 +14816,7 @@ rules:
             "schema": "axiom-encode/failed-encode-candidate/v1",
             "citation": "26 USC 1(j)(2)",
             "path": relative_rulespec.as_posix(),
-            "issues": final_issues,
+            "issues": ["best issue one", "best issue two"],
             "rulespec_sha256": hashlib.sha256(
                 (failed_candidate_root / relative_rulespec).read_bytes()
             ).hexdigest(),

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1705"
+ENCODER_VERSION = "0.2.1706"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1705"
+ENCODER_VERSION = "0.2.1706"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1705"
+ENCODER_VERSION = "0.2.1706"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1705"
+ENCODER_VERSION = "0.2.1706"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1705"
+ENCODER_VERSION = "0.2.1706"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1705"
+ENCODER_VERSION = "0.2.1706"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1705"')
+        .startswith('__version__ = "0.2.1706"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1705"
+    assert encoder_package["version"] == "0.2.1706"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1705"
+    assert project["project"]["version"] == "0.2.1706"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1705"')
+        .startswith('__version__ = "0.2.1706"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1705"
+    assert encoder_package["version"] == "0.2.1706"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1705"
+    assert project["project"]["version"] == "0.2.1706"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1705"')
+        .startswith('__version__ = "0.2.1706"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1705"
+ENCODER_VERSION = "0.2.1706"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1705"
+version = "0.2.1706"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- rank validator-rejected retry candidates by full deterministic finding count
- keep retry feedback bound to the selected candidate and penalize parser/compile-invalid output
- emit the same best candidate for durable cross-run repair instead of the last regression

## Checks
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused retry and rejected-candidate tests (11 passed)
- full `pytest -q` running locally; GitHub CI pending

## Review-cycle note
The user explicitly waived requests to Max or Nikhil for this immigration recovery work and directed continuation without their review. No review is requested from either adviser. Merge remains gated on green CI and resolved actionable findings.