### PR TITLE
Export retained RuleSpec candidate for repair replay

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1152,6 +1152,8 @@ jobs:
               --axiom-rules-engine-path "$GITHUB_WORKSPACE/axiom-rules-engine"
               --policy-repo-path "$RULESPEC_CHECKOUT"
               --output "$RUNNER_TEMP/generated/$output_lane"
+              --emit-final-rejected-candidate \
+                "$RUNNER_TEMP/generated/$output_lane/final-rejected-candidate"
               --mode repo-augmented
               --require-complete-source-unit
               --db "$RUNNER_TEMP/encodings.db"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Axiom Encode will be documented here.
 
+- Export the strongest validator-rejected candidate from targeted signed
+  re-encodes and prefer its integrity-bound three-file artifact during repair
+  replay, while retaining compatibility with older failure artifacts.
+
 - Retain the validator-rejected RuleSpec candidate with the fewest full
   validation findings across model retries, keep its bounded feedback attached
   to that exact candidate, and emit the same best candidate for cross-run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1706"
+version = "0.2.1707"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -13,6 +13,17 @@ import tarfile
 from pathlib import Path, PurePosixPath
 
 SCHEMA = "axiom-encode/failed-reencode-diagnostics/v1"
+FAILED_CANDIDATE_SCHEMA = "axiom-encode/failed-encode-candidate/v1"
+FAILED_CANDIDATE_KEYS = {
+    "attempt_count",
+    "citation",
+    "encoder_version",
+    "issues",
+    "path",
+    "rulespec_sha256",
+    "schema",
+    "tests_sha256",
+}
 ATOMIC_ROOTS = frozenset(
     {"guidance", "manuals", "policies", "programs", "regulations", "statutes"}
 )
@@ -22,6 +33,8 @@ SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
 RUNNER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 JURISDICTION_PATTERN = re.compile(r"[a-z]{2,3}(?:-[a-z0-9]+)*")
+VERSION_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9.+_-]{0,127}")
+MAX_RETAINED_ISSUES = 4096
 CONTRACT = runpy.run_path(
     Path(__file__).parents[1] / "src/axiom_encode/repair_candidate_contract.py"
 )
@@ -143,6 +156,73 @@ def _verified_generated_file(
     ):
         raise ValueError(f"repair candidate digest mismatch: {relative_path}")
     return data
+
+
+def _retained_candidate(
+    bundle: tarfile.TarFile,
+    members: dict[str, tarfile.TarInfo],
+    files: dict[str, dict[str, object]],
+    *,
+    repair_lane: str,
+    expected_module: str,
+    citation: str,
+) -> tuple[bytes, bytes] | None:
+    root = f"{repair_lane}/final-rejected-candidate"
+    issues_path = f"{root}/issues.json"
+    candidate_path = f"{root}/{expected_module}"
+    tests_path = f"{root}/{expected_module.removesuffix('.yaml')}.test.yaml"
+    retained_paths = {path for path in files if path.startswith(f"{root}/")}
+    expected_paths = {issues_path, candidate_path, tests_path}
+    if retained_paths and retained_paths != expected_paths:
+        raise ValueError(
+            "retained repair candidate must bind exactly three files"
+        )
+    if issues_path not in files:
+        return None
+    try:
+        metadata = json.loads(
+            _verified_generated_file(bundle, members, files, issues_path).decode(
+                "utf-8", errors="strict"
+            )
+        )
+    except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("retained repair candidate metadata is invalid") from exc
+    if (
+        not isinstance(metadata, dict)
+        or set(metadata) != FAILED_CANDIDATE_KEYS
+        or metadata.get("schema") != FAILED_CANDIDATE_SCHEMA
+        or metadata.get("citation") != citation
+        or metadata.get("path") != expected_module
+        or not isinstance(metadata.get("encoder_version"), str)
+        or VERSION_PATTERN.fullmatch(metadata["encoder_version"]) is None
+        or not isinstance(metadata.get("attempt_count"), int)
+        or isinstance(metadata["attempt_count"], bool)
+        or metadata["attempt_count"] < 1
+        or not isinstance(metadata.get("issues"), list)
+        or not metadata["issues"]
+        or len(metadata["issues"]) > MAX_RETAINED_ISSUES
+        or any(not isinstance(issue, str) or not issue for issue in metadata["issues"])
+        or not isinstance(metadata.get("rulespec_sha256"), str)
+        or SHA256_PATTERN.fullmatch(metadata["rulespec_sha256"]) is None
+        or not isinstance(metadata.get("tests_sha256"), str)
+        or SHA256_PATTERN.fullmatch(metadata["tests_sha256"]) is None
+    ):
+        raise ValueError("retained repair candidate metadata is invalid")
+    candidate = _verified_generated_file(
+        bundle, members, files, candidate_path
+    )
+    tests = _verified_generated_file(
+        bundle,
+        members,
+        files,
+        tests_path,
+    )
+    if (
+        hashlib.sha256(candidate).hexdigest() != metadata["rulespec_sha256"]
+        or hashlib.sha256(tests).hexdigest() != metadata["tests_sha256"]
+    ):
+        raise ValueError("retained repair candidate digest mismatch")
+    return candidate, tests
 
 
 def _expected_module_path(country: str, replace_rulespec_path: str) -> str:
