### PR TITLE
Allow signed repair overlays to remove obsolete rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1729"
+version = "0.2.1730"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1729"
+__version__ = "0.2.1730"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -16804,7 +16804,10 @@ def _merge_named_yaml_items(
             raise ValueError(f"generated {label} contains duplicate name `{name}`")
         generated_names.add(name)
         if "repair_remove" in item:
-            if set(item) != {"name", "repair_remove"} or item["repair_remove"] is not True:
+            if (
+                set(item) != {"name", "repair_remove"}
+                or item["repair_remove"] is not True
+            ):
                 raise ValueError(
                     f"generated {label} removal marker for `{name}` must contain "
                     "only name and repair_remove: true"

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -16301,6 +16301,8 @@ def _normalize_test_periods_to_effective_dates(
     def normalize_case(case: object) -> object:
         if not isinstance(case, dict):
             return case
+        if _is_exact_repair_removal_marker(case):
+            return case
         normalized_case = _repair_misindented_period_mapping_fields(case)
         if granularity == "Year" and effective_date is not None:
             normalized_case["period"] = _normalize_annual_test_period_value(
@@ -16364,6 +16366,17 @@ def _normalize_test_periods_to_effective_dates(
         )
 
     return normalized
+
+
+def _is_exact_repair_removal_marker(item: object) -> bool:
+    """Recognize the only transient deletion marker admitted by repair overlays."""
+
+    return (
+        isinstance(item, dict)
+        and set(item) == {"name", "repair_remove"}
+        and isinstance(item.get("name"), str)
+        and item.get("repair_remove") is True
+    )
 
 
 def _repair_misindented_period_mapping_fields(case: dict[str, Any]) -> dict[str, Any]:
@@ -16804,10 +16817,7 @@ def _merge_named_yaml_items(
             raise ValueError(f"generated {label} contains duplicate name `{name}`")
         generated_names.add(name)
         if "repair_remove" in item:
-            if (
-                set(item) != {"name", "repair_remove"}
-                or item["repair_remove"] is not True
-            ):
+            if not _is_exact_repair_removal_marker(item):
                 raise ValueError(
                     f"generated {label} removal marker for `{name}` must contain "
                     "only name and repair_remove: true"

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -15858,6 +15858,8 @@ def _normalize_single_amount_row_test_content(
     def normalize_case(case: object) -> object:
         if not isinstance(case, dict):
             return case
+        if _is_exact_repair_removal_marker(case):
+            return case
         normalized_case = dict(case)
         if annual_period and effective_date is not None:
             normalized_case["period"] = _normalize_annual_test_period_value(
@@ -15887,7 +15889,11 @@ def _normalize_single_amount_row_test_content(
         filtered = [
             normalize_case(case)
             for case in cases
-            if not isinstance(case, dict) or should_keep(case.get("name"))
+            if (
+                not isinstance(case, dict)
+                or _is_exact_repair_removal_marker(case)
+                or should_keep(case.get("name"))
+            )
         ]
         return yaml.safe_dump(filtered, sort_keys=False).strip() + "\n"
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9854,7 +9854,11 @@ companion test file required by the task and deterministic validation.
             "you may omit unchanged named rules, imports, deferred outputs, and "
             "named companion cases. The encoder overlays those omitted items from "
             "the hash-bound candidate before validation. Re-emit the complete item "
-            "only when changing or replacing it; never emit prose or patch syntax.\n"
+            "only when changing or replacing it. To remove an obsolete named rule "
+            "or companion case from this rejected candidate, emit an exact YAML "
+            "item containing only `name: <existing name>` and `repair_remove: true`; "
+            "the encoder removes that marker before validation. Never emit prose "
+            "or patch syntax.\n"
         )
     )
     return f"""
@@ -16784,19 +16788,30 @@ def _merge_named_yaml_items(
     preserved: object,
     *,
     label: str,
-) -> tuple[list[object], list[str]]:
+) -> tuple[list[object], list[str], list[str]]:
     """Restore omitted hash-bound items while allowing explicit replacements."""
 
-    generated_items = list(generated) if isinstance(generated, list) else []
+    raw_generated_items = list(generated) if isinstance(generated, list) else []
     preserved_items = list(preserved) if isinstance(preserved, list) else []
+    generated_items: list[object] = []
     generated_names: set[str] = set()
-    for item in generated_items:
+    removed_names: set[str] = set()
+    for item in raw_generated_items:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):
             raise ValueError(f"generated {label} items must have string names")
         name = item["name"]
         if name in generated_names:
             raise ValueError(f"generated {label} contains duplicate name `{name}`")
         generated_names.add(name)
+        if "repair_remove" in item:
+            if set(item) != {"name", "repair_remove"} or item["repair_remove"] is not True:
+                raise ValueError(
+                    f"generated {label} removal marker for `{name}` must contain "
+                    "only name and repair_remove: true"
+                )
+            removed_names.add(name)
+            continue
+        generated_items.append(item)
     preserved_names: set[str] = set()
     restored: list[str] = []
     for item in preserved_items:
@@ -16810,7 +16825,13 @@ def _merge_named_yaml_items(
             generated_items.append(item)
             generated_names.add(name)
             restored.append(name)
-    return generated_items, restored
+    unknown_removals = sorted(removed_names - preserved_names)
+    if unknown_removals:
+        raise ValueError(
+            f"generated {label} removal marker names no preserved item: "
+            + ", ".join(f"`{name}`" for name in unknown_removals)
+        )
+    return generated_items, restored, sorted(removed_names)
 
 
 def _normalize_repair_deferred_source_roots(
@@ -16888,16 +16909,17 @@ def _overlay_validation_retry_candidate(
         generated["imports"] = imports
 
     generated_rules = generated.get("rules")
-    generated_rule_names = (
-        {item.get("name") for item in generated_rules if isinstance(item, dict)}
-        if isinstance(generated_rules, list)
-        else set()
-    )
-    rules, restored_rules = _merge_named_yaml_items(
+    rules, restored_rules, removed_rules = _merge_named_yaml_items(
         generated_rules, preserved.get("rules"), label="rules"
     )
     generated["rules"] = rules
+    generated_rule_names = {
+        item["name"]
+        for item in rules
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
     repairs.extend(f"rule:{name}" for name in restored_rules)
+    repairs.extend(f"removed_rule:{name}" for name in removed_rules)
 
     generated_module = generated.get("module")
     preserved_module = preserved.get("module")
@@ -16986,7 +17008,7 @@ def _overlay_validation_retry_candidate(
             preserved_cases = preserved_tests
         if generated_wrapper != preserved_wrapper and test_file.exists():
             raise ValueError("repair overlay cannot change companion test container")
-        merged_tests, restored_tests = _merge_named_yaml_items(
+        merged_tests, restored_tests, removed_tests = _merge_named_yaml_items(
             generated_cases, preserved_cases, label="companion tests"
         )
         merged_test_payload: object = (
@@ -16998,6 +17020,7 @@ def _overlay_validation_retry_candidate(
             artifact_root,
         )
         repairs.extend(f"test:{name}" for name in restored_tests)
+        repairs.extend(f"removed_test:{name}" for name in removed_tests)
 
     _write_eval_artifact_text(
         rulespec_file,

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1729"
+ENCODER_VERSION = "0.2.1730"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1032,9 +1032,7 @@ def test_repair_tombstone_survives_materialization_before_overlay(tmp_path):
         ({"name": "unknown", "repair_remove": True}, "no preserved item"),
     ],
 )
-def test_repair_candidate_overlay_rejects_invalid_tombstones(
-    tmp_path, marker, match
-):
+def test_repair_candidate_overlay_rejects_invalid_tombstones(tmp_path, marker, match):
     artifact_root = tmp_path / "generated"
     rulespec_file = artifact_root / "section.yaml"
     artifact_root.mkdir()

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -847,6 +847,7 @@ def test_retry_candidate_formatter_explicitly_handles_missing_tests():
 
     assert "No companion test file was present" in section
     assert "you may omit unchanged named rules" in section
+    assert "`repair_remove: true`" in section
 
 
 def test_repair_candidate_overlay_restores_omitted_named_items(tmp_path):
@@ -924,6 +925,140 @@ def test_repair_candidate_overlay_restores_omitted_named_items(tmp_path):
     assert "rule:omitted" in repairs
     assert "test:preserved_case" in repairs
     assert "resolved_deferred_output:us:section#added" in repairs
+
+
+def test_repair_candidate_overlay_removes_explicit_named_tombstones(tmp_path):
+    artifact_root = tmp_path / "generated"
+    rulespec_file = artifact_root / "regulations" / "section.yaml"
+    rulespec_file.parent.mkdir(parents=True)
+    rulespec_file.write_text(
+        "format: rulespec/v1\n"
+        "rules:\n"
+        "  - name: obsolete\n"
+        "    repair_remove: true\n"
+        "  - name: retained\n"
+        "    kind: parameter\n"
+        "    dtype: Count\n"
+        "    versions: [{effective_from: '2026-01-01', formula: 2}]\n",
+        encoding="utf-8",
+    )
+    rulespec_file.with_suffix(".test.yaml").write_text(
+        "- name: obsolete_case\n  repair_remove: true\n"
+        "- name: retained_case\n  period: 2026-01\n  input: {}\n  output: {}\n",
+        encoding="utf-8",
+    )
+    candidate = ValidationRetryCandidate(
+        rulespec=(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: obsolete\n"
+            "    kind: parameter\n"
+            "    dtype: Count\n"
+            "    versions: [{effective_from: '2026-01-01', formula: 1}]\n"
+            "  - name: retained\n"
+            "    kind: parameter\n"
+            "    dtype: Count\n"
+            "    versions: [{effective_from: '2026-01-01', formula: 1}]\n"
+        ),
+        tests=(
+            "- name: obsolete_case\n  period: 2026-01\n  input: {}\n  output: {}\n"
+            "- name: retained_case\n  period: 2026-01\n  input: {}\n  output: {}\n"
+        ),
+    )
+
+    repairs = evals_module._overlay_validation_retry_candidate(
+        rulespec_file,
+        artifact_root=artifact_root,
+        candidate=candidate,
+    )
+
+    payload = yaml.safe_load(rulespec_file.read_text(encoding="utf-8"))
+    assert [rule["name"] for rule in payload["rules"]] == ["retained"]
+    assert "repair_remove" not in rulespec_file.read_text(encoding="utf-8")
+    tests = yaml.safe_load(
+        rulespec_file.with_suffix(".test.yaml").read_text(encoding="utf-8")
+    )
+    assert [case["name"] for case in tests] == ["retained_case"]
+    assert "removed_rule:obsolete" in repairs
+    assert "removed_test:obsolete_case" in repairs
+
+
+def test_repair_tombstone_survives_materialization_before_overlay(tmp_path):
+    artifact_root = tmp_path / "generated"
+    rulespec_file = artifact_root / "regulations" / "section.yaml"
+    candidate = ValidationRetryCandidate(
+        rulespec=(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: obsolete\n"
+            "    kind: parameter\n"
+            "    dtype: Count\n"
+            "    versions: [{effective_from: '2026-01-01', formula: 1}]\n"
+        )
+    )
+    response = (
+        "=== FILE: section.yaml ===\n"
+        "format: rulespec/v1\n"
+        "rules:\n"
+        "  - name: obsolete\n"
+        "    repair_remove: true\n"
+    )
+
+    assert evals_module._materialize_eval_artifact(
+        response,
+        rulespec_file,
+        artifact_root=artifact_root,
+    )
+    assert "repair_remove: true" in rulespec_file.read_text(encoding="utf-8")
+
+    repairs = evals_module._overlay_validation_retry_candidate(
+        rulespec_file,
+        artifact_root=artifact_root,
+        candidate=candidate,
+    )
+
+    assert yaml.safe_load(rulespec_file.read_text(encoding="utf-8"))["rules"] == []
+    assert repairs == ("removed_rule:obsolete",)
+
+
+@pytest.mark.parametrize(
+    "marker,match",
+    [
+        ({"name": "obsolete", "repair_remove": False}, "repair_remove: true"),
+        (
+            {"name": "obsolete", "repair_remove": True, "kind": "derived"},
+            "only name and repair_remove",
+        ),
+        ({"name": "unknown", "repair_remove": True}, "no preserved item"),
+    ],
+)
+def test_repair_candidate_overlay_rejects_invalid_tombstones(
+    tmp_path, marker, match
+):
+    artifact_root = tmp_path / "generated"
+    rulespec_file = artifact_root / "section.yaml"
+    artifact_root.mkdir()
+    rulespec_file.write_text(
+        yaml.safe_dump({"format": "rulespec/v1", "rules": [marker]}),
+        encoding="utf-8",
+    )
+    candidate = ValidationRetryCandidate(
+        rulespec=(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: obsolete\n"
+            "    kind: parameter\n"
+            "    dtype: Count\n"
+            "    versions: [{effective_from: '2026-01-01', formula: 1}]\n"
+        )
+    )
+
+    with pytest.raises(ValueError, match=match):
+        evals_module._overlay_validation_retry_candidate(
+            rulespec_file,
+            artifact_root=artifact_root,
+            candidate=candidate,
+        )
 
 
 def test_repair_candidate_overlay_normalizes_destination_root_deferrals(tmp_path):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -994,7 +994,8 @@ def test_repair_tombstone_survives_materialization_before_overlay(tmp_path):
             "    kind: parameter\n"
             "    dtype: Count\n"
             "    versions: [{effective_from: '2026-01-01', formula: 1}]\n"
-        )
+        ),
+        tests=("- name: obsolete_case\n  period: 2026-01\n  input: {}\n  output: {}\n"),
     )
     response = (
         "=== FILE: section.yaml ===\n"
@@ -1002,6 +1003,9 @@ def test_repair_tombstone_survives_materialization_before_overlay(tmp_path):
         "rules:\n"
         "  - name: obsolete\n"
         "    repair_remove: true\n"
+        "=== FILE: section.test.yaml ===\n"
+        "- name: obsolete_case\n"
+        "  repair_remove: true\n"
     )
 
     assert evals_module._materialize_eval_artifact(
@@ -1010,6 +1014,10 @@ def test_repair_tombstone_survives_materialization_before_overlay(tmp_path):
         artifact_root=artifact_root,
     )
     assert "repair_remove: true" in rulespec_file.read_text(encoding="utf-8")
+    test_file = rulespec_file.with_suffix(".test.yaml")
+    assert yaml.safe_load(test_file.read_text(encoding="utf-8")) == [
+        {"name": "obsolete_case", "repair_remove": True}
+    ]
 
     repairs = evals_module._overlay_validation_retry_candidate(
         rulespec_file,
@@ -1018,7 +1026,8 @@ def test_repair_tombstone_survives_materialization_before_overlay(tmp_path):
     )
 
     assert yaml.safe_load(rulespec_file.read_text(encoding="utf-8"))["rules"] == []
-    assert repairs == ("removed_rule:obsolete",)
+    assert yaml.safe_load(test_file.read_text(encoding="utf-8")) == []
+    assert repairs == ("removed_rule:obsolete", "removed_test:obsolete_case")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1030,6 +1030,25 @@ def test_repair_tombstone_survives_materialization_before_overlay(tmp_path):
     assert repairs == ("removed_rule:obsolete", "removed_test:obsolete_case")
 
 
+def test_single_amount_test_normalizer_preserves_exact_repair_tombstone():
+    normalized = evals_module._normalize_single_amount_row_test_content(
+        "- name: alternate_branch_case\n  repair_remove: true\n",
+        rulespec_content=(
+            "format: rulespec/v1\n"
+            "period: Year\n"
+            "rules:\n"
+            "  - name: amount\n"
+            "    kind: parameter\n"
+            "    dtype: Money\n"
+            "    versions: [{effective_from: '2026-01-01', formula: 1}]\n"
+        ),
+    )
+
+    assert yaml.safe_load(normalized) == [
+        {"name": "alternate_branch_case", "repair_remove": True}
+    ]
+
+
 @pytest.mark.parametrize(
     "marker,match",
     [

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1729"
+ENCODER_VERSION = "0.2.1730"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1729"
+ENCODER_VERSION = "0.2.1730"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1729"
+ENCODER_VERSION = "0.2.1730"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1729"
+ENCODER_VERSION = "0.2.1730"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1729"
+ENCODER_VERSION = "0.2.1730"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1729"
+ENCODER_VERSION = "0.2.1730"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1729"')
+        .startswith('__version__ = "0.2.1730"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1729"
+    assert encoder_package["version"] == "0.2.1730"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1729"
+    assert project["project"]["version"] == "0.2.1730"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1729"')
+        .startswith('__version__ = "0.2.1730"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1729"
+    assert encoder_package["version"] == "0.2.1730"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1729"
+    assert project["project"]["version"] == "0.2.1730"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1729"')
+        .startswith('__version__ = "0.2.1730"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1729"
+ENCODER_VERSION = "0.2.1730"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1729"
+version = "0.2.1730"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- add an exact `repair_remove: true` tombstone contract for named rules and companion cases in signed validation-retry overlays
- reject malformed, duplicate, or unknown deletion requests and strip valid markers before validation
- compute deferred-output resolution from the post-overlay rule set so deleted rules cannot resolve outputs
- preserve tombstones through dated and single-amount companion-case normalization

## Why
The immigration repair candidate must remove an obsolete derived helper. The previous integrity overlay restored every omitted hash-bound rule, making that valid structural repair impossible.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/axiom_encode tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused tombstone/overlay checks: 13 passed
- `uv run pytest tests/test_evals.py -q`: 787 passed
- version and pin checks: 18 passed
- `COPYFILE_DISABLE=1 uv run pytest -q`: 13,503 passed, 126 skipped
- exact-head GitHub CI and signing-supervisor jobs: green

## Cycle
Independent review found two normalization defects: dated normalization added fields to exact tombstones, and the single-amount case filter discarded tombstones with alternate case names. Both were fixed and regression-tested. The final independent review of the substantive behavior head reported no actionable findings; subsequent changes only updated package/version pins required by repository provenance checks.