### PR TITLE
Fix source completeness for immigration rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1722"
+version = "0.2.1723"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1713"
+version = "0.2.1714"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1720"
+version = "0.2.1721"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1716"
+version = "0.2.1717"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1728"
+version = "0.2.1729"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1718"
+version = "0.2.1719"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1723"
+version = "0.2.1724"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1715"
+version = "0.2.1716"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1724"
+version = "0.2.1725"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1725"
+version = "0.2.1726"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1721"
+version = "0.2.1722"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1719"
+version = "0.2.1720"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1717"
+version = "0.2.1718"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1714"
+version = "0.2.1715"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1726"
+version = "0.2.1727"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1727"
+version = "0.2.1728"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -174,9 +174,7 @@ def _retained_candidate(
     retained_paths = {path for path in files if path.startswith(f"{root}/")}
     expected_paths = {issues_path, candidate_path, tests_path}
     if retained_paths and retained_paths != expected_paths:
-        raise ValueError(
-            "retained repair candidate must bind exactly three files"
-        )
+        raise ValueError("retained repair candidate must bind exactly three files")
     if issues_path not in files:
         return None
     try:
@@ -208,9 +206,7 @@ def _retained_candidate(
         or SHA256_PATTERN.fullmatch(metadata["tests_sha256"]) is None
     ):
         raise ValueError("retained repair candidate metadata is invalid")
-    candidate = _verified_generated_file(
-        bundle, members, files, candidate_path
-    )
+    candidate = _verified_generated_file(bundle, members, files, candidate_path)
     tests = _verified_generated_file(
         bundle,
         members,
@@ -270,9 +266,7 @@ def _repair_lane_for_atomic_source(
                 "atomic_source_input"
             ) from exc
         if split != expected:
-            raise ValueError(
-                "repair artifact metadata mismatch: atomic_source_input"
-            )
+            raise ValueError("repair artifact metadata mismatch: atomic_source_input")
         return "target-preflight" if expected["source_bundle"] else "target"
     if expected != {
         "canonical_refresh_bundle": [],
@@ -342,9 +336,7 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
                 raise ValueError(
                     f"repair artifact is not a compatible single-target run: {field}"
                 )
-        repair_lane = _repair_lane_for_atomic_source(
-            metadata, args.atomic_source_json
-        )
+        repair_lane = _repair_lane_for_atomic_source(metadata, args.atomic_source_json)
         if metadata.get("workflow_run_attempt") != 1:
             raise ValueError("repair artifact must come from workflow attempt 1")
         if metadata.get("failed_steps") != ["encode_apply"]:
@@ -395,9 +387,7 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
         if retained is None:
             candidate_path = f"{repair_lane}/{runner}/{expected_module}"
             test_path = candidate_path.removesuffix(".yaml") + ".test.yaml"
-            candidate = _verified_generated_file(
-                bundle, members, files, candidate_path
-            )
+            candidate = _verified_generated_file(bundle, members, files, candidate_path)
             tests = _verified_generated_file(bundle, members, files, test_path)
         else:
             candidate, tests = retained

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1721"
+__version__ = "0.2.1722"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1726"
+__version__ = "0.2.1727"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1717"
+__version__ = "0.2.1718"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1718"
+__version__ = "0.2.1719"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1713"
+__version__ = "0.2.1714"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1716"
+__version__ = "0.2.1717"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1722"
+__version__ = "0.2.1723"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1724"
+__version__ = "0.2.1725"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1714"
+__version__ = "0.2.1715"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1727"
+__version__ = "0.2.1728"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1728"
+__version__ = "0.2.1729"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1725"
+__version__ = "0.2.1726"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1719"
+__version__ = "0.2.1720"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1723"
+__version__ = "0.2.1724"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1715"
+__version__ = "0.2.1716"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1720"
+__version__ = "0.2.1721"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -14936,6 +14936,7 @@ def _companion_test_issues(
         )
         missing_exception_branches = _unwitnessed_exception_branches(
             paired_exception_branches,
+            principal_rules=principal_rules,
             principal_rule_paths=principal_rule_paths,
             toggled_exception_selectors=toggled_exception_selectors,
             extract_numeric_occurrences=extract_numeric_occurrences,
@@ -21155,14 +21156,29 @@ def _formula_node_boundary_value(
         value = formula_environment.get(node.id)
         if _rulespec_runtime_decimal(value) is not None:
             return float(value)
-    boundary_nodes = [
-        candidate
-        for candidate in ast.walk(node)
-        if {name.id for name in ast.walk(candidate) if isinstance(name, ast.Name)}
-        & boundary_names
-    ]
-    for candidate in reversed(boundary_nodes):
-        value = _evaluate_condition_expression(candidate, formula_environment)
+    node_names = {
+        candidate.id for candidate in ast.walk(node) if isinstance(candidate, ast.Name)
+    }
+    boundary_factor: ast.AST | None = None
+    if node_names and node_names.issubset(boundary_names):
+        boundary_factor = node
+    elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mult):
+        for candidate, base in ((node.left, node.right), (node.right, node.left)):
+            candidate_names = {
+                name.id for name in ast.walk(candidate) if isinstance(name, ast.Name)
+            }
+            base_names = {
+                name.id for name in ast.walk(base) if isinstance(name, ast.Name)
+            }
+            if (
+                candidate_names
+                and candidate_names.issubset(boundary_names)
+                and not base_names.intersection(boundary_names)
+            ):
+                boundary_factor = candidate
+                break
+    if boundary_factor is not None:
+        value = _evaluate_condition_expression(boundary_factor, formula_environment)
         numeric_value = _rulespec_runtime_decimal(value)
         if numeric_value is not None and numeric_value_is_grounded(
             float(numeric_value),
@@ -23239,6 +23255,7 @@ def _rounding_source_formula_branches(
 def _unwitnessed_exception_branches(
     exception_branches: Sequence[SourceStructureBranch],
     *,
+    principal_rules: dict[str, dict[str, Any]],
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
     toggled_exception_selectors: set[_ExceptionWitness],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
@@ -23246,6 +23263,7 @@ def _unwitnessed_exception_branches(
     candidate_witnesses = {
         branch: _exception_witnesses_for_branch(
             branch,
+            principal_rules=principal_rules,
             principal_rule_paths=principal_rule_paths,
             toggled_exception_selectors=toggled_exception_selectors,
             extract_numeric_occurrences=extract_numeric_occurrences,
@@ -23311,6 +23329,7 @@ def _unconditional_nonapplicability_witnesses(
 def _exception_witnesses_for_branch(
     branch: SourceStructureBranch,
     *,
+    principal_rules: dict[str, dict[str, Any]],
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
     toggled_exception_selectors: set[_ExceptionWitness],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
@@ -23349,8 +23368,18 @@ def _exception_witnesses_for_branch(
         and _source_exception_selector_is_relevant(
             condition_text,
             witness.selector_name,
+            supporting_texts=tuple(
+                excerpt
+                for _citation_path, excerpt in _rule_source_excerpts(
+                    principal_rules[witness.rule_name]
+                )
+            ),
         )
-        and _exception_witness_satisfies_requirement(witness, requirement)
+        and _exception_witness_satisfies_requirement(
+            witness,
+            requirement,
+            rule=principal_rules[witness.rule_name],
+        )
     }
 
 
@@ -23626,7 +23655,12 @@ def _exception_reverses_negative_proposition(text: str) -> bool:
     )
 
 
-def _source_exception_selector_is_relevant(text: str, name: str) -> bool:
+def _source_exception_selector_is_relevant(
+    text: str,
+    name: str,
+    *,
+    supporting_texts: Sequence[str] = (),
+) -> bool:
     """Reject formula toggles with no semantic link to the source exception."""
 
     normalized_name = _normalized_selector_name(name)
@@ -23636,7 +23670,13 @@ def _source_exception_selector_is_relevant(text: str, name: str) -> bool:
         r"\b(?:criteria|conditions|requirements)\b",
         collapsed,
     ):
-        return True
+        return any(
+            _source_selector_concept_matches(
+                _collapse_text(supporting_text).lower(),
+                normalized_name,
+            )
+            for supporting_text in supporting_texts
+        )
     if _source_selector_concept_matches(collapsed, normalized_name):
         return True
     return any(
@@ -24105,26 +24145,23 @@ def _selector_identifier_negation_count(normalized_name: str) -> int:
 def _exception_witness_satisfies_requirement(
     witness: _ExceptionWitness,
     requirement: str,
+    *,
+    rule: Mapping[str, Any] | None = None,
 ) -> bool:
-    rule_name_tokens = _normalized_selector_name(witness.rule_name).split("_")
-    output_negation_count = sum(
-        token
-        in {
-            "absent",
-            "disqualified",
-            "ineligible",
-            "lacking",
-            "missing",
-            "no",
-            "non",
-            "not",
-            "unqualified",
-            "without",
-        }
-        for index, token in enumerate(rule_name_tokens)
-        if index > 0 or len(rule_name_tokens) == 1
+    semantic_texts = (
+        (
+            str(rule.get("description") or ""),
+            *(excerpt for _citation_path, excerpt in _rule_source_excerpts(rule)),
+        )
+        if rule is not None
+        else ()
     )
-    effective_blocks = witness.blocks != bool(output_negation_count % 2)
+    negative_output = any(
+        _source_negative_effect_matches(text) for text in semantic_texts if text
+    ) and not any(
+        _source_positive_effect_matches(text) for text in semantic_texts if text
+    )
+    effective_blocks = witness.blocks != negative_output
     if requirement == "zero":
         return witness.zeroes
     if requirement == "enable":

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -21255,9 +21255,9 @@ def _source_percentage_base_matches(
         trailing_text,
         flags=re.IGNORECASE,
     )
-    searchable_text = (
-        explicit_base.group("base") if explicit_base is not None else source_text
-    )
+    if explicit_base is None:
+        return False
+    searchable_text = explicit_base.group("base")
     collapsed = _collapse_text(searchable_text).lower()
     concept_tokens = tuple(
         token
@@ -23702,12 +23702,12 @@ def _source_negative_output_predicate_matches(
 
     return tuple(
         re.finditer(
-            r"\b(?:shall|will|is|are|becomes?)\s+(?:be\s+)?"
+            r"\b(?:must|shall|will|is|are|becomes?)\s+(?:be\s+)?"
             r"(?:ineligible|excluded|disqualified|unqualified)\b|"
-            r"\b(?:must|shall|will)\s+(?:be\s+)?"
-            r"(?:classif\w*|deem\w*|treat\w*)[^.;]{0,80}\bas\s+"
+            r"\b(?:must|shall|will)\s+classif\w*[^.;]{0,80}\bas\s+"
             r"(?:an?\s+)?(?:ineligible|excluded|disqualified|unqualified)\b|"
-            r"\b(?:is|are)\s+(?:classified|deemed|treated)\s+as\s+"
+            r"\b(?:must|shall|will|is|are)\s+(?:be\s+)?"
+            r"(?:classif\w*\s+as|deem\w*(?:\s+as)?|treat\w*(?:\s+as)?)\s+"
             r"(?:an?\s+)?(?:ineligible|excluded|disqualified|unqualified)\b|"
             r"\b(?:shall|does|is|are|will)\s+not\s+(?:be\s+)?"
             r"(?:apply|eligible|qualified|allowed|entitled)\b|"

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -21182,9 +21182,10 @@ def _formula_node_boundary_value(
                 and not base_names.intersection(boundary_names)
                 and source_text is not None
                 and any(
-                    _source_selector_concept_matches(
-                        _collapse_text(source_text).lower(),
-                        _normalized_selector_name(base_name),
+                    _source_percentage_base_matches(
+                        source_text,
+                        boundary=boundary,
+                        base_name=base_name,
                     )
                     for base_name in base_names
                 )
@@ -21228,6 +21229,31 @@ def _formula_node_boundary_value(
             )
         ),
         None,
+    )
+
+
+def _source_percentage_base_matches(
+    source_text: str,
+    *,
+    boundary: NumericOccurrenceLike,
+    base_name: str,
+) -> bool:
+    """Require an explicit ``percent of`` base when the source provides one."""
+
+    trailing_text = source_text[boundary.end :]
+    explicit_base = re.match(
+        r"\s+of\b(?P<base>[^.;:]{1,160})",
+        trailing_text,
+        flags=re.IGNORECASE,
+    )
+    searchable_text = (
+        explicit_base.group("base") if explicit_base is not None else source_text
+    )
+    return bool(
+        _source_selector_concept_matches(
+            _collapse_text(searchable_text).lower(),
+            _normalized_selector_name(base_name),
+        )
     )
 
 
@@ -24165,6 +24191,10 @@ def _selector_identifier_negation_count(normalized_name: str) -> int:
             "no",
             "non",
             "not",
+            "inability",
+            "unable",
+            "unwilling",
+            "unwillingness",
             "without",
         }
         for token in normalized_name.split("_")

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -23727,9 +23727,9 @@ def _rule_has_negative_output_semantics(
     description = str(rule.get("description") or "").strip() if rule else ""
     if description:
         output_clause = _described_output_clause(description)
-        return bool(_source_negative_output_predicate_matches(output_clause)) and not bool(
-            _source_positive_effect_matches(output_clause)
-        )
+        return bool(
+            _source_negative_output_predicate_matches(output_clause)
+        ) and not bool(_source_positive_effect_matches(output_clause))
     name = str(rule.get("name") or fallback_name) if rule else fallback_name
     normalized_name = re.sub(r"[^a-z0-9]+", "_", name.casefold()).strip("_")
     return bool(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -17531,7 +17531,7 @@ def _formula_operation_kinds(text: str) -> set[str]:
             r"\b(?:doppelte|zweifache|dreifache|twice)\b)"
         ),
         "divide": (
-            r"(?:(?<![a-z])/(?![a-z])|\bgeteilt\b|\bteilen\b|\bdivided\b|"
+            r"(?:(?<!\band)/(?!or\b)|\bgeteilt\b|\bteilen\b|\bdivided\b|"
             r"\bhälfte\b|\bhalbier\w*\b|\bhalbierung\b|\bhalf\s+of\b)"
         ),
     }
@@ -21155,11 +21155,14 @@ def _formula_node_boundary_value(
         value = formula_environment.get(node.id)
         if _rulespec_runtime_decimal(value) is not None:
             return float(value)
-    node_names = {
-        candidate.id for candidate in ast.walk(node) if isinstance(candidate, ast.Name)
-    }
-    if node_names & boundary_names:
-        value = _evaluate_condition_expression(node, formula_environment)
+    boundary_nodes = [
+        candidate
+        for candidate in ast.walk(node)
+        if {name.id for name in ast.walk(candidate) if isinstance(name, ast.Name)}
+        & boundary_names
+    ]
+    for candidate in reversed(boundary_nodes):
+        value = _evaluate_condition_expression(candidate, formula_environment)
         numeric_value = _rulespec_runtime_decimal(value)
         if numeric_value is not None and numeric_value_is_grounded(
             float(numeric_value),
@@ -24103,9 +24106,25 @@ def _exception_witness_satisfies_requirement(
     witness: _ExceptionWitness,
     requirement: str,
 ) -> bool:
-    effective_blocks = witness.blocks != bool(
-        _selector_identifier_negation_count(witness.rule_name) % 2
+    rule_name_tokens = _normalized_selector_name(witness.rule_name).split("_")
+    output_negation_count = sum(
+        token
+        in {
+            "absent",
+            "disqualified",
+            "ineligible",
+            "lacking",
+            "missing",
+            "no",
+            "non",
+            "not",
+            "unqualified",
+            "without",
+        }
+        for index, token in enumerate(rule_name_tokens)
+        if index > 0 or len(rule_name_tokens) == 1
     )
+    effective_blocks = witness.blocks != bool(output_negation_count % 2)
     if requirement == "zero":
         return witness.zeroes
     if requirement == "enable":

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -21182,16 +21182,14 @@ def _formula_node_boundary_value(
             if (
                 candidate_names
                 and candidate_names.issubset(boundary_names)
+                and isinstance(base, ast.Name)
                 and not base_names.intersection(boundary_names)
                 and boundary.has_rate_context
                 and source_text is not None
-                and any(
-                    _source_percentage_base_matches(
-                        source_text,
-                        boundary=boundary,
-                        base_name=base_name,
-                    )
-                    for base_name in base_names
+                and _source_percentage_base_matches(
+                    source_text,
+                    boundary=boundary,
+                    base_name=base.id,
                 )
             ):
                 boundary_factor = candidate
@@ -23698,6 +23696,51 @@ def _source_negative_output_predicate_matches(
     )
 
 
+def _described_output_clause(text: str) -> str:
+    """Return the main output clause without a subordinate condition."""
+
+    normalized = " ".join(text.split())
+    leading_condition = re.match(
+        r"^(?:if|when|unless|except\s+when)\b[^,;]*[,;]\s*(?P<output>.+)$",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if leading_condition is not None:
+        return leading_condition.group("output")
+    trailing_condition = re.search(
+        r"\b(?:if|when|unless|except\s+when)\b",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if trailing_condition is not None:
+        return normalized[: trailing_condition.start()].strip()
+    return normalized
+
+
+def _rule_has_negative_output_semantics(
+    rule: Mapping[str, Any] | None,
+    *,
+    fallback_name: str,
+) -> bool:
+    """Infer polarity from the described output, or a predicate-shaped name."""
+
+    description = str(rule.get("description") or "").strip() if rule else ""
+    if description:
+        output_clause = _described_output_clause(description)
+        return bool(_source_negative_output_predicate_matches(output_clause)) and not bool(
+            _source_positive_effect_matches(output_clause)
+        )
+    name = str(rule.get("name") or fallback_name) if rule else fallback_name
+    normalized_name = re.sub(r"[^a-z0-9]+", "_", name.casefold()).strip("_")
+    return bool(
+        re.search(
+            r"(?:^|_)(?:ineligible|excluded|disqualified|unqualified)"
+            r"(?:$|_(?:after|because|due|following|from|pending|until|when)(?:_|$))",
+            normalized_name,
+        )
+    )
+
+
 def _exception_reverses_negative_proposition(text: str) -> bool:
     reversal = re.search(
         r"\b(?:außer|ausser|es\s+sei\s+denn|unless|except)\b",
@@ -24239,14 +24282,9 @@ def _exception_witness_satisfies_requirement(
     *,
     rule: Mapping[str, Any] | None = None,
 ) -> bool:
-    description = str(rule.get("description") or "").strip() if rule else ""
-    semantic_texts = (description,) if description else ()
-    negative_output = any(
-        _source_negative_output_predicate_matches(text)
-        for text in semantic_texts
-        if text
-    ) and not any(
-        _source_positive_effect_matches(text) for text in semantic_texts if text
+    negative_output = _rule_has_negative_output_semantics(
+        rule,
+        fallback_name=witness.rule_name,
     )
     effective_blocks = witness.blocks != negative_output
     if requirement == "zero":

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -20541,6 +20541,7 @@ def _branch_boundary_test_witnesses(
                     and _formula_execution_binds_boundary(
                         controller_execution,
                         boundary,
+                        source_text=branch.text,
                         input_names=input_names,
                         formula_environment=(controller_execution.constant_environment),
                         evaluation_environment=execution_environment,
@@ -20655,6 +20656,7 @@ def _formula_execution_binds_boundary(
     execution: _FormulaExecution,
     boundary: NumericOccurrenceLike,
     *,
+    source_text: str,
     input_names: set[str],
     formula_environment: dict[str, Any],
     evaluation_environment: dict[str, Any] | None = None,
@@ -20698,6 +20700,7 @@ def _formula_execution_binds_boundary(
             input_names=input_names,
             boundary_names=boundary_names,
             boundary=boundary,
+            source_text=source_text,
             formula_environment=resolved_environment,
             source_bound_boundary_names=source_bound_boundary_names,
             source_bound_constant_occurrences=source_bound_constant_occurrences,
@@ -20716,6 +20719,7 @@ def _formula_text_has_boundary_comparison(
     input_names: set[str],
     boundary_names: set[str],
     boundary: NumericOccurrenceLike,
+    source_text: str | None = None,
     formula_environment: dict[str, Any],
     source_interval: _NumericInterval | None,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
@@ -20752,6 +20756,7 @@ def _formula_text_has_boundary_comparison(
                     boundary_node,
                     boundary_names=boundary_names,
                     boundary=boundary,
+                    source_text=source_text,
                     formula_environment=formula_environment,
                     extract_numeric_occurrences=extract_numeric_occurrences,
                     numeric_value_is_grounded=numeric_value_is_grounded,
@@ -21148,6 +21153,7 @@ def _formula_node_boundary_value(
     *,
     boundary_names: set[str],
     boundary: NumericOccurrenceLike,
+    source_text: str | None = None,
     formula_environment: dict[str, Any],
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
     numeric_value_is_grounded: NumericGroundingPredicate,
@@ -21174,6 +21180,14 @@ def _formula_node_boundary_value(
                 candidate_names
                 and candidate_names.issubset(boundary_names)
                 and not base_names.intersection(boundary_names)
+                and source_text is not None
+                and any(
+                    _source_selector_concept_matches(
+                        _collapse_text(source_text).lower(),
+                        _normalized_selector_name(base_name),
+                    )
+                    for base_name in base_names
+                )
             ):
                 boundary_factor = candidate
                 break
@@ -23630,6 +23644,26 @@ def _source_negative_effect_matches(text: str) -> tuple[re.Match[str], ...]:
     )
 
 
+def _source_negative_output_predicate_matches(
+    text: str,
+) -> tuple[re.Match[str], ...]:
+    """Match a negative legal effect, excluding negative subject modifiers."""
+
+    return tuple(
+        re.finditer(
+            r"\b(?:shall|will|is|are|becomes?)\s+(?:be\s+)?"
+            r"(?:ineligible|excluded|disqualified|unqualified)\b|"
+            r"\b(?:must|shall)\s+classif\w*[^.;]{0,80}\bas\s+"
+            r"(?:an?\s+)?(?:ineligible|excluded|disqualified|unqualified)\b|"
+            r"\b(?:shall|does|is|are|will)\s+not\s+(?:be\s+)?"
+            r"(?:apply|eligible|qualified|allowed|entitled)\b|"
+            r"\bnicht\s+berechtigt\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
 def _exception_reverses_negative_proposition(text: str) -> bool:
     reversal = re.search(
         r"\b(?:außer|ausser|es\s+sei\s+denn|unless|except)\b",
@@ -23665,6 +23699,8 @@ def _source_exception_selector_is_relevant(
 
     normalized_name = _normalized_selector_name(name)
     collapsed = _collapse_text(text).lower()
+    if _source_selector_concept_matches(collapsed, normalized_name):
+        return True
     if re.search(
         r"\b(?:at\s+least\s+one|one\s+or\s+more)\b[^.;]{0,80}"
         r"\b(?:criteria|conditions|requirements)\b",
@@ -23677,8 +23713,6 @@ def _source_exception_selector_is_relevant(
             )
             for supporting_text in supporting_texts
         )
-    if _source_selector_concept_matches(collapsed, normalized_name):
-        return True
     return any(
         len(token) >= 4
         and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
@@ -24157,7 +24191,9 @@ def _exception_witness_satisfies_requirement(
         else ()
     )
     negative_output = any(
-        _source_negative_effect_matches(text) for text in semantic_texts if text
+        _source_negative_output_predicate_matches(text)
+        for text in semantic_texts
+        if text
     ) and not any(
         _source_positive_effect_matches(text) for text in semantic_texts if text
     )

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -17508,6 +17508,7 @@ def _formula_operation_kinds(text: str) -> set[str]:
         return parsed_operations
     operations: set[str] = set()
     lowered_text = text.lower()
+    arithmetic_text = re.sub(r"\band\s*/\s*or\b", "and or", lowered_text)
     operation_patterns = {
         "add": (
             r"(?:\+|\bplus\b|\bsumme\b|\bsum\s+of\b|\bzuzüglich\b|"
@@ -17542,7 +17543,7 @@ def _formula_operation_kinds(text: str) -> set[str]:
     operations.update(
         operation
         for operation, pattern in operation_patterns.items()
-        if re.search(pattern, lowered_text, flags=re.IGNORECASE)
+        if re.search(pattern, arithmetic_text, flags=re.IGNORECASE)
     )
     return operations
 
@@ -21244,7 +21245,7 @@ def _source_percentage_base_matches(
 
     trailing_text = source_text[boundary.end :]
     explicit_base = re.match(
-        r"\s*%?\s+of\b(?P<base>[^.;:]{1,160})",
+        r"\s*%?\s+of\b(?P<base>[^,.;:]{1,160})",
         trailing_text,
         flags=re.IGNORECASE,
     )
@@ -23809,11 +23810,10 @@ def _source_selector_distinctive_concept_matches(
         and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
         and token not in _SOURCE_SELECTOR_GENERIC_ENTITY_TOKENS
     )
-    return bool(distinctive_tokens) and bool(
-        _source_selector_concept_matches(
-            _collapse_text(text).lower(),
-            "_".join(distinctive_tokens),
-        )
+    collapsed = _collapse_text(text).lower()
+    return bool(distinctive_tokens) and all(
+        re.search(rf"\b{re.escape(token)}\w*", collapsed) is not None
+        for token in distinctive_tokens
     )
 
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1273,6 +1273,11 @@ _SOURCE_SELECTOR_GENERIC_ENTITY_TOKENS = frozenset(
     {"alien", "applicant", "household", "individual", "member", "person"}
 )
 _SOURCE_GENERIC_NUMERIC_NAME_TOKENS = frozenset({"amount", "value"})
+_SOURCE_ACRONYM_EXPANSIONS = {
+    "fpl": ("federal", "poverty", "level"),
+    "lpr": ("lawful", "permanent", "resident"),
+    "ssn": ("social", "security", "number"),
+}
 _NEGATIVE_NONAPPLICABILITY_LANGUAGE = re.compile(
     r"\b(?:"
     r"(?:shall|does)\s+not\s+apply|"
@@ -21257,15 +21262,24 @@ def _source_percentage_base_matches(
     concept_tokens = tuple(
         token
         for token in _normalized_selector_name(base_name).split("_")
-        if len(token) >= 4
+        if (len(token) >= 4 or token in _SOURCE_ACRONYM_EXPANSIONS)
         and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
         and token not in _SOURCE_SELECTOR_GENERIC_ENTITY_TOKENS
         and token not in _SOURCE_GENERIC_NUMERIC_NAME_TOKENS
     )
     return bool(concept_tokens) and all(
-        re.search(rf"\b{re.escape(token)}\w*", collapsed) is not None
-        for token in concept_tokens
+        _source_concept_token_matches(collapsed, token) for token in concept_tokens
     )
+
+
+def _source_concept_token_matches(text: str, token: str) -> bool:
+    expansion = _SOURCE_ACRONYM_EXPANSIONS.get(token)
+    if expansion is not None:
+        return all(
+            re.search(rf"\b{re.escape(part)}\w*", text) is not None
+            for part in expansion
+        )
+    return re.search(rf"\b{re.escape(token)}\w*", text) is not None
 
 
 def _source_interval_and_polarity_for_boundary(
@@ -23816,14 +23830,13 @@ def _source_selector_distinctive_concept_matches(
     distinctive_tokens = tuple(
         token
         for token in normalized_name.split("_")
-        if len(token) >= 4
+        if (len(token) >= 4 or token in _SOURCE_ACRONYM_EXPANSIONS)
         and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
         and token not in _SOURCE_SELECTOR_GENERIC_ENTITY_TOKENS
     )
     collapsed = _collapse_text(text).lower()
     return bool(distinctive_tokens) and all(
-        re.search(rf"\b{re.escape(token)}\w*", collapsed) is not None
-        for token in distinctive_tokens
+        _source_concept_token_matches(collapsed, token) for token in distinctive_tokens
     )
 
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1269,6 +1269,9 @@ _SOURCE_SELECTOR_TOKEN_STOPWORDS = frozenset(
         "without",
     }
 )
+_SOURCE_SELECTOR_GENERIC_ENTITY_TOKENS = frozenset(
+    {"alien", "applicant", "household", "individual", "member", "person"}
+)
 _NEGATIVE_NONAPPLICABILITY_LANGUAGE = re.compile(
     r"\b(?:"
     r"(?:shall|does)\s+not\s+apply|"
@@ -21249,11 +21252,15 @@ def _source_percentage_base_matches(
     searchable_text = (
         explicit_base.group("base") if explicit_base is not None else source_text
     )
-    return bool(
-        _source_selector_concept_matches(
-            _collapse_text(searchable_text).lower(),
-            _normalized_selector_name(base_name),
-        )
+    collapsed = _collapse_text(searchable_text).lower()
+    concept_tokens = tuple(
+        token
+        for token in _normalized_selector_name(base_name).split("_")
+        if len(token) >= 4 and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
+    )
+    return bool(concept_tokens) and all(
+        re.search(rf"\b{re.escape(token)}\w*", collapsed) is not None
+        for token in concept_tokens
     )
 
 
@@ -23733,8 +23740,8 @@ def _source_exception_selector_is_relevant(
         collapsed,
     ):
         return any(
-            _source_selector_concept_matches(
-                _collapse_text(supporting_text).lower(),
+            _source_selector_distinctive_concept_matches(
+                supporting_text,
                 normalized_name,
             )
             for supporting_text in supporting_texts
@@ -23744,6 +23751,25 @@ def _source_exception_selector_is_relevant(
         and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
         and re.search(rf"\b{re.escape(token)}\w*", collapsed) is not None
         for token in normalized_name.split("_")
+    )
+
+
+def _source_selector_distinctive_concept_matches(
+    text: str,
+    normalized_name: str,
+) -> bool:
+    distinctive_tokens = tuple(
+        token
+        for token in normalized_name.split("_")
+        if len(token) >= 4
+        and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
+        and token not in _SOURCE_SELECTOR_GENERIC_ENTITY_TOKENS
+    )
+    return bool(distinctive_tokens) and bool(
+        _source_selector_concept_matches(
+            _collapse_text(text).lower(),
+            "_".join(distinctive_tokens),
+        )
     )
 
 
@@ -24212,13 +24238,15 @@ def _exception_witness_satisfies_requirement(
     *,
     rule: Mapping[str, Any] | None = None,
 ) -> bool:
+    description = str(rule.get("description") or "").strip() if rule else ""
     semantic_texts = (
-        (
-            str(rule.get("description") or ""),
-            *(excerpt for _citation_path, excerpt in _rule_source_excerpts(rule)),
+        (description,)
+        if description
+        else (
+            tuple(excerpt for _citation_path, excerpt in _rule_source_excerpts(rule))
+            if rule is not None
+            else ()
         )
-        if rule is not None
-        else ()
     )
     negative_output = any(
         _source_negative_output_predicate_matches(text)

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -20544,7 +20544,7 @@ def _branch_boundary_test_witnesses(
                     and _formula_execution_binds_boundary(
                         controller_execution,
                         boundary,
-                        source_text=branch.text,
+                        source_text=authoritative_numeric_recall_text(branch.text),
                         input_names=input_names,
                         formula_environment=(controller_execution.constant_environment),
                         evaluation_environment=execution_environment,
@@ -24240,15 +24240,7 @@ def _exception_witness_satisfies_requirement(
     rule: Mapping[str, Any] | None = None,
 ) -> bool:
     description = str(rule.get("description") or "").strip() if rule else ""
-    semantic_texts = (
-        (description,)
-        if description
-        else (
-            tuple(excerpt for _citation_path, excerpt in _rule_source_excerpts(rule))
-            if rule is not None
-            else ()
-        )
-    )
+    semantic_texts = (description,) if description else ()
     negative_output = any(
         _source_negative_output_predicate_matches(text)
         for text in semantic_texts

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -23793,9 +23793,10 @@ def _rule_has_negative_output_semantics(
     description = str(rule.get("description") or "").strip() if rule else ""
     if description:
         output_clause = _described_output_clause(description)
-        return bool(
-            _source_negative_output_predicate_matches(output_clause)
-        ) and not bool(_source_positive_effect_matches(output_clause))
+        negative_output = bool(_source_negative_output_predicate_matches(output_clause))
+        positive_output = bool(_source_positive_effect_matches(output_clause))
+        if negative_output or positive_output:
+            return negative_output and not positive_output
     name = str(rule.get("name") or fallback_name) if rule else fallback_name
     normalized_name = re.sub(r"[^a-z0-9]+", "_", name.casefold()).strip("_")
     name_tokens = normalized_name.split("_")
@@ -24303,13 +24304,13 @@ def _source_selector_concept_polarity(
             re.search(
                 r"\b(?:kein(?:e|en|em|er|es)?|fehlend\w*|ohne|mangels|"
                 r"no|without|lack(?:ing)?(?:\s+of)?|absence\s+of)"
-                r"\b[^.;]{0,40}$|"
+                r"\b\s+(?:(?!(?:and|or|und|oder)\b)\w+\s+){0,2}$|"
                 r"\b(?:nicht|not)\s+(?:\w+\s+){0,1}$",
                 before,
                 flags=re.IGNORECASE,
             )
             or re.match(
-                r"[^.;]{0,40}\b(?:fehlt|fehlen|nicht\s+(?:vorhanden|"
+                r"\s+(?:fehlt|fehlen|nicht\s+(?:vorhanden|"
                 r"gegeben)|liegt\s+nicht\s+vor|is\s+not\s+present|"
                 r"is\s+absent)\b",
                 after,

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -23703,6 +23703,7 @@ def _source_negative_output_predicate_matches(
     return tuple(
         re.finditer(
             r"\b(?:must|shall|will|is|are|becomes?)\s+(?:be\s+)?"
+            r"(?:(?:an?|the)\s+)?"
             r"(?:ineligible|excluded|disqualified|unqualified)\b|"
             r"\b(?:must|shall|will)\s+classif\w*[^.;]{0,80}\bas\s+"
             r"(?:an?\s+)?(?:ineligible|excluded|disqualified|unqualified)\b|"
@@ -24278,28 +24279,34 @@ def _source_selector_concept_polarity(
 
 
 def _selector_identifier_negation_count(normalized_name: str) -> int:
-    count = sum(
+    tokens = normalized_name.split("_")
+    explicit_negation_count = sum(
         token
         in {
-            "absent",
-            "lacking",
-            "missing",
             "no",
             "non",
             "not",
-            "inability",
-            "unable",
-            "unwilling",
-            "unwillingness",
             "without",
         }
-        for token in normalized_name.split("_")
+        for token in tokens
     )
-    count += sum(
-        marker in normalized_name.split("_")
-        for marker in {"disqualified", "ineligible", "unqualified"}
+    has_negative_state = any(
+        token
+        in {
+            "absent",
+            "disqualified",
+            "inability",
+            "ineligible",
+            "lacking",
+            "missing",
+            "unable",
+            "unqualified",
+            "unwilling",
+            "unwillingness",
+        }
+        for token in tokens
     )
-    return count
+    return explicit_negation_count + int(has_negative_state)
 
 
 def _exception_witness_satisfies_requirement(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -21251,7 +21251,9 @@ def _source_percentage_base_matches(
 
     trailing_text = source_text[boundary.end :]
     explicit_base = re.match(
-        r"\s*%?\s+of\b(?P<base>[^,.;:]{1,160})",
+        r"\s*%?\s+of\b(?P<base>[^,.;:]{1,160}?)"
+        r"(?=\s+\b(?:after|before|less|minus|plus|subtract\w*|add\w*|"
+        r"reduc\w*|increas\w*)\b|[,.;:]|$)",
         trailing_text,
         flags=re.IGNORECASE,
     )
@@ -23411,6 +23413,10 @@ def _exception_witnesses_for_branch(
     }
     requirement = _source_exception_effect_requirement(branch.text)
     condition_text = _source_exception_condition_text(branch.text)
+    numeric_interval = _formula_interval_from_text(
+        authoritative_numeric_recall_text(condition_text),
+        extract_numeric_occurrences=extract_numeric_occurrences,
+    )
     return {
         witness
         for witness in toggled_exception_selectors
@@ -23423,7 +23429,15 @@ def _exception_witnesses_for_branch(
             )
             if witness.numeric_transition is not None
             else (
-                witness.active_value
+                (
+                    numeric_interval is None
+                    or not _selector_targets_numeric_condition(
+                        condition_text,
+                        witness.selector_name,
+                        numeric_interval=numeric_interval,
+                    )
+                )
+                and witness.active_value
                 == _source_exception_selector_active_value(
                     condition_text,
                     witness.selector_name,
@@ -23446,6 +23460,35 @@ def _exception_witnesses_for_branch(
             rule=principal_rules[witness.rule_name],
         )
     }
+
+
+def _selector_targets_numeric_condition(
+    text: str,
+    selector_name: str,
+    *,
+    numeric_interval: _NumericInterval,
+) -> bool:
+    """Identify a Boolean selector that merely restates a numeric predicate."""
+
+    boundary_end = max(
+        boundary.end
+        for boundary in (numeric_interval.lower, numeric_interval.upper)
+        if boundary is not None
+    )
+    normalized_name = _normalized_selector_name(selector_name)
+    matches = tuple(_source_selector_concept_matches(text, normalized_name))
+    if any(
+        match.start() > boundary_end
+        and re.search(
+            r"\b(?:unless|except(?:\s+when)?|au(?:ß|ss)er|es\s+sei\s+denn)\b",
+            text[boundary_end : match.start()],
+            flags=re.IGNORECASE,
+        )
+        is not None
+        for match in matches
+    ):
+        return False
+    return bool(matches)
 
 
 def _source_exception_condition_text(text: str) -> str:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1272,6 +1272,7 @@ _SOURCE_SELECTOR_TOKEN_STOPWORDS = frozenset(
 _SOURCE_SELECTOR_GENERIC_ENTITY_TOKENS = frozenset(
     {"alien", "applicant", "household", "individual", "member", "person"}
 )
+_SOURCE_GENERIC_NUMERIC_NAME_TOKENS = frozenset({"amount", "value"})
 _NEGATIVE_NONAPPLICABILITY_LANGUAGE = re.compile(
     r"\b(?:"
     r"(?:shall|does)\s+not\s+apply|"
@@ -21256,7 +21257,10 @@ def _source_percentage_base_matches(
     concept_tokens = tuple(
         token
         for token in _normalized_selector_name(base_name).split("_")
-        if len(token) >= 4 and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
+        if len(token) >= 4
+        and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
+        and token not in _SOURCE_SELECTOR_GENERIC_ENTITY_TOKENS
+        and token not in _SOURCE_GENERIC_NUMERIC_NAME_TOKENS
     )
     return bool(concept_tokens) and all(
         re.search(rf"\b{re.escape(token)}\w*", collapsed) is not None
@@ -23686,7 +23690,10 @@ def _source_negative_output_predicate_matches(
         re.finditer(
             r"\b(?:shall|will|is|are|becomes?)\s+(?:be\s+)?"
             r"(?:ineligible|excluded|disqualified|unqualified)\b|"
-            r"\b(?:must|shall)\s+classif\w*[^.;]{0,80}\bas\s+"
+            r"\b(?:must|shall|will)\s+(?:be\s+)?"
+            r"(?:classif\w*|deem\w*|treat\w*)[^.;]{0,80}\bas\s+"
+            r"(?:an?\s+)?(?:ineligible|excluded|disqualified|unqualified)\b|"
+            r"\b(?:is|are)\s+(?:classified|deemed|treated)\s+as\s+"
             r"(?:an?\s+)?(?:ineligible|excluded|disqualified|unqualified)\b|"
             r"\b(?:shall|does|is|are|will)\s+not\s+(?:be\s+)?"
             r"(?:apply|eligible|qualified|allowed|entitled)\b|"

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -23733,12 +23733,15 @@ def _rule_has_negative_output_semantics(
         ) and not bool(_source_positive_effect_matches(output_clause))
     name = str(rule.get("name") or fallback_name) if rule else fallback_name
     normalized_name = re.sub(r"[^a-z0-9]+", "_", name.casefold()).strip("_")
-    return bool(
-        re.search(
-            r"(?:^|_)(?:ineligible|excluded|disqualified|unqualified)"
-            r"(?:$|_(?:after|because|due|following|from|pending|until|when)(?:_|$))",
-            normalized_name,
+    name_tokens = normalized_name.split("_")
+    negative_predicates = {"disqualified", "excluded", "ineligible", "unqualified"}
+    return any(
+        token in negative_predicates
+        and (
+            index + 1 == len(name_tokens)
+            or name_tokens[index + 1] not in _SOURCE_SELECTOR_GENERIC_ENTITY_TOKENS
         )
+        for index, token in enumerate(name_tokens)
     )
 
 
@@ -24224,14 +24227,16 @@ def _source_selector_concept_polarity(
     for match in _source_selector_concept_matches(text, normalized_name):
         before = text[max(0, match.start() - 48) : match.start()]
         after = text[match.end() : min(len(text), match.end() + 48)]
-        negative = bool(
+        inherently_negative = bool(
             re.fullmatch(
                 r"(?:ineligible|disqualified|unqualified|inability|unable|"
                 r"unwilling|unwillingness)",
                 match.group(0),
                 flags=re.IGNORECASE,
             )
-            or re.search(
+        )
+        explicitly_negated = bool(
+            re.search(
                 r"\b(?:kein(?:e|en|em|er|es)?|fehlend\w*|ohne|mangels|"
                 r"no|without|lack(?:ing)?(?:\s+of)?|absence\s+of)"
                 r"\b[^.;]{0,40}$|"
@@ -24247,6 +24252,7 @@ def _source_selector_concept_polarity(
                 flags=re.IGNORECASE,
             )
         )
+        negative = inherently_negative != explicitly_negated
         polarities.add(-1 if negative else 1)
     return next(iter(polarities)) if len(polarities) == 1 else None
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -12871,7 +12871,7 @@ def _source_proposition_bounds(text: str, start: int, end: int) -> tuple[int, in
     boundaries.extend(
         match.end()
         for match in re.finditer(
-            r";|[.!?](?=\s+(?:[A-Z(]|\d+\s*[.)]))",
+            r";|[.!?:](?=\s+(?:[A-Z(]|\d+\s*[.)]|\d+\s+(?:After|For)\b))",
             text,
         )
     )
@@ -17531,7 +17531,7 @@ def _formula_operation_kinds(text: str) -> set[str]:
             r"\b(?:doppelte|zweifache|dreifache|twice)\b)"
         ),
         "divide": (
-            r"(?:/|\bgeteilt\b|\bteilen\b|\bdivided\b|"
+            r"(?:(?<![a-z])/(?![a-z])|\bgeteilt\b|\bteilen\b|\bdivided\b|"
             r"\bhälfte\b|\bhalbier\w*\b|\bhalbierung\b|\bhalf\s+of\b)"
         ),
     }
@@ -20512,6 +20512,13 @@ def _branch_boundary_test_witnesses(
             )
             if execution is None:
                 continue
+            execution_environment = _case_formula_identifier_environment(
+                case,
+                formula_environment=formula_environment or {},
+                dependency_environment=dependency_environment,
+            )
+            if execution_environment is None:
+                continue
             for (
                 controller_rule,
                 controller_execution,
@@ -20535,6 +20542,7 @@ def _branch_boundary_test_witnesses(
                         boundary,
                         input_names=input_names,
                         formula_environment=(controller_execution.constant_environment),
+                        evaluation_environment=execution_environment,
                         source_bound_constant_occurrences=(
                             source_bound_constant_occurrences or {}
                         ),
@@ -20648,6 +20656,7 @@ def _formula_execution_binds_boundary(
     *,
     input_names: set[str],
     formula_environment: dict[str, Any],
+    evaluation_environment: dict[str, Any] | None = None,
     source_bound_constant_occurrences: dict[str, tuple[NumericOccurrenceLike, ...]],
     source_interval: _NumericInterval | None,
     source_boolean_polarity: int,
@@ -20679,6 +20688,8 @@ def _formula_execution_binds_boundary(
             continue
         checks.extend((selector, True) for selector in step.selectors)
     checks.append((execution.leaf, source_boolean_polarity < 0))
+    resolved_environment = dict(formula_environment)
+    resolved_environment.update(evaluation_environment or {})
     return any(
         _formula_text_has_boundary_comparison(
             text,
@@ -20686,7 +20697,7 @@ def _formula_execution_binds_boundary(
             input_names=input_names,
             boundary_names=boundary_names,
             boundary=boundary,
-            formula_environment=formula_environment,
+            formula_environment=resolved_environment,
             source_bound_boundary_names=source_bound_boundary_names,
             source_bound_constant_occurrences=source_bound_constant_occurrences,
             source_interval=source_interval,
@@ -21144,6 +21155,17 @@ def _formula_node_boundary_value(
         value = formula_environment.get(node.id)
         if _rulespec_runtime_decimal(value) is not None:
             return float(value)
+    node_names = {
+        candidate.id for candidate in ast.walk(node) if isinstance(candidate, ast.Name)
+    }
+    if node_names & boundary_names:
+        value = _evaluate_condition_expression(node, formula_environment)
+        numeric_value = _rulespec_runtime_decimal(value)
+        if numeric_value is not None and numeric_value_is_grounded(
+            float(numeric_value),
+            (boundary,),
+        ):
+            return float(numeric_value)
     if (
         isinstance(node, ast.Constant)
         and isinstance(
@@ -23302,10 +23324,6 @@ def _exception_witnesses_for_branch(
     }
     requirement = _source_exception_effect_requirement(branch.text)
     condition_text = _source_exception_condition_text(branch.text)
-    numeric_interval = _formula_interval_from_text(
-        authoritative_numeric_recall_text(branch.text),
-        extract_numeric_occurrences=extract_numeric_occurrences,
-    )
     return {
         witness
         for witness in toggled_exception_selectors
@@ -23318,8 +23336,7 @@ def _exception_witnesses_for_branch(
             )
             if witness.numeric_transition is not None
             else (
-                numeric_interval is None
-                and witness.active_value
+                witness.active_value
                 == _source_exception_selector_active_value(
                     condition_text,
                     witness.selector_name,
@@ -23596,6 +23613,7 @@ def _exception_reverses_negative_proposition(text: str) -> bool:
             r"\bfindet\s+keine\s+anwendung\b|"
             r"\b(?:does|shall)\s+not\s+apply\b|"
             r"\b(?:is|are)\s+not\s+(?:eligible|qualified|entitled)\b|"
+            r"\bno\b[^.;]{0,80}\b(?:is|are)\s+(?:eligible|qualified|entitled)\b|"
             r"\b(?:ineligible|excluded|disqualified|unqualified)\b|"
             r"\bkein(?:e|en|em|er|es)?\s+(?:anspruch|berechtigung)\b",
             proposition,
@@ -23610,6 +23628,12 @@ def _source_exception_selector_is_relevant(text: str, name: str) -> bool:
 
     normalized_name = _normalized_selector_name(name)
     collapsed = _collapse_text(text).lower()
+    if re.search(
+        r"\b(?:at\s+least\s+one|one\s+or\s+more)\b[^.;]{0,80}"
+        r"\b(?:criteria|conditions|requirements)\b",
+        collapsed,
+    ):
+        return True
     if _source_selector_concept_matches(collapsed, normalized_name):
         return True
     return any(
@@ -24029,7 +24053,8 @@ def _source_selector_concept_polarity(
         after = text[match.end() : min(len(text), match.end() + 48)]
         negative = bool(
             re.fullmatch(
-                r"(?:ineligible|disqualified|unqualified)",
+                r"(?:ineligible|disqualified|unqualified|inability|unable|"
+                r"unwilling|unwillingness)",
                 match.group(0),
                 flags=re.IGNORECASE,
             )
@@ -24078,14 +24103,17 @@ def _exception_witness_satisfies_requirement(
     witness: _ExceptionWitness,
     requirement: str,
 ) -> bool:
+    effective_blocks = witness.blocks != bool(
+        _selector_identifier_negation_count(witness.rule_name) % 2
+    )
     if requirement == "zero":
         return witness.zeroes
     if requirement == "enable":
-        return (witness.boolean_effect and not witness.blocks) or (
+        return (witness.boolean_effect and not effective_blocks) or (
             not witness.boolean_effect
         )
     if requirement == "exclude":
-        return witness.blocks or not witness.boolean_effect
+        return effective_blocks or not witness.boolean_effect
     return True
 
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -23470,12 +23470,24 @@ def _selector_targets_numeric_condition(
 ) -> bool:
     """Identify a Boolean selector that merely restates a numeric predicate."""
 
+    normalized_name = _normalized_selector_name(selector_name)
+    selector_tokens = set(normalized_name.split("_"))
+    numeric_selector_tokens = _FORMULA_NUMERIC_OPERAND_HEADS | {
+        "age",
+        "day",
+        "days",
+        "month",
+        "months",
+        "year",
+        "years",
+    }
+    if not selector_tokens & numeric_selector_tokens:
+        return False
     boundary_end = max(
         boundary.end
         for boundary in (numeric_interval.lower, numeric_interval.upper)
         if boundary is not None
     )
-    normalized_name = _normalized_selector_name(selector_name)
     matches = tuple(_source_selector_concept_matches(text, normalized_name))
     if any(
         match.start() > boundary_end
@@ -24300,15 +24312,37 @@ def _source_selector_concept_polarity(
                 flags=re.IGNORECASE,
             )
         )
-        explicitly_negated = bool(
+        explicit_prefix = re.search(
+            r"\b(?:kein(?:e|en|em|er|es)?|fehlend\w*|ohne|mangels|"
+            r"no|without|lack(?:ing)?(?:\s+of)?|absence\s+of|nicht|not)\b"
+            r"(?P<scope>[^.;,:]{0,80})$",
+            before,
+            flags=re.IGNORECASE,
+        )
+        prefix_scope = explicit_prefix.group("scope") if explicit_prefix else ""
+        prefix_crosses_predicate = bool(
             re.search(
-                r"\b(?:kein(?:e|en|em|er|es)?|fehlend\w*|ohne|mangels|"
-                r"no|without|lack(?:ing)?(?:\s+of)?|absence\s+of)"
-                r"\b\s+(?:(?!(?:and|or|und|oder)\b)\w+\s+){0,2}$|"
-                r"\b(?:nicht|not)\s+(?:\w+\s+){0,1}$",
-                before,
+                r"\b(?:although|because|but|except|if|unless|when|while)\b|"
+                r"\b(?:and|or|und|oder)\b\s+"
+                r"(?:(?:the|a|an|der|die|das|ein(?:e|en|em|er|es)?)\s+)?"
+                r"(?:\w+\s+){0,3}"
+                r"(?:is|are|was|were|has|have|does|do|shall|must|can|"
+                r"ist|sind|hat|haben)\b",
+                prefix_scope,
                 flags=re.IGNORECASE,
             )
+            or (
+                inherently_negative
+                and re.search(
+                    r"\b(?:and|or|und|oder)\b",
+                    prefix_scope,
+                    flags=re.IGNORECASE,
+                )
+                is not None
+            )
+        )
+        explicitly_negated = bool(
+            (explicit_prefix is not None and not prefix_crosses_predicate)
             or re.match(
                 r"\s+(?:fehlt|fehlen|nicht\s+(?:vorhanden|"
                 r"gegeben)|liegt\s+nicht\s+vor|is\s+not\s+present|"

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -21183,6 +21183,7 @@ def _formula_node_boundary_value(
                 candidate_names
                 and candidate_names.issubset(boundary_names)
                 and not base_names.intersection(boundary_names)
+                and boundary.has_rate_context
                 and source_text is not None
                 and any(
                     _source_percentage_base_matches(
@@ -21245,7 +21246,7 @@ def _source_percentage_base_matches(
 
     trailing_text = source_text[boundary.end :]
     explicit_base = re.match(
-        r"\s+of\b(?P<base>[^.;:]{1,160})",
+        r"\s*%?\s+of\b(?P<base>[^.;:]{1,160})",
         trailing_text,
         flags=re.IGNORECASE,
     )

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1728"
+ENCODER_VERSION = "0.2.1729"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1718"
+ENCODER_VERSION = "0.2.1719"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1719"
+ENCODER_VERSION = "0.2.1720"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1725"
+ENCODER_VERSION = "0.2.1726"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1714"
+ENCODER_VERSION = "0.2.1715"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1721"
+ENCODER_VERSION = "0.2.1722"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1726"
+ENCODER_VERSION = "0.2.1727"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1716"
+ENCODER_VERSION = "0.2.1717"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1727"
+ENCODER_VERSION = "0.2.1728"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1722"
+ENCODER_VERSION = "0.2.1723"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1713"
+ENCODER_VERSION = "0.2.1714"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1717"
+ENCODER_VERSION = "0.2.1718"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1723"
+ENCODER_VERSION = "0.2.1724"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1720"
+ENCODER_VERSION = "0.2.1721"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1715"
+ENCODER_VERSION = "0.2.1716"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1724"
+ENCODER_VERSION = "0.2.1725"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1725"
+ENCODER_VERSION = "0.2.1726"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1716"
+ENCODER_VERSION = "0.2.1717"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1722"
+ENCODER_VERSION = "0.2.1723"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1713"
+ENCODER_VERSION = "0.2.1714"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1723"
+ENCODER_VERSION = "0.2.1724"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1726"
+ENCODER_VERSION = "0.2.1727"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1718"
+ENCODER_VERSION = "0.2.1719"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1717"
+ENCODER_VERSION = "0.2.1718"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1721"
+ENCODER_VERSION = "0.2.1722"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1719"
+ENCODER_VERSION = "0.2.1720"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1724"
+ENCODER_VERSION = "0.2.1725"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1720"
+ENCODER_VERSION = "0.2.1721"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1728"
+ENCODER_VERSION = "0.2.1729"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1727"
+ENCODER_VERSION = "0.2.1728"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1714"
+ENCODER_VERSION = "0.2.1715"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1715"
+ENCODER_VERSION = "0.2.1716"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1722"
+ENCODER_VERSION = "0.2.1723"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1721"
+ENCODER_VERSION = "0.2.1722"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1723"
+ENCODER_VERSION = "0.2.1724"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1715"
+ENCODER_VERSION = "0.2.1716"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1718"
+ENCODER_VERSION = "0.2.1719"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1717"
+ENCODER_VERSION = "0.2.1718"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1713"
+ENCODER_VERSION = "0.2.1714"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1728"
+ENCODER_VERSION = "0.2.1729"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1716"
+ENCODER_VERSION = "0.2.1717"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1720"
+ENCODER_VERSION = "0.2.1721"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1726"
+ENCODER_VERSION = "0.2.1727"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1714"
+ENCODER_VERSION = "0.2.1715"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1727"
+ENCODER_VERSION = "0.2.1728"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1725"
+ENCODER_VERSION = "0.2.1726"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1719"
+ENCODER_VERSION = "0.2.1720"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1724"
+ENCODER_VERSION = "0.2.1725"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1716"
+ENCODER_VERSION = "0.2.1717"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1727"
+ENCODER_VERSION = "0.2.1728"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1718"
+ENCODER_VERSION = "0.2.1719"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1715"
+ENCODER_VERSION = "0.2.1716"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1725"
+ENCODER_VERSION = "0.2.1726"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1724"
+ENCODER_VERSION = "0.2.1725"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1721"
+ENCODER_VERSION = "0.2.1722"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1723"
+ENCODER_VERSION = "0.2.1724"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1714"
+ENCODER_VERSION = "0.2.1715"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1717"
+ENCODER_VERSION = "0.2.1718"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1726"
+ENCODER_VERSION = "0.2.1727"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1728"
+ENCODER_VERSION = "0.2.1729"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1719"
+ENCODER_VERSION = "0.2.1720"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1713"
+ENCODER_VERSION = "0.2.1714"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1722"
+ENCODER_VERSION = "0.2.1723"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1720"
+ENCODER_VERSION = "0.2.1721"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1719"
+ENCODER_VERSION = "0.2.1720"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1716"
+ENCODER_VERSION = "0.2.1717"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1726"
+ENCODER_VERSION = "0.2.1727"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1714"
+ENCODER_VERSION = "0.2.1715"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1723"
+ENCODER_VERSION = "0.2.1724"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1720"
+ENCODER_VERSION = "0.2.1721"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1725"
+ENCODER_VERSION = "0.2.1726"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1722"
+ENCODER_VERSION = "0.2.1723"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1721"
+ENCODER_VERSION = "0.2.1722"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1724"
+ENCODER_VERSION = "0.2.1725"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1713"
+ENCODER_VERSION = "0.2.1714"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1718"
+ENCODER_VERSION = "0.2.1719"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1715"
+ENCODER_VERSION = "0.2.1716"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1717"
+ENCODER_VERSION = "0.2.1718"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1727"
+ENCODER_VERSION = "0.2.1728"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1728"
+ENCODER_VERSION = "0.2.1729"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1719"
+ENCODER_VERSION = "0.2.1720"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1718"
+ENCODER_VERSION = "0.2.1719"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1720"
+ENCODER_VERSION = "0.2.1721"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1727"
+ENCODER_VERSION = "0.2.1728"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1724"
+ENCODER_VERSION = "0.2.1725"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1713"
+ENCODER_VERSION = "0.2.1714"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1721"
+ENCODER_VERSION = "0.2.1722"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1714"
+ENCODER_VERSION = "0.2.1715"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1723"
+ENCODER_VERSION = "0.2.1724"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1726"
+ENCODER_VERSION = "0.2.1727"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1716"
+ENCODER_VERSION = "0.2.1717"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1725"
+ENCODER_VERSION = "0.2.1726"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1717"
+ENCODER_VERSION = "0.2.1718"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1715"
+ENCODER_VERSION = "0.2.1716"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1728"
+ENCODER_VERSION = "0.2.1729"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1722"
+ENCODER_VERSION = "0.2.1723"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1721"
+ENCODER_VERSION = "0.2.1722"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1716"
+ENCODER_VERSION = "0.2.1717"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1715"
+ENCODER_VERSION = "0.2.1716"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1719"
+ENCODER_VERSION = "0.2.1720"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1718"
+ENCODER_VERSION = "0.2.1719"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1717"
+ENCODER_VERSION = "0.2.1718"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1723"
+ENCODER_VERSION = "0.2.1724"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1722"
+ENCODER_VERSION = "0.2.1723"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1724"
+ENCODER_VERSION = "0.2.1725"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1727"
+ENCODER_VERSION = "0.2.1728"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1726"
+ENCODER_VERSION = "0.2.1727"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1725"
+ENCODER_VERSION = "0.2.1726"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1714"
+ENCODER_VERSION = "0.2.1715"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1728"
+ENCODER_VERSION = "0.2.1729"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1713"
+ENCODER_VERSION = "0.2.1714"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1720"
+ENCODER_VERSION = "0.2.1721"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1719"')
+        .startswith('__version__ = "0.2.1720"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1719"
+    assert encoder_package["version"] == "0.2.1720"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1719"
+    assert project["project"]["version"] == "0.2.1720"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1719"')
+        .startswith('__version__ = "0.2.1720"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1719"
+    assert encoder_package["version"] == "0.2.1720"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1719"
+    assert project["project"]["version"] == "0.2.1720"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1719"')
+        .startswith('__version__ = "0.2.1720"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1727"')
+        .startswith('__version__ = "0.2.1728"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1727"
+    assert encoder_package["version"] == "0.2.1728"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1727"
+    assert project["project"]["version"] == "0.2.1728"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1727"')
+        .startswith('__version__ = "0.2.1728"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1727"
+    assert encoder_package["version"] == "0.2.1728"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1727"
+    assert project["project"]["version"] == "0.2.1728"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1727"')
+        .startswith('__version__ = "0.2.1728"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1722"')
+        .startswith('__version__ = "0.2.1723"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1722"
+    assert encoder_package["version"] == "0.2.1723"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1722"
+    assert project["project"]["version"] == "0.2.1723"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1722"')
+        .startswith('__version__ = "0.2.1723"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1722"
+    assert encoder_package["version"] == "0.2.1723"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1722"
+    assert project["project"]["version"] == "0.2.1723"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1722"')
+        .startswith('__version__ = "0.2.1723"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1716"')
+        .startswith('__version__ = "0.2.1717"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1716"
+    assert encoder_package["version"] == "0.2.1717"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1716"
+    assert project["project"]["version"] == "0.2.1717"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1716"')
+        .startswith('__version__ = "0.2.1717"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1716"
+    assert encoder_package["version"] == "0.2.1717"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1716"
+    assert project["project"]["version"] == "0.2.1717"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1716"')
+        .startswith('__version__ = "0.2.1717"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1726"')
+        .startswith('__version__ = "0.2.1727"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1726"
+    assert encoder_package["version"] == "0.2.1727"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1726"
+    assert project["project"]["version"] == "0.2.1727"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1726"')
+        .startswith('__version__ = "0.2.1727"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1726"
+    assert encoder_package["version"] == "0.2.1727"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1726"
+    assert project["project"]["version"] == "0.2.1727"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1726"')
+        .startswith('__version__ = "0.2.1727"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1715"')
+        .startswith('__version__ = "0.2.1716"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1715"
+    assert encoder_package["version"] == "0.2.1716"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1715"
+    assert project["project"]["version"] == "0.2.1716"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1715"')
+        .startswith('__version__ = "0.2.1716"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1715"
+    assert encoder_package["version"] == "0.2.1716"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1715"
+    assert project["project"]["version"] == "0.2.1716"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1715"')
+        .startswith('__version__ = "0.2.1716"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1717"')
+        .startswith('__version__ = "0.2.1718"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1717"
+    assert encoder_package["version"] == "0.2.1718"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1717"
+    assert project["project"]["version"] == "0.2.1718"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1717"')
+        .startswith('__version__ = "0.2.1718"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1717"
+    assert encoder_package["version"] == "0.2.1718"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1717"
+    assert project["project"]["version"] == "0.2.1718"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1717"')
+        .startswith('__version__ = "0.2.1718"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1728"')
+        .startswith('__version__ = "0.2.1729"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1728"
+    assert encoder_package["version"] == "0.2.1729"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1728"
+    assert project["project"]["version"] == "0.2.1729"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1728"')
+        .startswith('__version__ = "0.2.1729"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1728"
+    assert encoder_package["version"] == "0.2.1729"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1728"
+    assert project["project"]["version"] == "0.2.1729"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1728"')
+        .startswith('__version__ = "0.2.1729"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1713"')
+        .startswith('__version__ = "0.2.1714"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1713"
+    assert encoder_package["version"] == "0.2.1714"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1713"
+    assert project["project"]["version"] == "0.2.1714"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1713"')
+        .startswith('__version__ = "0.2.1714"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1713"
+    assert encoder_package["version"] == "0.2.1714"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1713"
+    assert project["project"]["version"] == "0.2.1714"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1713"')
+        .startswith('__version__ = "0.2.1714"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1725"')
+        .startswith('__version__ = "0.2.1726"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1725"
+    assert encoder_package["version"] == "0.2.1726"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1725"
+    assert project["project"]["version"] == "0.2.1726"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1725"')
+        .startswith('__version__ = "0.2.1726"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1725"
+    assert encoder_package["version"] == "0.2.1726"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1725"
+    assert project["project"]["version"] == "0.2.1726"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1725"')
+        .startswith('__version__ = "0.2.1726"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1723"')
+        .startswith('__version__ = "0.2.1724"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1723"
+    assert encoder_package["version"] == "0.2.1724"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1723"
+    assert project["project"]["version"] == "0.2.1724"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1723"')
+        .startswith('__version__ = "0.2.1724"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1723"
+    assert encoder_package["version"] == "0.2.1724"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1723"
+    assert project["project"]["version"] == "0.2.1724"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1723"')
+        .startswith('__version__ = "0.2.1724"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1718"')
+        .startswith('__version__ = "0.2.1719"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1718"
+    assert encoder_package["version"] == "0.2.1719"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1718"
+    assert project["project"]["version"] == "0.2.1719"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1718"')
+        .startswith('__version__ = "0.2.1719"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1718"
+    assert encoder_package["version"] == "0.2.1719"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1718"
+    assert project["project"]["version"] == "0.2.1719"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1718"')
+        .startswith('__version__ = "0.2.1719"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1721"')
+        .startswith('__version__ = "0.2.1722"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1721"
+    assert encoder_package["version"] == "0.2.1722"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1721"
+    assert project["project"]["version"] == "0.2.1722"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1721"')
+        .startswith('__version__ = "0.2.1722"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1721"
+    assert encoder_package["version"] == "0.2.1722"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1721"
+    assert project["project"]["version"] == "0.2.1722"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1721"')
+        .startswith('__version__ = "0.2.1722"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1724"')
+        .startswith('__version__ = "0.2.1725"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1724"
+    assert encoder_package["version"] == "0.2.1725"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1724"
+    assert project["project"]["version"] == "0.2.1725"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1724"')
+        .startswith('__version__ = "0.2.1725"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1724"
+    assert encoder_package["version"] == "0.2.1725"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1724"
+    assert project["project"]["version"] == "0.2.1725"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1724"')
+        .startswith('__version__ = "0.2.1725"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1720"')
+        .startswith('__version__ = "0.2.1721"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1720"
+    assert encoder_package["version"] == "0.2.1721"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1720"
+    assert project["project"]["version"] == "0.2.1721"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1720"')
+        .startswith('__version__ = "0.2.1721"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1720"
+    assert encoder_package["version"] == "0.2.1721"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1720"
+    assert project["project"]["version"] == "0.2.1721"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1720"')
+        .startswith('__version__ = "0.2.1721"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1714"')
+        .startswith('__version__ = "0.2.1715"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1714"
+    assert encoder_package["version"] == "0.2.1715"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1714"
+    assert project["project"]["version"] == "0.2.1715"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1714"')
+        .startswith('__version__ = "0.2.1715"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1714"
+    assert encoder_package["version"] == "0.2.1715"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1714"
+    assert project["project"]["version"] == "0.2.1715"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1714"')
+        .startswith('__version__ = "0.2.1715"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1718"
+ENCODER_VERSION = "0.2.1719"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1720"
+ENCODER_VERSION = "0.2.1721"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1728"
+ENCODER_VERSION = "0.2.1729"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1725"
+ENCODER_VERSION = "0.2.1726"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1714"
+ENCODER_VERSION = "0.2.1715"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1721"
+ENCODER_VERSION = "0.2.1722"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1723"
+ENCODER_VERSION = "0.2.1724"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1717"
+ENCODER_VERSION = "0.2.1718"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1726"
+ENCODER_VERSION = "0.2.1727"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1724"
+ENCODER_VERSION = "0.2.1725"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1727"
+ENCODER_VERSION = "0.2.1728"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1719"
+ENCODER_VERSION = "0.2.1720"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1716"
+ENCODER_VERSION = "0.2.1717"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1713"
+ENCODER_VERSION = "0.2.1714"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1715"
+ENCODER_VERSION = "0.2.1716"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1722"
+ENCODER_VERSION = "0.2.1723"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -33115,6 +33115,46 @@ def test_negative_condition_name_is_active_when_source_uses_same_condition(
 @pytest.mark.parametrize(
     ("source", "selector"),
     (
+        (
+            "When there is an absence of any reasonably available documentation.",
+            "documentation_missing",
+        ),
+        ("When the person has no income or resources.", "resources_missing"),
+    ),
+)
+def test_qualified_or_coordinated_negation_controls_selector_polarity(
+    source: str,
+    selector: str,
+):
+    assert completeness_module._source_exception_selector_active_value(
+        source,
+        selector,
+    )
+
+
+def test_only_numeric_selector_names_restate_compound_numeric_condition():
+    source = "Income is more than 100 dollars and the applicant is disabled."
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert completeness_module._selector_targets_numeric_condition(
+        source,
+        "income_more_than_limit",
+        numeric_interval=interval,
+    )
+    assert not completeness_module._selector_targets_numeric_condition(
+        source,
+        "applicant_is_disabled",
+        numeric_interval=interval,
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "selector"),
+    (
         ("When the person is not unwilling to provide documentation.", "is_unwilling"),
         ("When the person is not unable to work.", "is_unable"),
         ("When no applicant has inability to work.", "has_inability"),

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -32478,12 +32478,18 @@ rules:
     cases = [
         {
             "name": "presumption applies",
-            "input": {"months_absent": 7, "evidence_of_intent_to_resume_residency": False},
+            "input": {
+                "months_absent": 7,
+                "evidence_of_intent_to_resume_residency": False,
+            },
             "output": {"residency_interruption_presumed": True},
         },
         {
             "name": "resume evidence blocks presumption",
-            "input": {"months_absent": 7, "evidence_of_intent_to_resume_residency": True},
+            "input": {
+                "months_absent": 7,
+                "evidence_of_intent_to_resume_residency": True,
+            },
             "output": {"residency_interruption_presumed": False},
         },
     ]

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5951,6 +5951,15 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
 
+    labeled_source = f"(1) {multi_amount_source}"
+    cleaned_labeled_source = authoritative_numeric_recall_text(labeled_source)
+    labeled_boundary = extractor(cleaned_labeled_source)[0]
+    assert not completeness_module._source_percentage_base_matches(
+        cleaned_labeled_source,
+        boundary=labeled_boundary,
+        base_name="poverty_guideline",
+    )
+
     amount_source = "Assistance does not exceed $100 when income is reported."
     amount_boundary = extractor(amount_source)[0]
     amount_interval = completeness_module._formula_interval_from_text(
@@ -32743,6 +32752,44 @@ def test_positive_rule_description_controls_negative_source_excerpt_polarity():
     assert completeness_module._exception_witness_satisfies_requirement(
         witness,
         "enable",
+        rule=rule,
+    )
+
+
+def test_proof_excerpt_does_not_define_undescribed_rule_output_polarity():
+    witness = completeness_module._ExceptionWitness(
+        rule_name="eligible",
+        selector_name="disqualification_applies",
+        active_value=True,
+        blocks=True,
+        boolean_effect=True,
+        zeroes=False,
+        numeric_transition=None,
+        relational_transitions=(),
+        case_pair_identity=(1, 2),
+    )
+    rule = {
+        "metadata": {
+            "proof": {
+                "atoms": [
+                    {
+                        "path": "versions[0].formula",
+                        "source": {
+                            "corpus_citation_path": CORPUS_CITATION_PATH,
+                            "excerpt": (
+                                "The claimant is not eligible if a "
+                                "disqualification applies."
+                            ),
+                        },
+                    }
+                ]
+            }
+        }
+    }
+
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
         rule=rule,
     )
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5950,6 +5950,30 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
             extract_numeric_occurrences=extractor,
             numeric_value_is_grounded=numeric_value_is_grounded,
         )
+
+    fpl_source = "Assistance does not exceed 130 percent of the federal poverty level."
+    fpl_boundary = extractor(fpl_source)[0]
+    fpl_interval = completeness_module._formula_interval_from_text(
+        fpl_source,
+        extract_numeric_occurrences=extractor,
+    )
+    assert fpl_interval is not None
+    assert completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= fpl * poverty_rate",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=fpl_boundary,
+        source_text=fpl_source,
+        formula_environment={
+            "assistance": 26_000,
+            "fpl": 20_000,
+            "poverty_rate": 1.3,
+        },
+        source_interval=fpl_interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
     assert not completeness_module._formula_text_has_boundary_comparison(
         "assistance <= poverty_guideline * poverty_rate",
         allow_complement_relation=False,
@@ -32753,6 +32777,16 @@ def test_generic_at_least_one_criterion_chapeau_accepts_descendant_selector():
     assert completeness_module._source_exception_selector_is_relevant(
         "At least one of the conditions applies: refugee status.",
         "member_is_refugee",
+    )
+    assert completeness_module._source_exception_selector_is_relevant(
+        source,
+        "member_is_lpr",
+        supporting_texts=("The alien is a lawful permanent resident.",),
+    )
+    assert completeness_module._source_exception_selector_is_relevant(
+        source,
+        "member_has_ssn",
+        supporting_texts=("The member has a Social Security number.",),
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5933,6 +5933,23 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         extract_numeric_occurrences=extractor,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
+    for conventional_base in ("earned_income_amount", "household_earned_income"):
+        assert completeness_module._formula_text_has_boundary_comparison(
+            f"assistance <= {conventional_base} * poverty_rate",
+            allow_complement_relation=False,
+            input_names={"assistance"},
+            boundary_names={"poverty_rate"},
+            boundary=multi_amount_boundary,
+            source_text=multi_amount_source,
+            formula_environment={
+                "assistance": 26_000,
+                conventional_base: 20_000,
+                "poverty_rate": 1.3,
+            },
+            source_interval=multi_amount_interval,
+            extract_numeric_occurrences=extractor,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+        )
     assert not completeness_module._formula_text_has_boundary_comparison(
         "assistance <= poverty_guideline * poverty_rate",
         allow_complement_relation=False,
@@ -32765,6 +32782,11 @@ def test_true_ineligibility_output_witnesses_exclusion_effect():
         rule={
             "description": "The agency must classify the person as an ineligible alien."
         },
+    )
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
+        rule={"description": "The person must be classified as an ineligible alien."},
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5974,6 +5974,31 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         extract_numeric_occurrences=extractor,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
+    unlinked_source = (
+        "The poverty guideline is updated. Assistance does not exceed 130 percent."
+    )
+    unlinked_boundary = extractor(unlinked_source)[0]
+    unlinked_interval = completeness_module._formula_interval_from_text(
+        "Assistance does not exceed 130 percent.",
+        extract_numeric_occurrences=extractor,
+    )
+    assert unlinked_interval is not None
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= poverty_guideline * poverty_rate",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=unlinked_boundary,
+        source_text=unlinked_source,
+        formula_environment={
+            "assistance": 26_000,
+            "poverty_guideline": 20_000,
+            "poverty_rate": 1.3,
+        },
+        source_interval=unlinked_interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
     assert not completeness_module._formula_text_has_boundary_comparison(
         "assistance <= poverty_guideline * poverty_rate",
         allow_complement_relation=False,
@@ -32822,6 +32847,17 @@ def test_true_ineligibility_output_witnesses_exclusion_effect():
         "exclude",
         rule={"description": "The person must be classified as an ineligible alien."},
     )
+    for description in (
+        "The person shall be deemed ineligible.",
+        "The person is deemed ineligible.",
+        "The person must be treated as ineligible.",
+        "The person must be ineligible.",
+    ):
+        assert completeness_module._exception_witness_satisfies_requirement(
+            witness,
+            "exclude",
+            rule={"description": description},
+        )
 
 
 def test_undescribed_negative_rule_name_controls_output_polarity():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5828,6 +5828,7 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         input_names={"assistance"},
         boundary_names={"poverty_rate"},
         boundary=boundary,
+        source_text=source,
         formula_environment={
             "assistance": 26_000,
             "poverty_guideline": 20_000,
@@ -5843,7 +5844,24 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         input_names={"assistance"},
         boundary_names={"poverty_rate"},
         boundary=boundary,
+        source_text=source,
         formula_environment={"assistance": 26_000, "poverty_rate": 1.3},
+        source_interval=interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= unrelated_amount * poverty_rate",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=boundary,
+        source_text=source,
+        formula_environment={
+            "assistance": 26_000,
+            "unrelated_amount": 20_000,
+            "poverty_rate": 1.3,
+        },
         source_interval=interval,
         extract_numeric_occurrences=extractor,
         numeric_value_is_grounded=numeric_value_is_grounded,
@@ -32545,6 +32563,10 @@ def test_generic_at_least_one_criterion_chapeau_accepts_descendant_selector():
             "An alien admitted as a refugee under section 207 of the INA",
         ),
     )
+    assert completeness_module._source_exception_selector_is_relevant(
+        "At least one of the conditions applies: refugee status.",
+        "member_is_refugee",
+    )
 
 
 def test_true_ineligibility_output_witnesses_exclusion_effect():
@@ -32563,12 +32585,16 @@ def test_true_ineligibility_output_witnesses_exclusion_effect():
     assert completeness_module._exception_witness_satisfies_requirement(
         witness,
         "exclude",
-        rule={"description": "The person shall be ineligible."},
+        rule={
+            "description": "The agency must classify the person as an ineligible alien."
+        },
     )
     assert not completeness_module._exception_witness_satisfies_requirement(
         witness,
         "enable",
-        rule={"description": "The person shall be ineligible."},
+        rule={
+            "description": "The agency must classify the person as an ineligible alien."
+        },
     )
 
 
@@ -32588,12 +32614,12 @@ def test_negative_subject_modifier_does_not_invert_positive_output_effect():
     assert not completeness_module._exception_witness_satisfies_requirement(
         witness,
         "exclude",
-        rule={"description": "Whether the person receives a notice."},
+        rule={"description": "Whether the ineligible person receives a notice."},
     )
     assert completeness_module._exception_witness_satisfies_requirement(
         witness,
         "enable",
-        rule={"description": "Whether the person receives a notice."},
+        rule={"description": "Whether the ineligible person receives a notice."},
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5867,6 +5867,49 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
 
+    multi_amount_source = (
+        "The poverty guideline is updated, and assistance does not exceed "
+        "130 percent of earned income."
+    )
+    multi_amount_boundary = extractor(multi_amount_source)[0]
+    multi_amount_interval = completeness_module._formula_interval_from_text(
+        multi_amount_source,
+        extract_numeric_occurrences=extractor,
+    )
+    assert multi_amount_interval is not None
+    assert completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= earned_income * poverty_rate",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=multi_amount_boundary,
+        source_text=multi_amount_source,
+        formula_environment={
+            "assistance": 26_000,
+            "earned_income": 20_000,
+            "poverty_rate": 1.3,
+        },
+        source_interval=multi_amount_interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= poverty_guideline * poverty_rate",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=multi_amount_boundary,
+        source_text=multi_amount_source,
+        formula_environment={
+            "assistance": 26_000,
+            "poverty_guideline": 20_000,
+            "poverty_rate": 1.3,
+        },
+        source_interval=multi_amount_interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
 
 @pytest.mark.parametrize("floor_expression", ("bracket_floor", "5000"))
 def test_progressive_max_clamp_binds_exact_source_lower_boundary(
@@ -32632,6 +32675,24 @@ def test_inability_or_unwillingness_is_active_missing_documentation_condition():
     assert completeness_module._source_exception_selector_active_value(
         source,
         "alien_status_documentation_missing_or_unwilling",
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "selector"),
+    (
+        ("When the person is unwilling to provide documentation.", "is_unwilling"),
+        ("When the person is unable to work.", "is_unable"),
+        ("When the person indicates inability to work.", "has_inability"),
+    ),
+)
+def test_negative_condition_name_is_active_when_source_uses_same_condition(
+    source: str,
+    selector: str,
+):
+    assert completeness_module._source_exception_selector_active_value(
+        source,
+        selector,
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5866,6 +5866,23 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         extract_numeric_occurrences=extractor,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= poverty_rate * (poverty_guideline + unrelated_amount)",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=boundary,
+        source_text=source,
+        formula_environment={
+            "assistance": 26_000,
+            "poverty_guideline": 20_000,
+            "poverty_rate": 1.3,
+            "unrelated_amount": 1,
+        },
+        source_interval=interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
 
     multi_amount_source = (
         "The poverty guideline is updated, and assistance does not exceed "
@@ -32720,6 +32737,36 @@ def test_true_ineligibility_output_witnesses_exclusion_effect():
     )
 
 
+def test_undescribed_negative_rule_name_controls_output_polarity():
+    witness = completeness_module._ExceptionWitness(
+        rule_name="alien_status_documentation_ineligible",
+        selector_name="documentation_missing_or_unwilling",
+        active_value=True,
+        blocks=False,
+        boolean_effect=True,
+        zeroes=False,
+        numeric_transition=None,
+        relational_transitions=(),
+        case_pair_identity=(1, 2),
+    )
+
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
+        rule={"name": "alien_status_documentation_ineligible"},
+    )
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
+        rule={"name": "alien_status_ineligible_after_consent_failure"},
+    )
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
+        rule={"name": "entire_household_ineligible_pending_sponsor_verification"},
+    )
+
+
 def test_positive_rule_description_controls_negative_source_excerpt_polarity():
     witness = completeness_module._ExceptionWitness(
         rule_name="person_eligible",
@@ -32816,6 +32863,14 @@ def test_negative_subject_modifier_does_not_invert_positive_output_effect():
         witness,
         "enable",
         rule={"description": "Whether the ineligible person receives a notice."},
+    )
+
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "enable",
+        rule={
+            "description": "Whether a notice is required when the person is ineligible."
+        },
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2273,6 +2273,48 @@ def test_later_independent_condition_in_same_sentence_does_not_contaminate():
     assert not _has_issue(result, "source-explicit-conditions")
 
 
+def test_proposition_bounds_split_bare_footnote_before_following_sentence():
+    source = (
+        "A battered alien is exempt when the agency approves the case. 3 "
+        "After 12 months, deeming stops if a court recognizes the battery and "
+        "the alien lives apart."
+    )
+    excerpt = "the agency approves the case"
+    start = source.index(excerpt)
+    end = start + len(excerpt)
+
+    proposition_start, proposition_end = completeness_module._source_proposition_bounds(
+        source,
+        start,
+        end,
+    )
+
+    assert source[proposition_start:proposition_end] == (
+        "A battered alien is exempt when the agency approves the case."
+    )
+
+
+def test_proposition_bounds_split_chapeau_before_labeled_children():
+    source = (
+        "A qualified alien is immediately eligible if the individual meets one "
+        "criterion: (A) The alien has qualifying quarters. (B) The alien is a refugee."
+    )
+    excerpt = "meets one criterion"
+    start = source.index(excerpt)
+    end = start + len(excerpt)
+
+    proposition_start, proposition_end = completeness_module._source_proposition_bounds(
+        source,
+        start,
+        end,
+    )
+
+    assert source[proposition_start:proposition_end] == (
+        "A qualified alien is immediately eligible if the individual meets one "
+        "criterion:"
+    )
+
+
 def test_elided_subject_later_condition_does_not_contaminate_atomic_proposition():
     source = (
         "A credit applies if certification status holds, and is refundable if "
@@ -5763,6 +5805,36 @@ def test_progressive_min_clamp_binds_matching_subtracted_offset():
         formula_environment={"rate": 0.02, "lower_bound": 100, "ceiling": 500},
         source_interval=interval,
         extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
+def test_percentage_boundary_comparison_uses_resolved_case_scale():
+    source = "Assistance does not exceed 130 percent of the poverty guideline."
+    extractor = functools.partial(
+        extract_typed_numeric_inventory_occurrences_from_text,
+        profile="legacy",
+    )
+    boundary = extractor(source)[0]
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=extractor,
+    )
+
+    assert interval is not None
+    assert completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= poverty_guideline * poverty_rate",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=boundary,
+        formula_environment={
+            "assistance": 1.3,
+            "poverty_guideline": 1,
+            "poverty_rate": 1.3,
+        },
+        source_interval=interval,
+        extract_numeric_occurrences=extractor,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
 
@@ -20825,6 +20897,19 @@ def test_en_us_state_code_citations_are_structural_for_numeric_recall():
     assert inventory == []
 
 
+def test_section_symbol_decimal_citation_is_not_numeric_recall():
+    cleaned = authoritative_numeric_recall_text(
+        "Determine remaining household eligibility under § 273.11(c); "
+        "a 500 dollar cap applies."
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        cleaned,
+        profile="legacy",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(500.0, "500")]
+
+
 def test_louisiana_revised_statutes_citations_are_structural_for_numeric_recall():
     source = (
         "The amount is determined under R.S. 47:32. Notwithstanding R.S.\n"
@@ -31293,6 +31378,16 @@ def test_ordinary_language_is_not_a_formal_structural_reference(text: str):
     assert not completeness_module._source_has_formal_cross_reference(text)
 
 
+def test_and_or_in_legal_prose_is_not_treated_as_division():
+    source = (
+        "The agency must explain the determination to the alien and/or household "
+        "representative."
+    )
+
+    assert "divide" not in completeness_module._formula_operation_kinds(source)
+    assert "divide" in completeness_module._formula_operation_kinds("income / 2")
+
+
 @pytest.mark.parametrize(
     "source",
     [
@@ -32355,6 +32450,106 @@ rules:
     result = _analyze(content, source, test_cases=cases)
 
     assert _has_issue(result, "exception", "test") is expected_issue
+
+
+def test_boolean_unless_exception_can_witness_numeric_trigger_clause():
+    source = (
+        "(1) Residency is presumed interrupted if absence is more than 6 months "
+        "unless the resident presents evidence of intent to resume residency."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-zz/statute/1
+rules:
+  - name: absence_month_limit
+    kind: parameter
+    dtype: Count
+    source: us-zz/statute/1(1)
+    versions: [{formula: 6}]
+  - name: residency_interruption_presumed
+    kind: derived
+    dtype: Judgment
+    source: us-zz/statute/1(1)
+    versions:
+      - formula: 'months_absent > absence_month_limit and not evidence_of_intent_to_resume_residency'
+"""
+    cases = [
+        {
+            "name": "presumption applies",
+            "input": {"months_absent": 7, "evidence_of_intent_to_resume_residency": False},
+            "output": {"residency_interruption_presumed": True},
+        },
+        {
+            "name": "resume evidence blocks presumption",
+            "input": {"months_absent": 7, "evidence_of_intent_to_resume_residency": True},
+            "output": {"residency_interruption_presumed": False},
+        },
+    ]
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-zz/statute/1",
+        test_cases=cases,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+    )
+
+    assert not _has_issue(result, "exceptions or applicability", "paired")
+
+
+def test_no_person_eligible_unless_status_is_an_enabling_exception():
+    source = "No person is eligible unless that person is a citizen."
+
+    assert completeness_module._source_exception_effect_requirement(source) == "enable"
+
+
+def test_generic_at_least_one_criterion_chapeau_accepts_descendant_selector():
+    source = "The person is eligible if the person meets at least one of the criteria."
+
+    assert completeness_module._source_exception_selector_is_relevant(
+        source,
+        "member_is_refugee",
+    )
+
+
+def test_true_ineligibility_output_witnesses_exclusion_effect():
+    witness = completeness_module._ExceptionWitness(
+        rule_name="person_ineligible_after_consent_failure",
+        selector_name="person_failed_to_provide_consent",
+        active_value=True,
+        blocks=False,
+        boolean_effect=True,
+        zeroes=False,
+        numeric_transition=None,
+        relational_transitions=(),
+        case_pair_identity=(1, 2),
+    )
+
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
+    )
+    assert not completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "enable",
+    )
+
+
+def test_inability_or_unwillingness_is_active_missing_documentation_condition():
+    source = (
+        "When a person indicates inability or unwillingness to provide "
+        "documentation of alien status, the person is ineligible."
+    )
+
+    assert completeness_module._source_exception_selector_active_value(
+        source,
+        "alien_status_documentation_missing_or_unwilling",
+    )
 
 
 def test_numeric_input_change_cannot_hide_identical_exception_branches():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -6033,6 +6033,22 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
             numeric_value_is_grounded=numeric_value_is_grounded,
         )
 
+    trailing_amount_source = (
+        "Assistance does not exceed 130 percent of earned income after "
+        "subtracting unearned income."
+    )
+    trailing_amount_boundary = extractor(trailing_amount_source)[0]
+    assert completeness_module._source_percentage_base_matches(
+        trailing_amount_source,
+        boundary=trailing_amount_boundary,
+        base_name="earned_income",
+    )
+    assert not completeness_module._source_percentage_base_matches(
+        trailing_amount_source,
+        boundary=trailing_amount_boundary,
+        base_name="unearned_income",
+    )
+
     symbolic_source = multi_amount_source.replace("130 percent", "130%")
     symbolic_boundary = extractor(symbolic_source)[0]
     symbolic_interval = completeness_module._formula_interval_from_text(
@@ -32764,6 +32780,37 @@ rules:
     )
 
     assert not _has_issue(result, "exceptions or applicability", "paired")
+
+
+def test_boolean_selector_cannot_replace_numeric_exception_evidence():
+    source = "Applicant is ineligible if income is more than 100 dollars."
+    branch = completeness_module.SourceStructureBranch(
+        ("1",), "sentence", "1", source, 0, len(source)
+    )
+    witness = completeness_module._ExceptionWitness(
+        rule_name="applicant_ineligible",
+        selector_name="income_more_than_limit",
+        active_value=True,
+        blocks=False,
+        boolean_effect=True,
+        zeroes=False,
+        numeric_transition=None,
+        relational_transitions=(),
+        case_pair_identity=(1, 2),
+    )
+
+    assert not completeness_module._exception_witnesses_for_branch(
+        branch,
+        principal_rules={
+            "applicant_ineligible": {
+                "name": "applicant_ineligible",
+                "description": "Whether the applicant is ineligible.",
+            }
+        },
+        principal_rule_paths={"applicant_ineligible": {("1",)}},
+        toggled_exception_selectors={witness},
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
 
 
 def test_no_person_eligible_unless_status_is_an_enabling_exception():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -32852,6 +32852,8 @@ def test_true_ineligibility_output_witnesses_exclusion_effect():
         "The person is deemed ineligible.",
         "The person must be treated as ineligible.",
         "The person must be ineligible.",
+        "The applicant is an ineligible alien.",
+        "The applicant becomes an excluded member.",
     ):
         assert completeness_module._exception_witness_satisfies_requirement(
             witness,
@@ -33021,6 +33023,14 @@ def test_inability_or_unwillingness_is_active_missing_documentation_condition():
     assert completeness_module._source_exception_selector_active_value(
         source,
         "alien_status_documentation_missing_or_unwilling",
+    )
+    assert completeness_module._source_exception_selector_active_value(
+        source,
+        "has_inability_or_unwillingness",
+    )
+    assert completeness_module._source_exception_selector_active_value(
+        "When the person is unable or unwilling to provide documentation.",
+        "is_unable_or_unwilling",
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5837,6 +5837,17 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         extract_numeric_occurrences=extractor,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= poverty_rate + 999999",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=boundary,
+        formula_environment={"assistance": 26_000, "poverty_rate": 1.3},
+        source_interval=interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
 
 
 @pytest.mark.parametrize("floor_expression", ("bracket_floor", "5000"))
@@ -30116,6 +30127,7 @@ def test_exception_branch_accepts_principal_rule_grounded_to_descendant():
 
     candidates = completeness_module._exception_witnesses_for_branch(
         branch,
+        principal_rules={"low_income_credit_amount": {}},
         principal_rule_paths={
             "low_income_credit_amount": {("a", "1", "a", "i")},
         },
@@ -30174,6 +30186,7 @@ def test_numeric_transition_propagates_through_asserted_judgment_dependency():
 
     candidates = completeness_module._exception_witnesses_for_branch(
         branch,
+        principal_rules=principal_rules,
         principal_rule_paths={
             "low_income_applies": {("a", "1", "b")},
             "low_income_credit_amount": {("a", "1", "a", "i")},
@@ -32521,6 +32534,16 @@ def test_generic_at_least_one_criterion_chapeau_accepts_descendant_selector():
     assert completeness_module._source_exception_selector_is_relevant(
         source,
         "member_is_refugee",
+        supporting_texts=(
+            "An alien admitted as a refugee under section 207 of the INA",
+        ),
+    )
+    assert not completeness_module._source_exception_selector_is_relevant(
+        source,
+        "owns_luxury_car",
+        supporting_texts=(
+            "An alien admitted as a refugee under section 207 of the INA",
+        ),
     )
 
 
@@ -32540,10 +32563,12 @@ def test_true_ineligibility_output_witnesses_exclusion_effect():
     assert completeness_module._exception_witness_satisfies_requirement(
         witness,
         "exclude",
+        rule={"description": "The person shall be ineligible."},
     )
     assert not completeness_module._exception_witness_satisfies_requirement(
         witness,
         "enable",
+        rule={"description": "The person shall be ineligible."},
     )
 
 
@@ -32563,10 +32588,12 @@ def test_negative_subject_modifier_does_not_invert_positive_output_effect():
     assert not completeness_module._exception_witness_satisfies_requirement(
         witness,
         "exclude",
+        rule={"description": "Whether the person receives a notice."},
     )
     assert completeness_module._exception_witness_satisfies_requirement(
         witness,
         "enable",
+        rule={"description": "Whether the person receives a notice."},
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -32947,6 +32947,14 @@ def test_undescribed_negative_rule_name_controls_output_polarity():
         "exclude",
         rule={"name": "person_ineligible_under_section_1"},
     )
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
+        rule={
+            "name": "person_ineligible",
+            "description": "Whether this rule applies to the person.",
+        },
+    )
 
 
 def test_positive_rule_description_controls_negative_source_excerpt_polarity():
@@ -33087,6 +33095,11 @@ def test_inability_or_unwillingness_is_active_missing_documentation_condition():
         ("When the person is unwilling to provide documentation.", "is_unwilling"),
         ("When the person is unable to work.", "is_unable"),
         ("When the person indicates inability to work.", "has_inability"),
+        (
+            "The person has no income and is unwilling to provide documentation.",
+            "is_unwilling",
+        ),
+        ("There is no job, and the person is unable to work.", "is_unable"),
     ),
 )
 def test_negative_condition_name_is_active_when_source_uses_same_condition(

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5927,6 +5927,54 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
             numeric_value_is_grounded=numeric_value_is_grounded,
         )
 
+    symbolic_source = multi_amount_source.replace("130 percent", "130%")
+    symbolic_boundary = extractor(symbolic_source)[0]
+    symbolic_interval = completeness_module._formula_interval_from_text(
+        symbolic_source,
+        extract_numeric_occurrences=extractor,
+    )
+    assert symbolic_interval is not None
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= poverty_guideline * poverty_rate",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=symbolic_boundary,
+        source_text=symbolic_source,
+        formula_environment={
+            "assistance": 26_000,
+            "poverty_guideline": 20_000,
+            "poverty_rate": 1.3,
+        },
+        source_interval=symbolic_interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+    amount_source = "Assistance does not exceed $100 when income is reported."
+    amount_boundary = extractor(amount_source)[0]
+    amount_interval = completeness_module._formula_interval_from_text(
+        amount_source,
+        extract_numeric_occurrences=extractor,
+    )
+    assert amount_interval is not None
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= income * assistance_limit",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"assistance_limit"},
+        boundary=amount_boundary,
+        source_text=amount_source,
+        formula_environment={
+            "assistance": 100,
+            "income": 2,
+            "assistance_limit": 100,
+        },
+        source_interval=amount_interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
 
 @pytest.mark.parametrize("floor_expression", ("bracket_floor", "5000"))
 def test_progressive_max_clamp_binds_exact_source_lower_boundary(

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5883,6 +5883,29 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         extract_numeric_occurrences=extractor,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
+    qualified_source = source.removesuffix(".") + ", based on household size."
+    qualified_boundary = extractor(qualified_source)[0]
+    qualified_interval = completeness_module._formula_interval_from_text(
+        qualified_source,
+        extract_numeric_occurrences=extractor,
+    )
+    assert qualified_interval is not None
+    assert not completeness_module._formula_text_has_boundary_comparison(
+        "assistance <= poverty_rate * household_size",
+        allow_complement_relation=False,
+        input_names={"assistance"},
+        boundary_names={"poverty_rate"},
+        boundary=qualified_boundary,
+        source_text=qualified_source,
+        formula_environment={
+            "assistance": 5.2,
+            "household_size": 4,
+            "poverty_rate": 1.3,
+        },
+        source_interval=qualified_interval,
+        extract_numeric_occurrences=extractor,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
 
     multi_amount_source = (
         "The poverty guideline is updated, and assistance does not exceed "
@@ -31550,6 +31573,9 @@ def test_and_or_in_legal_prose_is_not_treated_as_division():
     )
 
     assert "divide" not in completeness_module._formula_operation_kinds(source)
+    assert "divide" not in completeness_module._formula_operation_kinds(
+        "The agency must notify the alien and / or household representative."
+    )
     assert "divide" in completeness_module._formula_operation_kinds("income / 2")
     assert "divide" in completeness_module._formula_operation_kinds("$5/person")
 
@@ -32701,6 +32727,11 @@ def test_generic_at_least_one_criterion_chapeau_accepts_descendant_selector():
         source,
         "member_owns_luxury_car",
         supporting_texts=("A member is admitted as a refugee.",),
+    )
+    assert not completeness_module._source_exception_selector_is_relevant(
+        source,
+        "member_owns_luxury_car",
+        supporting_texts=("The household owns a car.",),
     )
     assert completeness_module._source_exception_selector_is_relevant(
         "At least one of the conditions applies: refugee status.",

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -32796,6 +32796,16 @@ def test_undescribed_negative_rule_name_controls_output_polarity():
         "exclude",
         rule={"name": "entire_household_ineligible_pending_sponsor_verification"},
     )
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
+        rule={"name": "person_ineligible_for_benefits"},
+    )
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
+        rule={"name": "person_ineligible_under_section_1"},
+    )
 
 
 def test_positive_rule_description_controls_negative_source_excerpt_polarity():
@@ -32903,6 +32913,11 @@ def test_negative_subject_modifier_does_not_invert_positive_output_effect():
             "description": "Whether a notice is required when the person is ineligible."
         },
     )
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "enable",
+        rule={"name": "ineligible_person_receives_notice"},
+    )
 
 
 def test_inability_or_unwillingness_is_active_missing_documentation_condition():
@@ -32930,6 +32945,24 @@ def test_negative_condition_name_is_active_when_source_uses_same_condition(
     selector: str,
 ):
     assert completeness_module._source_exception_selector_active_value(
+        source,
+        selector,
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "selector"),
+    (
+        ("When the person is not unwilling to provide documentation.", "is_unwilling"),
+        ("When the person is not unable to work.", "is_unable"),
+        ("When no applicant has inability to work.", "has_inability"),
+    ),
+)
+def test_explicit_negation_reverses_inherently_negative_condition(
+    source: str,
+    selector: str,
+):
+    assert not completeness_module._source_exception_selector_active_value(
         source,
         selector,
     )

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5829,8 +5829,8 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         boundary_names={"poverty_rate"},
         boundary=boundary,
         formula_environment={
-            "assistance": 1.3,
-            "poverty_guideline": 1,
+            "assistance": 26_000,
+            "poverty_guideline": 20_000,
             "poverty_rate": 1.3,
         },
         source_interval=interval,
@@ -31386,6 +31386,7 @@ def test_and_or_in_legal_prose_is_not_treated_as_division():
 
     assert "divide" not in completeness_module._formula_operation_kinds(source)
     assert "divide" in completeness_module._formula_operation_kinds("income / 2")
+    assert "divide" in completeness_module._formula_operation_kinds("$5/person")
 
 
 @pytest.mark.parametrize(
@@ -32541,6 +32542,29 @@ def test_true_ineligibility_output_witnesses_exclusion_effect():
         "exclude",
     )
     assert not completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "enable",
+    )
+
+
+def test_negative_subject_modifier_does_not_invert_positive_output_effect():
+    witness = completeness_module._ExceptionWitness(
+        rule_name="ineligible_person_receives_notice",
+        selector_name="notice_required",
+        active_value=True,
+        blocks=False,
+        boolean_effect=True,
+        zeroes=False,
+        numeric_transition=None,
+        relational_transitions=(),
+        case_pair_identity=(1, 2),
+    )
+
+    assert not completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "exclude",
+    )
+    assert completeness_module._exception_witness_satisfies_requirement(
         witness,
         "enable",
     )

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5909,6 +5909,23 @@ def test_percentage_boundary_comparison_uses_resolved_case_scale():
         extract_numeric_occurrences=extractor,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
+    for wrong_base in ("unearned_income", "other_income"):
+        assert not completeness_module._formula_text_has_boundary_comparison(
+            f"assistance <= {wrong_base} * poverty_rate",
+            allow_complement_relation=False,
+            input_names={"assistance"},
+            boundary_names={"poverty_rate"},
+            boundary=multi_amount_boundary,
+            source_text=multi_amount_source,
+            formula_environment={
+                "assistance": 26_000,
+                wrong_base: 20_000,
+                "poverty_rate": 1.3,
+            },
+            source_interval=multi_amount_interval,
+            extract_numeric_occurrences=extractor,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+        )
 
 
 @pytest.mark.parametrize("floor_expression", ("bracket_floor", "5000"))
@@ -32606,6 +32623,11 @@ def test_generic_at_least_one_criterion_chapeau_accepts_descendant_selector():
             "An alien admitted as a refugee under section 207 of the INA",
         ),
     )
+    assert not completeness_module._source_exception_selector_is_relevant(
+        source,
+        "member_owns_luxury_car",
+        supporting_texts=("A member is admitted as a refugee.",),
+    )
     assert completeness_module._source_exception_selector_is_relevant(
         "At least one of the conditions applies: refugee status.",
         "member_is_refugee",
@@ -32638,6 +32660,42 @@ def test_true_ineligibility_output_witnesses_exclusion_effect():
         rule={
             "description": "The agency must classify the person as an ineligible alien."
         },
+    )
+
+
+def test_positive_rule_description_controls_negative_source_excerpt_polarity():
+    witness = completeness_module._ExceptionWitness(
+        rule_name="person_eligible",
+        selector_name="person_is_citizen",
+        active_value=True,
+        blocks=False,
+        boolean_effect=True,
+        zeroes=False,
+        numeric_transition=None,
+        relational_transitions=(),
+        case_pair_identity=(1, 2),
+    )
+    rule = {
+        "description": "Whether the person is eligible.",
+        "metadata": {
+            "proof": {
+                "atoms": [
+                    {
+                        "path": "versions[0].formula",
+                        "citation_path": CORPUS_CITATION_PATH,
+                        "excerpt": (
+                            "A person is ineligible unless that person is a citizen."
+                        ),
+                    }
+                ]
+            }
+        },
+    }
+
+    assert completeness_module._exception_witness_satisfies_requirement(
+        witness,
+        "enable",
+        rule=rule,
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1728"
+version = "0.2.1729"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1722"
+version = "0.2.1723"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1714"
+version = "0.2.1715"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1727"
+version = "0.2.1728"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1718"
+version = "0.2.1719"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1717"
+version = "0.2.1718"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1725"
+version = "0.2.1726"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1715"
+version = "0.2.1716"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1713"
+version = "0.2.1714"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1721"
+version = "0.2.1722"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1719"
+version = "0.2.1720"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1726"
+version = "0.2.1727"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1716"
+version = "0.2.1717"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1720"
+version = "0.2.1721"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1724"
+version = "0.2.1725"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1723"
+version = "0.2.1724"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- distinguish resolved test-case values from legal constant environments when validating numeric boundaries
- recognize immigration exception, exclusion, chapeau, and documentation polarity patterns
- improve proposition boundaries and avoid treating `and/or` as arithmetic division
- add regression coverage and bump axiom-encode to 0.2.1714

Supports completion of TheAxiomFoundation/rulespec-us#1248.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `COPYFILE_DISABLE=1 uv run pytest` (13,481 passed, 126 skipped)
- `uv run pytest tests/test_source_completeness.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- corpus-backed signed validation of `us/regulations/7-cfr/273/4.yaml`: `ci_pass: true`, 143 companion cases passing