@@ -304,10 +384,24 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
         ):
             raise ValueError("final repair manifest identity is invalid")
 
-        candidate_path = f"{repair_lane}/{runner}/{expected_module}"
-        test_path = candidate_path.removesuffix(".yaml") + ".test.yaml"
-        candidate = _verified_generated_file(bundle, members, files, candidate_path)
-        tests = _verified_generated_file(bundle, members, files, test_path)
+        retained = _retained_candidate(
+            bundle,
+            members,
+            files,
+            repair_lane=repair_lane,
+            expected_module=expected_module,
+            citation=args.citation,
+        )
+        if retained is None:
+            candidate_path = f"{repair_lane}/{runner}/{expected_module}"
+            test_path = candidate_path.removesuffix(".yaml") + ".test.yaml"
+            candidate = _verified_generated_file(
+                bundle, members, files, candidate_path
+            )
+            tests = _verified_generated_file(bundle, members, files, test_path)
+        else:
+            candidate, tests = retained
+            runner = "retained-best"
 
     root = destination / runner
     output = root / expected_module

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1706"
+__version__ = "0.2.1707"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1706"
+ENCODER_VERSION = "0.2.1707"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -68,6 +68,61 @@ def _archive(tmp_path: Path, *, candidate: bytes | None = None) -> tuple[Path, d
     return archive, metadata
 
 
+def _add_retained_candidate(
+    source_archive: Path,
+    destination: Path,
+    metadata: dict,
+    *,
+    candidate: bytes,
+    tests: bytes = b"[]\n",
+) -> Path:
+    module = "statutes/42/1437c-1.yaml"
+    root = "target/final-rejected-candidate"
+    issues = json.dumps(
+        {
+            "schema": "axiom-encode/failed-encode-candidate/v1",
+            "citation": "us/statute/42/1437c\u20131",
+            "path": module,
+            "issues": ["best candidate still needs one repair"],
+            "rulespec_sha256": hashlib.sha256(candidate).hexdigest(),
+            "tests_sha256": hashlib.sha256(tests).hexdigest(),
+            "encoder_version": "0.2.1707",
+            "attempt_count": 4,
+        }
+    ).encode()
+    payloads = {
+        f"{root}/issues.json": issues,
+        f"{root}/{module}": candidate,
+        f"{root}/{module.removesuffix('.yaml')}.test.yaml": tests,
+    }
+    metadata["files"].extend(
+        {
+            "path": path,
+            "size": len(body),
+            "sha256": hashlib.sha256(body).hexdigest(),
+        }
+        for path, body in sorted(payloads.items())
+    )
+    metadata["files"].sort(key=lambda entry: entry["path"])
+    with (
+        tarfile.open(source_archive, "r") as source,
+        tarfile.open(destination, "w") as target,
+    ):
+        for member in source.getmembers():
+            extracted = source.extractfile(member)
+            assert extracted is not None
+            body = extracted.read()
+            if member.name == "metadata.json":
+                body = json.dumps(metadata).encode()
+                member.size = len(body)
+            target.addfile(member, io.BytesIO(body))
+        for path, body in payloads.items():
+            info = tarfile.TarInfo(f"generated/{path}")
+            info.size = len(body)
+            target.addfile(info, io.BytesIO(body))
+    return destination
+
+
 def _rewrite_metadata(
     source_archive: Path,
     destination: Path,
@@ -117,6 +172,47 @@ def test_extracts_checksum_bound_final_candidate(tmp_path):
     assert result["source_rulespec_ref"] == "d" * 40
     assert (root / result["path"]).read_text() == "format: rulespec/v1\nrules: []\n"
     assert (root / "statutes/42/1437c-1.test.yaml").read_text() == "[]\n"
+
+
+def test_prefers_integrity_bound_retained_best_candidate(tmp_path):
+    archive, metadata = _archive(tmp_path, candidate=b"final regression\n")
+    retained = b"strongest retained candidate\n"
+    replacement = _add_retained_candidate(
+        archive,
+        tmp_path / "retained.tar",
+        metadata,
+        candidate=retained,
+    )
+
+    result = extract_candidate(_args(tmp_path, replacement))
+
+    root = Path(result["root"])
+    assert result["runner"] == "retained-best"
+    assert (root / result["path"]).read_bytes() == retained
+
+
+def test_rejects_tampered_retained_best_candidate(tmp_path):
+    archive, metadata = _archive(tmp_path)
+    replacement = _add_retained_candidate(
+        archive,
+        tmp_path / "retained.tar",
+        metadata,
+        candidate=b"strongest retained candidate\n",
+    )
+    candidate_entry = next(
+        entry
+        for entry in metadata["files"]
+        if entry["path"].endswith("final-rejected-candidate/statutes/42/1437c-1.yaml")
+    )
+    candidate_entry["sha256"] = "0" * 64
+    tampered = _rewrite_metadata(
+        replacement,
+        tmp_path / "tampered-retained.tar",
+        metadata,
+    )
+
+    with pytest.raises(ValueError, match="digest mismatch"):
+        extract_candidate(_args(tmp_path, tampered))
 
 
 def test_state_rulespec_path_maps_to_lane_relative_candidate_path():

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1706"
+ENCODER_VERSION = "0.2.1707"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1706"
+ENCODER_VERSION = "0.2.1707"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1706"
+ENCODER_VERSION = "0.2.1707"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1706"
+ENCODER_VERSION = "0.2.1707"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1706"
+ENCODER_VERSION = "0.2.1707"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1706"
+ENCODER_VERSION = "0.2.1707"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1706"')
+        .startswith('__version__ = "0.2.1707"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1706"
+    assert encoder_package["version"] == "0.2.1707"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1706"
+    assert project["project"]["version"] == "0.2.1707"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1706"')
+        .startswith('__version__ = "0.2.1707"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1706"
+    assert encoder_package["version"] == "0.2.1707"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1706"
+    assert project["project"]["version"] == "0.2.1707"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1706"')
+        .startswith('__version__ = "0.2.1707"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1706"
+ENCODER_VERSION = "0.2.1707"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2459,6 +2459,11 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "--allowed-event-name workflow_dispatch" in command
     assert "--apply" in command
     assert "--require-complete-source-unit" in command
+    assert "--emit-final-rejected-candidate" in command
+    assert (
+        '"$RUNNER_TEMP/generated/$output_lane/final-rejected-candidate"'
+        in command
+    )
     assert "--skip-reviewers" not in command
     assert 'mktemp -d "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX"' in command
     assert 'review_finding_path="$review_finding_dir/review-finding.txt"' in command

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2460,10 +2460,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "--apply" in command
     assert "--require-complete-source-unit" in command
     assert "--emit-final-rejected-candidate" in command
-    assert (
-        '"$RUNNER_TEMP/generated/$output_lane/final-rejected-candidate"'
-        in command
-    )
+    assert '"$RUNNER_TEMP/generated/$output_lane/final-rejected-candidate"' in command
     assert "--skip-reviewers" not in command
     assert 'mktemp -d "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX"' in command
     assert 'review_finding_path="$review_finding_dir/review-finding.txt"' in command

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1706"
+version = "0.2.1707"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- make targeted signed re-encodes request durable emission of the strongest validator-rejected candidate
- preserve that exact three-file candidate in bounded failure diagnostics
- make repair replay prefer and independently verify the retained candidate while remaining compatible with older artifacts
- bump encoder version to 0.2.1707

## Checks
- `ruff check pyproject.toml src/axiom_encode scripts tests/test_extract_repair_candidate.py tests/test_signing_supervisor.py`
- `python -m compileall -q src/axiom_encode scripts`
- focused: 62 passed (`tests/test_extract_repair_candidate.py` plus targeted workflow contract test)
- broader workflow slice: 156 passed, 58 skipped, with 5 macOS-only AppleDouble tar inventory failures (`._*`) to be adjudicated by Linux CI

## Review cycle
This is the review-fix cycle for the immigration repair unblock. Per the user override, do not request Max or Nikhil; Nikhil is advisory only. Merge remains gated on green CI and no actionable automated findings.