### PR TITLE
Fix generated local input declarations

### DIFF
--- a/changelog.d/declare-local-formula-inputs.fixed.md
+++ b/changelog.d/declare-local-formula-inputs.fixed.md
@@ -1,0 +1,1 @@
+Require generated bare local formula facts to be declared in the RuleSpec module's top-level input contract, and include that requirement in source-completeness retry feedback.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1731"
+version = "0.2.1732"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1731"
+__version__ = "0.2.1732"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -10935,7 +10935,7 @@ RuleSpec requirements:
   amounts described by that upstream source.
 - If an upstream output is already executable, do not replace it with a local
   placeholder fact or compatibility alias.
-- Do not encode simple unary factual inputs as `kind: data_relation` rules. If a formula needs a local true/false fact, reference a descriptive bare fact name in the formula and put that fact in tests as `{target_ref_prefix + "#input.<fact>" if target_ref_prefix else "<jurisdiction>:<path>#input.<fact>"}`.
+- Do not encode simple unary factual inputs as `kind: data_relation` rules. If a formula needs a local true/false fact, reference a descriptive bare fact name in the formula, declare that fact in the module's top-level `inputs` list with its `entity`, `dtype`, and `period`, and put that fact in tests as `{target_ref_prefix + "#input.<fact>" if target_ref_prefix else "<jurisdiction>:<path>#input.<fact>"}`.
 - Use `kind: data_relation` only for structural runtime predicates with explicit `data_relation.predicate`, `data_relation.arity`, and `data_relation.arguments`.
 - If the requested source text includes a limitation, cap, exception, or
   cross-referenced subparagraph that changes the final exported amount, the

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -13950,7 +13950,8 @@ def _opaque_same_source_condition_input_issues(
         "version(s) delegate multiple conjunctive factual gates stated in their "
         "exact authoritative source clause to too few terminal local inputs or "
         f"canonical imports: {'; '.join(rendered)}. Encode the source-stated facts "
-        "as distinct local inputs or canonical imports, combine them in a "
+        "as distinct local inputs or canonical imports, declare every local fact "
+        "in the module's top-level `inputs` list, combine them in a "
         "source-proved derived Judgment, and test each gate. Reserve aggregate "
         "boundary statuses for source-atomic or externally determined conditions."
     ]

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -801,7 +801,8 @@ _NAMING_PROTOCOL = """- Do not create standalone small-number parameters just to
   `member_of_household`. Put arity under `data_relation.arity`.
 - Do not encode simple unary factual inputs as `kind: data_relation` rules. If
   a formula needs a local true/false fact, reference a descriptive bare fact
-  name in the formula and put that fact in tests as
+  name in the formula, declare that fact in the module's top-level `inputs`
+  list with its `entity`, `dtype`, and `period`, and put that fact in tests as
   `<jurisdiction>:<repo-path>#input.<fact>`.
 - If an upstream output is already executable, do not replace it with a local
   placeholder fact or compatibility alias.

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1731"
+ENCODER_VERSION = "0.2.1732"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -123,6 +123,7 @@ def _assert_encoder_prompt_topics(prompt: str) -> None:
         "Never drop the jurisdiction prefix",
         "Importing an adjacent upstream output only as proof",
         "is not an executable dependency",
+        "declare that fact in the module's top-level `inputs`",
         "purpose-limited replacement rate",
         "not as `section_<cited>_*`",
         "predicate for the excepted category",

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1731"
+ENCODER_VERSION = "0.2.1732"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1731"
+ENCODER_VERSION = "0.2.1732"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1731"
+ENCODER_VERSION = "0.2.1732"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1731"
+ENCODER_VERSION = "0.2.1732"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1731"
+ENCODER_VERSION = "0.2.1732"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1731"
+ENCODER_VERSION = "0.2.1732"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1731"')
+        .startswith('__version__ = "0.2.1732"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1731"
+    assert encoder_package["version"] == "0.2.1732"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1731"
+    assert project["project"]["version"] == "0.2.1732"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1731"')
+        .startswith('__version__ = "0.2.1732"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1731"
+    assert encoder_package["version"] == "0.2.1732"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1731"
+    assert project["project"]["version"] == "0.2.1732"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1731"')
+        .startswith('__version__ = "0.2.1732"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1731"
+ENCODER_VERSION = "0.2.1732"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -365,6 +365,10 @@ def test_rejects_aggregate_boolean_for_same_source_spouse_credit_gates():
         "spouse_blindness_credit_conditions_hold",
     )
     assert any(
+        "declare every local fact in the module's top-level `inputs` list" in issue
+        for issue in result.issues
+    )
+    assert any(
         "source-explicit-conditions" in issue
         for issue in _pipeline_issues(
             content,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1731"
+version = "0.2.1732"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- require generated bare formula facts to be declared in the RuleSpec module top-level `inputs` contract
- repeat that requirement in source-completeness retry diagnostics
- add regression assertions and bump the encoder to 0.2.1732

## Why

The protected 7 CFR 273.4 immigration replay generated the correct battered-alien conjunction, but omitted its five facts from top-level `inputs`. Source completeness correctly rejected the otherwise coherent formula. The encoder guidance previously required bare facts and `#input` test values without explicitly requiring their declarations.

## Review cycle

Independent `codex review --uncommitted` completed after the final changelog change with no actionable findings.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused encoder/source-completeness suite: 5,896 passed
- broader validation and version-registry suite: 8,390 passed, 31 skipped
- `python -m towncrier build --draft --version 0.0.0`
- `git diff --check`
- full `uv run pytest` is running locally; required CI must be green before merge