### PR TITLE
Normalize repair deferrals to canonical source roots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1710"
+version = "0.2.1711"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1711"
+version = "0.2.1712"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1711"
+__version__ = "0.2.1712"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1710"
+__version__ = "0.2.1711"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -116,6 +116,7 @@ from .policyengine_runtime import (
 )
 from .pricing import estimate_usage_cost_usd
 from .source_completeness import (
+    _rulespec_target_base,
     collect_artifact_numeric_values,
 )
 from .validator_pipeline import (
@@ -16812,6 +16813,45 @@ def _merge_named_yaml_items(
     return generated_items, restored
 
 
+def _normalize_repair_deferred_source_roots(
+    deferred_outputs: object,
+    *,
+    rulespec_file: Path,
+    artifact_root: Path,
+    corpus_citation_path: str,
+) -> tuple[list[object], list[str]]:
+    """Map destination-root deferrals onto the integrity-bound source root."""
+
+    if not isinstance(deferred_outputs, list):
+        raise ValueError("repair overlay deferred outputs must be lists")
+    try:
+        relative_target = rulespec_file.relative_to(artifact_root).with_suffix("")
+    except ValueError as exc:
+        raise ValueError("repair overlay RuleSpec must be inside artifact root") from exc
+    source_root = _rulespec_target_base(corpus_citation_path)
+    jurisdiction = source_root.partition(":")[0]
+    destination_root = f"{jurisdiction}:{relative_target.as_posix()}"
+    normalized: list[object] = []
+    repairs: list[str] = []
+    for item in deferred_outputs:
+        if not isinstance(item, dict) or not isinstance(item.get("output"), str):
+            raise ValueError("repair overlay deferred outputs must name an output")
+        output = item["output"]
+        output_path, separator, fragment = output.partition("#")
+        if output_path == destination_root or output_path.startswith(
+            f"{destination_root}/"
+        ):
+            suffix = output_path[len(destination_root) :]
+            corrected = f"{source_root}{suffix}"
+            if separator:
+                corrected = f"{corrected}#{fragment}"
+            if corrected != output:
+                item = {**item, "output": corrected}
+                repairs.append(f"deferred_output_source_root:{output}->{corrected}")
+        normalized.append(item)
+    return normalized, repairs
+
+
 def _overlay_validation_retry_candidate(
     rulespec_file: Path,
     *,
@@ -16860,9 +16900,34 @@ def _overlay_validation_retry_candidate(
     generated_module = generated.get("module")
     preserved_module = preserved.get("module")
     if isinstance(generated_module, dict) and isinstance(preserved_module, dict):
+        preserved_source_verification = preserved_module.get("source_verification")
+        corpus_citation_path = (
+            preserved_source_verification.get("corpus_citation_path")
+            if isinstance(preserved_source_verification, dict)
+            else None
+        )
         generated_deferred = generated_module.get("deferred_outputs", [])
         preserved_deferred = preserved_module.get("deferred_outputs", [])
-        if not isinstance(generated_deferred, list) or not isinstance(
+        if isinstance(corpus_citation_path, str) and corpus_citation_path:
+            generated_deferred, generated_root_repairs = (
+                _normalize_repair_deferred_source_roots(
+                    generated_deferred,
+                    rulespec_file=rulespec_file,
+                    artifact_root=artifact_root,
+                    corpus_citation_path=corpus_citation_path,
+                )
+            )
+            preserved_deferred, preserved_root_repairs = (
+                _normalize_repair_deferred_source_roots(
+                    preserved_deferred,
+                    rulespec_file=rulespec_file,
+                    artifact_root=artifact_root,
+                    corpus_citation_path=corpus_citation_path,
+                )
+            )
+            repairs.extend(generated_root_repairs)
+            repairs.extend(preserved_root_repairs)
+        elif not isinstance(generated_deferred, list) or not isinstance(
             preserved_deferred, list
         ):
             raise ValueError("repair overlay deferred outputs must be lists")

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -16827,7 +16827,9 @@ def _normalize_repair_deferred_source_roots(
     try:
         relative_target = rulespec_file.relative_to(artifact_root).with_suffix("")
     except ValueError as exc:
-        raise ValueError("repair overlay RuleSpec must be inside artifact root") from exc
+        raise ValueError(
+            "repair overlay RuleSpec must be inside artifact root"
+        ) from exc
     source_root = _rulespec_target_base(corpus_citation_path)
     jurisdiction = source_root.partition(":")[0]
     destination_root = f"{jurisdiction}:{relative_target.as_posix()}"

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1710"
+ENCODER_VERSION = "0.2.1712"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -926,6 +926,64 @@ def test_repair_candidate_overlay_restores_omitted_named_items(tmp_path):
     assert "resolved_deferred_output:us:section#added" in repairs
 
 
+def test_repair_candidate_overlay_normalizes_destination_root_deferrals(tmp_path):
+    artifact_root = tmp_path / "generated"
+    rulespec_file = artifact_root / "regulations" / "7-cfr" / "273" / "4.yaml"
+    rulespec_file.parent.mkdir(parents=True)
+    rulespec_file.write_text(
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_path: us/regulation/7/273/4\n"
+        "  deferred_outputs:\n"
+        "    - output: us:regulations/7-cfr/273/4/a/6/ii/h#generated\n"
+        "      reason: generated\n"
+        "rules: []\n",
+        encoding="utf-8",
+    )
+    candidate = ValidationRetryCandidate(
+        rulespec=(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us/regulation/7/273/4\n"
+            "  deferred_outputs:\n"
+            "    - output: us:regulations/7-cfr/273/4/a/6/ii/h#generated\n"
+            "      reason: preserved duplicate\n"
+            "    - output: us:regulations/7-cfr/273/4/c/1#preserved\n"
+            "      reason: preserved\n"
+            "    - output: us:statutes/8/1641/b#external_dependency\n"
+            "      reason: external\n"
+            "rules: []\n"
+        ),
+    )
+
+    repairs = evals_module._overlay_validation_retry_candidate(
+        rulespec_file,
+        artifact_root=artifact_root,
+        candidate=candidate,
+    )
+
+    payload = yaml.safe_load(rulespec_file.read_text(encoding="utf-8"))
+    deferred = payload["module"]["deferred_outputs"]
+    assert deferred == [
+        {
+            "output": "us:regulations/7/273/4/a/6/ii/h#generated",
+            "reason": "generated",
+        },
+        {
+            "output": "us:regulations/7/273/4/c/1#preserved",
+            "reason": "preserved",
+        },
+        {
+            "output": "us:statutes/8/1641/b#external_dependency",
+            "reason": "external",
+        },
+    ]
+    assert not any("7-cfr" in item["output"] for item in deferred)
+    assert any(repair.startswith("deferred_output_source_root:") for repair in repairs)
+
+
 def test_run_model_eval_appends_repair_parameters_after_existing_public_parameters():
     parameters = list(inspect.signature(run_model_eval).parameters)
 

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -86,7 +86,7 @@ def _add_retained_candidate(
             "issues": ["best candidate still needs one repair"],
             "rulespec_sha256": hashlib.sha256(candidate).hexdigest(),
             "tests_sha256": hashlib.sha256(tests).hexdigest(),
-            "encoder_version": "0.2.1710",
+            "encoder_version": "0.2.1712",
             "attempt_count": 4,
         }
     ).encode()

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1710"
+ENCODER_VERSION = "0.2.1712"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1710"
+ENCODER_VERSION = "0.2.1712"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1710"
+ENCODER_VERSION = "0.2.1712"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1710"
+ENCODER_VERSION = "0.2.1712"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1710"
+ENCODER_VERSION = "0.2.1712"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1710"
+ENCODER_VERSION = "0.2.1712"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1710"')
+        .startswith('__version__ = "0.2.1712"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1710"
+    assert encoder_package["version"] == "0.2.1712"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1710"
+    assert project["project"]["version"] == "0.2.1712"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1710"')
+        .startswith('__version__ = "0.2.1712"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1710"
+    assert encoder_package["version"] == "0.2.1712"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1710"
+    assert project["project"]["version"] == "0.2.1712"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1710"')
+        .startswith('__version__ = "0.2.1712"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1710"
+ENCODER_VERSION = "0.2.1712"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1710"
+version = "0.2.1711"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1711"
+version = "0.2.1712"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- normalize repair-candidate deferred outputs from the destination file root to the integrity-bound canonical corpus root
- normalize generated and preserved overlay deferrals before deduplication
- preserve fragments, suffixes, and unrelated external dependency roots

## Why
The 7 CFR 273.4 immigration repair artifact used `us:regulations/7-cfr/273/4/...` while its verified corpus citation resolves to `us:regulations/7/273/4/...`. The completeness validator therefore ignored all 40 deferrals and reported a misleading 44-issue baseline. This change makes those deferrals visible to validation without weakening any completeness checks.

## Verification
- exact rejected artifact: 40/40 destination-root deferrals normalized; 0 stale roots remain
- validator replay remains fail-closed and exposes the 40 imprecise deferral reasons rather than treating them as coverage
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `pytest -q tests/test_evals.py` (781 passed)

## Cycle
Independent Codex review requested after opening.