### PR TITLE
Preserve omitted items across repair retries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1708"
+version = "0.2.1709"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1708"
+__version__ = "0.2.1709"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -8816,6 +8816,29 @@ def _run_single_eval(
             required_test_case_contracts=required_test_case_contracts,
         )
     )
+    if (
+        wrote_artifact
+        and validation_retry_candidate is not None
+        and not repair_candidate_tests_only
+    ):
+        overlay_repairs = _overlay_validation_retry_candidate(
+            output_file,
+            artifact_root=artifact_root,
+            candidate=validation_retry_candidate,
+        )
+        if overlay_repairs:
+            print("  repair_candidate_overlay:" + ",".join(overlay_repairs))
+        materialized_paths = frozenset(
+            set(materialized_paths)
+            | {
+                output_file,
+                *(
+                    {_rulespec_test_path(output_file)}
+                    if validation_retry_candidate.tests is not None
+                    else set()
+                ),
+            }
+        )
     wrote_artifact = wrote_artifact and output_file in materialized_paths
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
@@ -9826,9 +9849,11 @@ companion test file required by the task and deterministic validation.
         "and add the exact required witnesses.\n"
         if tests_only
         else (
-            "- Return complete replacement RuleSpec and companion test files, "
-            "including all preserved historical and current cases, not a patch "
-            "or partial fragment.\n"
+            "- Return syntactically complete RuleSpec and companion test YAML, but "
+            "you may omit unchanged named rules, imports, deferred outputs, and "
+            "named companion cases. The encoder overlays those omitted items from "
+            "the hash-bound candidate before validation. Re-emit the complete item "
+            "only when changing or replacing it; never emit prose or patch syntax.\n"
         )
     )
     return f"""
@@ -16751,6 +16776,168 @@ def _materialize_eval_artifact(
     if materialized_paths is not None:
         materialized_paths.add(expected_path)
     return True
+
+
+def _merge_named_yaml_items(
+    generated: object,
+    preserved: object,
+    *,
+    label: str,
+) -> tuple[list[object], list[str]]:
+    """Restore omitted hash-bound items while allowing explicit replacements."""
+
+    generated_items = list(generated) if isinstance(generated, list) else []
+    preserved_items = list(preserved) if isinstance(preserved, list) else []
+    generated_names: set[str] = set()
+    for item in generated_items:
+        if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+            raise ValueError(f"generated {label} items must have string names")
+        name = item["name"]
+        if name in generated_names:
+            raise ValueError(f"generated {label} contains duplicate name `{name}`")
+        generated_names.add(name)
+    preserved_names: set[str] = set()
+    restored: list[str] = []
+    for item in preserved_items:
+        if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+            raise ValueError(f"preserved {label} items must have string names")
+        name = item["name"]
+        if name in preserved_names:
+            raise ValueError(f"preserved {label} contains duplicate name `{name}`")
+        preserved_names.add(name)
+        if name not in generated_names:
+            generated_items.append(item)
+            generated_names.add(name)
+            restored.append(name)
+    return generated_items, restored
+
+
+def _overlay_validation_retry_candidate(
+    rulespec_file: Path,
+    *,
+    artifact_root: Path,
+    candidate: ValidationRetryCandidate,
+) -> tuple[str, ...]:
+    """Overlay partial repair output onto its integrity-bound prior candidate."""
+
+    try:
+        generated = yaml.safe_load(rulespec_file.read_text(encoding="utf-8"))
+        preserved = yaml.safe_load(candidate.rulespec)
+    except (OSError, UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError("repair overlay RuleSpec must be valid UTF-8 YAML") from exc
+    if not isinstance(generated, dict) or not isinstance(preserved, dict):
+        raise ValueError("repair overlay RuleSpec must be a YAML mapping")
+
+    repairs: list[str] = []
+    generated_imports = generated.get("imports", [])
+    preserved_imports = preserved.get("imports", [])
+    if not isinstance(generated_imports, list) or not isinstance(
+        preserved_imports, list
+    ):
+        raise ValueError("repair overlay imports must be lists")
+    imports = list(generated_imports)
+    for import_target in preserved_imports:
+        if not isinstance(import_target, str):
+            raise ValueError("preserved repair imports must be strings")
+        if import_target not in imports:
+            imports.append(import_target)
+            repairs.append(f"import:{import_target}")
+    if imports:
+        generated["imports"] = imports
+
+    generated_rules = generated.get("rules")
+    generated_rule_names = (
+        {item.get("name") for item in generated_rules if isinstance(item, dict)}
+        if isinstance(generated_rules, list)
+        else set()
+    )
+    rules, restored_rules = _merge_named_yaml_items(
+        generated_rules, preserved.get("rules"), label="rules"
+    )
+    generated["rules"] = rules
+    repairs.extend(f"rule:{name}" for name in restored_rules)
+
+    generated_module = generated.get("module")
+    preserved_module = preserved.get("module")
+    if isinstance(generated_module, dict) and isinstance(preserved_module, dict):
+        generated_deferred = generated_module.get("deferred_outputs", [])
+        preserved_deferred = preserved_module.get("deferred_outputs", [])
+        if not isinstance(generated_deferred, list) or not isinstance(
+            preserved_deferred, list
+        ):
+            raise ValueError("repair overlay deferred outputs must be lists")
+        generated_outputs: set[str] = set()
+        for item in generated_deferred:
+            if not isinstance(item, dict) or not isinstance(item.get("output"), str):
+                raise ValueError("generated deferred outputs must name an output")
+            output = item["output"]
+            if output in generated_outputs:
+                raise ValueError(
+                    f"generated deferred outputs contains duplicate output `{output}`"
+                )
+            generated_outputs.add(output)
+        deferred = list(generated_deferred)
+        for item in preserved_deferred:
+            if not isinstance(item, dict) or not isinstance(item.get("output"), str):
+                raise ValueError("preserved deferred outputs must name an output")
+            output = item["output"]
+            output_name = output.rsplit("#", 1)[-1]
+            if output_name in generated_rule_names:
+                repairs.append(f"resolved_deferred_output:{output}")
+                continue
+            if output not in generated_outputs:
+                deferred.append(item)
+                generated_outputs.add(output)
+                repairs.append(f"deferred_output:{output}")
+        if deferred:
+            generated_module["deferred_outputs"] = deferred
+
+    test_file = _rulespec_test_path(rulespec_file)
+    if candidate.tests is not None:
+        try:
+            generated_tests = (
+                yaml.safe_load(test_file.read_text(encoding="utf-8"))
+                if test_file.exists()
+                else []
+            )
+            preserved_tests = yaml.safe_load(candidate.tests)
+        except (OSError, UnicodeError, yaml.YAMLError, RecursionError) as exc:
+            raise ValueError("repair overlay tests must be valid UTF-8 YAML") from exc
+        generated_wrapper = isinstance(generated_tests, dict)
+        preserved_wrapper = isinstance(preserved_tests, dict)
+        if generated_wrapper:
+            if set(generated_tests) != {"cases"}:
+                raise ValueError("generated companion test mapping must contain cases")
+            generated_cases = generated_tests["cases"]
+        else:
+            generated_cases = generated_tests
+        if preserved_wrapper:
+            if set(preserved_tests) != {"cases"}:
+                raise ValueError("preserved companion test mapping must contain cases")
+            preserved_cases = preserved_tests["cases"]
+        else:
+            preserved_cases = preserved_tests
+        if generated_wrapper != preserved_wrapper and test_file.exists():
+            raise ValueError("repair overlay cannot change companion test container")
+        merged_tests, restored_tests = _merge_named_yaml_items(
+            generated_cases, preserved_cases, label="companion tests"
+        )
+        merged_test_payload: object = (
+            {"cases": merged_tests} if preserved_wrapper else merged_tests
+        )
+        _write_eval_artifact_text(
+            test_file,
+            yaml.safe_dump(merged_test_payload, sort_keys=False, allow_unicode=True),
+            artifact_root,
+        )
+        repairs.extend(f"test:{name}" for name in restored_tests)
+
+    _write_eval_artifact_text(
+        rulespec_file,
+        yaml.safe_dump(generated, sort_keys=False, allow_unicode=True),
+        artifact_root,
+    )
+    return tuple(repairs)
 
 
 def _preserves_companion_test_cases(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1708"
+ENCODER_VERSION = "0.2.1709"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -846,7 +846,84 @@ def test_retry_candidate_formatter_explicitly_handles_missing_tests():
     )
 
     assert "No companion test file was present" in section
-    assert "complete replacement RuleSpec and companion test files" in section
+    assert "you may omit unchanged named rules" in section
+
+
+def test_repair_candidate_overlay_restores_omitted_named_items(tmp_path):
+    artifact_root = tmp_path / "generated"
+    rulespec_file = artifact_root / "regulations" / "section.yaml"
+    rulespec_file.parent.mkdir(parents=True)
+    rulespec_file.write_text(
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  deferred_outputs:\n"
+        "    - output: us:section#new_deferred\n"
+        "      reason: new\n"
+        "imports:\n"
+        "  - us:source#new\n"
+        "rules:\n"
+        "  - name: existing_changed\n"
+        "    kind: parameter\n"
+        "    dtype: Count\n"
+        "    versions: [{effective_from: '2026-01-01', formula: 2}]\n"
+        "  - name: added\n"
+        "    kind: parameter\n"
+        "    dtype: Count\n"
+        "    versions: [{effective_from: '2026-01-01', formula: 3}]\n",
+        encoding="utf-8",
+    )
+    rulespec_file.with_suffix(".test.yaml").write_text(
+        "- name: added_case\n  period: 2026-01\n  input: {}\n  output: {}\n",
+        encoding="utf-8",
+    )
+    candidate = ValidationRetryCandidate(
+        rulespec=(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  deferred_outputs:\n"
+            "    - output: us:section#preserved_deferred\n"
+            "      reason: preserved\n"
+            "    - output: us:section#added\n"
+            "      reason: replaced by the generated rule\n"
+            "imports:\n"
+            "  - us:source#preserved\n"
+            "rules:\n"
+            "  - name: existing_changed\n"
+            "    kind: parameter\n"
+            "    dtype: Count\n"
+            "    versions: [{effective_from: '2026-01-01', formula: 1}]\n"
+            "  - name: omitted\n"
+            "    kind: parameter\n"
+            "    dtype: Count\n"
+            "    versions: [{effective_from: '2026-01-01', formula: 4}]\n"
+        ),
+        tests=(
+            "- name: preserved_case\n  period: 2026-01\n  input: {}\n  output: {}\n"
+        ),
+    )
+
+    repairs = evals_module._overlay_validation_retry_candidate(
+        rulespec_file,
+        artifact_root=artifact_root,
+        candidate=candidate,
+    )
+
+    payload = yaml.safe_load(rulespec_file.read_text(encoding="utf-8"))
+    rules = {rule["name"]: rule for rule in payload["rules"]}
+    assert rules["existing_changed"]["versions"][0]["formula"] == 2
+    assert set(rules) == {"existing_changed", "added", "omitted"}
+    assert payload["imports"] == ["us:source#new", "us:source#preserved"]
+    assert {item["output"] for item in payload["module"]["deferred_outputs"]} == {
+        "us:section#new_deferred",
+        "us:section#preserved_deferred",
+    }
+    tests = yaml.safe_load(
+        rulespec_file.with_suffix(".test.yaml").read_text(encoding="utf-8")
+    )
+    assert {case["name"] for case in tests} == {"added_case", "preserved_case"}
+    assert "rule:omitted" in repairs
+    assert "test:preserved_case" in repairs
+    assert "resolved_deferred_output:us:section#added" in repairs
 
 
 def test_run_model_eval_appends_repair_parameters_after_existing_public_parameters():

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -86,7 +86,7 @@ def _add_retained_candidate(
             "issues": ["best candidate still needs one repair"],
             "rulespec_sha256": hashlib.sha256(candidate).hexdigest(),
             "tests_sha256": hashlib.sha256(tests).hexdigest(),
-            "encoder_version": "0.2.1708",
+            "encoder_version": "0.2.1709",
             "attempt_count": 4,
         }
     ).encode()

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1708"
+ENCODER_VERSION = "0.2.1709"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1708"
+ENCODER_VERSION = "0.2.1709"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1708"
+ENCODER_VERSION = "0.2.1709"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1708"
+ENCODER_VERSION = "0.2.1709"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1708"
+ENCODER_VERSION = "0.2.1709"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1708"
+ENCODER_VERSION = "0.2.1709"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1708"')
+        .startswith('__version__ = "0.2.1709"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1708"
+    assert encoder_package["version"] == "0.2.1709"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1708"
+    assert project["project"]["version"] == "0.2.1709"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1708"')
+        .startswith('__version__ = "0.2.1709"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1708"
+    assert encoder_package["version"] == "0.2.1709"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1708"
+    assert project["project"]["version"] == "0.2.1709"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1708"')
+        .startswith('__version__ = "0.2.1709"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1708"
+ENCODER_VERSION = "0.2.1709"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1708"
+version = "0.2.1709"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- overlay omitted named rules, imports, deferred outputs, and companion cases from the integrity-bound rejected candidate
- let explicit generated replacements win and retire a preserved deferral when its output is implemented
- keep repair retries within model output limits without losing prior valid work
- bump encoder to 0.2.1709

## Checks
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused repair-candidate tests: 4 passed
- focused version/registry tests: passed

## Cycle
Independent review and CI pending.