### PR TITLE
Make signed repair tombstones idempotent across retries

### DIFF
--- a/changelog.d/idempotent-repair-tombstones.fixed.md
+++ b/changelog.d/idempotent-repair-tombstones.fixed.md
@@ -1,0 +1,1 @@
+Allow a signed repair retry to repeat an exact deletion tombstone for a rule or companion case already removed by an earlier attempt in the same repair chain.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1730"
+version = "0.2.1731"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1730"
+__version__ = "0.2.1731"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26934,6 +26934,43 @@ def _encode_validation_retry_context(
         raise RuntimeError(
             "Immediately preceding validator-rejected candidate is unavailable"
         )
+    if initial_retry_candidate is not None:
+
+        def named_items(content: str, *, tests: bool) -> set[str]:
+            try:
+                payload = yaml.safe_load(content)
+            except (yaml.YAMLError, RecursionError):
+                return set()
+            if tests:
+                items = payload.get("cases") if isinstance(payload, dict) else payload
+            else:
+                items = payload.get("rules") if isinstance(payload, dict) else None
+            if not isinstance(items, list):
+                return set()
+            return {
+                item["name"]
+                for item in items
+                if isinstance(item, dict) and isinstance(item.get("name"), str)
+            }
+
+        initial_rule_names = named_items(initial_retry_candidate.rulespec, tests=False)
+        current_rule_names = named_items(candidate.rulespec, tests=False)
+        initial_test_names = (
+            named_items(initial_retry_candidate.tests, tests=True)
+            if initial_retry_candidate.tests is not None
+            else set()
+        )
+        current_test_names = (
+            named_items(candidate.tests, tests=True)
+            if candidate.tests is not None
+            else set()
+        )
+        candidate = ValidationRetryCandidate(
+            candidate.rulespec,
+            candidate.tests,
+            tuple(sorted(initial_rule_names - current_rule_names)),
+            tuple(sorted(initial_test_names - current_test_names)),
+        )
     return _encode_validation_retry_feedback(prior_attempts), candidate
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -166,6 +166,8 @@ class ValidationRetryCandidate:
 
     rulespec: str
     tests: str | None = None
+    allowed_missing_rule_removals: tuple[str, ...] = ()
+    allowed_missing_test_removals: tuple[str, ...] = ()
     rulespec_sha256: str = field(init=False)
     tests_sha256: str | None = field(init=False)
 
@@ -174,6 +176,18 @@ class ValidationRetryCandidate:
             raise ValueError("Validation retry candidate RuleSpec must be non-empty")
         if self.tests is not None and not isinstance(self.tests, str):
             raise TypeError("Validation retry candidate tests must be text or None")
+        for label, names in (
+            ("rule", self.allowed_missing_rule_removals),
+            ("companion test", self.allowed_missing_test_removals),
+        ):
+            if (
+                not isinstance(names, tuple)
+                or any(not isinstance(name, str) or not name for name in names)
+                or len(set(names)) != len(names)
+            ):
+                raise ValueError(
+                    f"Allowed missing {label} removals must be unique non-empty names"
+                )
         rulespec_bytes = self.rulespec.encode("utf-8")
         tests_bytes = self.tests.encode("utf-8") if self.tests is not None else b""
         if len(rulespec_bytes) > VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES:
@@ -16807,6 +16821,7 @@ def _merge_named_yaml_items(
     preserved: object,
     *,
     label: str,
+    allowed_missing_removals: Sequence[str] = (),
 ) -> tuple[list[object], list[str], list[str]]:
     """Restore omitted hash-bound items while allowing explicit replacements."""
 
@@ -16844,7 +16859,9 @@ def _merge_named_yaml_items(
             generated_items.append(item)
             generated_names.add(name)
             restored.append(name)
-    unknown_removals = sorted(removed_names - preserved_names)
+    unknown_removals = sorted(
+        removed_names - preserved_names - set(allowed_missing_removals)
+    )
     if unknown_removals:
         raise ValueError(
             f"generated {label} removal marker names no preserved item: "
@@ -16929,7 +16946,10 @@ def _overlay_validation_retry_candidate(
 
     generated_rules = generated.get("rules")
     rules, restored_rules, removed_rules = _merge_named_yaml_items(
-        generated_rules, preserved.get("rules"), label="rules"
+        generated_rules,
+        preserved.get("rules"),
+        label="rules",
+        allowed_missing_removals=candidate.allowed_missing_rule_removals,
     )
     generated["rules"] = rules
     generated_rule_names = {
@@ -17028,7 +17048,10 @@ def _overlay_validation_retry_candidate(
         if generated_wrapper != preserved_wrapper and test_file.exists():
             raise ValueError("repair overlay cannot change companion test container")
         merged_tests, restored_tests, removed_tests = _merge_named_yaml_items(
-            generated_cases, preserved_cases, label="companion tests"
+            generated_cases,
+            preserved_cases,
+            label="companion tests",
+            allowed_missing_removals=candidate.allowed_missing_test_removals,
         )
         merged_test_payload: object = (
             {"cases": merged_tests} if preserved_wrapper else merged_tests

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1730"
+ENCODER_VERSION = "0.2.1731"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15022,6 +15022,36 @@ rules:
         assert feedback == ("missing required witness",)
         assert candidate is initial
 
+    def test_encode_retry_allows_repeating_cross_run_tombstones(self):
+        import axiom_encode.cli as cli_module
+
+        initial = cli_module.ValidationRetryCandidate(
+            rulespec=(
+                "format: rulespec/v1\nrules:\n"
+                "  - name: obsolete\n    kind: derived\n    versions: []\n"
+            ),
+            tests="- name: obsolete_case\n  input: {}\n  output: {}\n",
+        )
+        rejected = cli_module.ValidationRetryCandidate(
+            rulespec="format: rulespec/v1\nrules: []\n",
+            tests="[]\n",
+        )
+        failed_attempt = cli_module._FailedEncodeAttempt(
+            result=SimpleNamespace(metrics=SimpleNamespace()),
+            error="remaining validation issue",
+            candidate=rejected,
+            validation_issues=("remaining validation issue",),
+        )
+
+        _, candidate = cli_module._encode_validation_retry_context(
+            [failed_attempt],
+            initial_retry_candidate=initial,
+        )
+
+        assert candidate is not None
+        assert candidate.allowed_missing_rule_removals == ("obsolete",)
+        assert candidate.allowed_missing_test_removals == ("obsolete_case",)
+
     def test_encode_replaces_cross_run_candidate_after_in_run_rejection(self, tmp_path):
         candidate_root = tmp_path / "preserved-candidate"
         candidate_path = Path("statutes/26/1/j/2.yaml")

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -983,6 +983,41 @@ def test_repair_candidate_overlay_removes_explicit_named_tombstones(tmp_path):
     assert "removed_test:obsolete_case" in repairs
 
 
+def test_repair_candidate_overlay_accepts_idempotent_named_tombstones(tmp_path):
+    artifact_root = tmp_path / "generated"
+    rulespec_file = artifact_root / "section.yaml"
+    artifact_root.mkdir()
+    rulespec_file.write_text(
+        "format: rulespec/v1\nrules:\n  - name: obsolete\n    repair_remove: true\n",
+        encoding="utf-8",
+    )
+    rulespec_file.with_suffix(".test.yaml").write_text(
+        "- name: obsolete_case\n  repair_remove: true\n",
+        encoding="utf-8",
+    )
+    candidate = ValidationRetryCandidate(
+        rulespec="format: rulespec/v1\nrules: []\n",
+        tests="[]\n",
+        allowed_missing_rule_removals=("obsolete",),
+        allowed_missing_test_removals=("obsolete_case",),
+    )
+
+    repairs = evals_module._overlay_validation_retry_candidate(
+        rulespec_file,
+        artifact_root=artifact_root,
+        candidate=candidate,
+    )
+
+    assert yaml.safe_load(rulespec_file.read_text(encoding="utf-8"))["rules"] == []
+    assert (
+        yaml.safe_load(
+            rulespec_file.with_suffix(".test.yaml").read_text(encoding="utf-8")
+        )
+        == []
+    )
+    assert repairs == ("removed_rule:obsolete", "removed_test:obsolete_case")
+
+
 def test_repair_tombstone_survives_materialization_before_overlay(tmp_path):
     artifact_root = tmp_path / "generated"
     rulespec_file = artifact_root / "regulations" / "section.yaml"

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1730"
+ENCODER_VERSION = "0.2.1731"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1730"
+ENCODER_VERSION = "0.2.1731"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1730"
+ENCODER_VERSION = "0.2.1731"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1730"
+ENCODER_VERSION = "0.2.1731"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1730"
+ENCODER_VERSION = "0.2.1731"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1730"
+ENCODER_VERSION = "0.2.1731"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1730"')
+        .startswith('__version__ = "0.2.1731"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1730"
+    assert encoder_package["version"] == "0.2.1731"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1730"
+    assert project["project"]["version"] == "0.2.1731"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1730"')
+        .startswith('__version__ = "0.2.1731"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1730"
+    assert encoder_package["version"] == "0.2.1731"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1730"
+    assert project["project"]["version"] == "0.2.1731"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1730"')
+        .startswith('__version__ = "0.2.1731"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1730"
+ENCODER_VERSION = "0.2.1731"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1730"
+version = "0.2.1731"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- carry an allowlist of names proven removed from the original signed repair candidate into later retry attempts
- accept repeated exact tombstones only for those names
- keep rejecting malformed and arbitrary unknown removal markers
- cover rule and companion-case retry behavior

## Checks
- focused retry/tombstone tests: 6 passed
- `COPYFILE_DISABLE=1 uv run pytest -q`: 13,505 passed, 126 skipped
- Ruff lint and format checks: green
- compileall: green
- GitHub CI and both signing-supervisor builds: green

## Cycle
Independent review found no actionable findings. It verified that the allowlist is derived from the original signed cross-run candidate and that arbitrary unknown tombstones remain rejected.