### PR TITLE
Keep invalid repair overlays retryable

### DIFF
--- a/changelog.d/retry-invalid-repair-overlay.fixed.md
+++ b/changelog.d/retry-invalid-repair-overlay.fixed.md
@@ -1,0 +1,1 @@
+Keep bounded encoder repairs running when a generated retry cannot be overlaid onto its retained candidate, so duplicate names or malformed YAML become validator feedback instead of aborting the remaining attempts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1733"
+version = "0.2.1734"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1733"
+__version__ = "0.2.1734"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -160,6 +160,10 @@ EvalOracleMode = Literal["none", "policyengine"]
 EvalFailureKind = Literal["timeout", "validation", "error"]
 
 
+class _PreservedRepairOverlayError(ValueError):
+    """The retained retry candidate cannot serve as an overlay base."""
+
+
 @dataclass(frozen=True)
 class ValidationRetryCandidate:
     """One rejected generated pair retained as bounded retry-edit context."""
@@ -8831,29 +8835,71 @@ def _run_single_eval(
             required_test_case_contracts=required_test_case_contracts,
         )
     )
+    overlay_validation_issue: str | None = None
     if (
         wrote_artifact
         and validation_retry_candidate is not None
         and not repair_candidate_tests_only
     ):
-        overlay_repairs = _overlay_validation_retry_candidate(
-            output_file,
-            artifact_root=artifact_root,
-            candidate=validation_retry_candidate,
-        )
-        if overlay_repairs:
-            print("  repair_candidate_overlay:" + ",".join(overlay_repairs))
-        materialized_paths = frozenset(
-            set(materialized_paths)
-            | {
+        try:
+            overlay_repairs = _overlay_validation_retry_candidate(
                 output_file,
-                *(
-                    {_rulespec_test_path(output_file)}
-                    if validation_retry_candidate.tests is not None
-                    else set()
-                ),
-            }
-        )
+                artifact_root=artifact_root,
+                candidate=validation_retry_candidate,
+            )
+        except _PreservedRepairOverlayError as exc:
+            # Do not restore an unusable base, but also do not accept this
+            # attempt: repair prompts may emit partial artifacts. Retaining the
+            # new output lets the next bounded attempt recover from a parseable
+            # base, while the explicit feedback requires a complete replacement.
+            overlay_validation_issue = (
+                "Retained repair candidate is unusable; emit a complete "
+                f"replacement: {exc}"
+            )
+            print(f"  repair_candidate_overlay_base_skipped:{exc}")
+        except ValueError as exc:
+            # An overlay failure is an ordinary validator rejection, not an
+            # encoder crash. Restore the retained candidate before validation
+            # so malformed or duplicate partial output cannot replace the
+            # healthier candidate used by later bounded attempts.
+            overlay_validation_issue = f"Repair candidate overlay failed: {exc}"
+            print(f"  repair_candidate_overlay_skipped:{exc}")
+            _clear_eval_target_artifacts(output_file, artifact_root)
+            _write_eval_artifact_text(
+                output_file,
+                validation_retry_candidate.rulespec,
+                artifact_root,
+            )
+            restored_paths = {output_file}
+            if validation_retry_candidate.tests is not None:
+                restored_test_file = _rulespec_test_path(output_file)
+                _write_eval_artifact_text(
+                    restored_test_file,
+                    validation_retry_candidate.tests,
+                    artifact_root,
+                )
+                restored_paths.add(restored_test_file)
+            materialized_paths = frozenset(
+                (
+                    set(materialized_paths)
+                    - {output_file, _rulespec_test_path(output_file)}
+                )
+                | restored_paths
+            )
+        else:
+            if overlay_repairs:
+                print("  repair_candidate_overlay:" + ",".join(overlay_repairs))
+            materialized_paths = frozenset(
+                set(materialized_paths)
+                | {
+                    output_file,
+                    *(
+                        {_rulespec_test_path(output_file)}
+                        if validation_retry_candidate.tests is not None
+                        else set()
+                    ),
+                }
+            )
     wrote_artifact = wrote_artifact and output_file in materialized_paths
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
@@ -8896,10 +8942,16 @@ def _run_single_eval(
             replacement_overlay_scope=replacement_overlay_scope,
             allow_artifact_repairs=not repair_candidate_tests_only,
         )
+    if overlay_validation_issue is not None and metrics is not None:
+        metrics.ci_pass = False
+        if overlay_validation_issue not in metrics.ci_issues:
+            metrics.ci_issues.append(overlay_validation_issue)
     validation_error = _eval_artifact_validation_error(
         metrics,
         require_policyengine=oracle == "policyengine",
     )
+    if overlay_validation_issue is not None and validation_error is None:
+        validation_error = "Generated RuleSpec failed CI validation"
     outcome = _eval_result_outcome(
         response,
         wrote_artifact=wrote_artifact,
@@ -16955,6 +17007,68 @@ def _normalize_repair_deferred_source_roots(
     return normalized, repairs
 
 
+def _repair_overlay_candidate_base_issue(
+    candidate: ValidationRetryCandidate,
+) -> str | None:
+    """Return why a retained candidate cannot safely receive partial overlays."""
+
+    try:
+        preserved = yaml.safe_load(candidate.rulespec)
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        return f"preserved repair overlay RuleSpec must be valid UTF-8 YAML: {exc}"
+    if not isinstance(preserved, dict):
+        return "preserved repair overlay RuleSpec must be a YAML mapping"
+
+    imports = preserved.get("imports", [])
+    if not isinstance(imports, list) or any(
+        not isinstance(import_target, str) for import_target in imports
+    ):
+        return "preserved repair overlay imports must be a list of strings"
+    preserved_rules = preserved.get("rules")
+    if not isinstance(preserved_rules, list):
+        return "preserved repair overlay rules must be a list"
+    try:
+        _merge_named_yaml_items([], preserved_rules, label="rules")
+    except ValueError as exc:
+        return str(exc)
+
+    module = preserved.get("module")
+    if isinstance(module, dict):
+        deferred_outputs = module.get("deferred_outputs", [])
+        if not isinstance(deferred_outputs, list):
+            return "preserved repair overlay deferred outputs must be a list"
+        seen_outputs: set[str] = set()
+        for item in deferred_outputs:
+            if not isinstance(item, dict) or not isinstance(item.get("output"), str):
+                return "preserved deferred outputs must name an output"
+            output = item["output"]
+            if output in seen_outputs:
+                return (
+                    f"preserved deferred outputs contains duplicate output `{output}`"
+                )
+            seen_outputs.add(output)
+
+    if candidate.tests is None:
+        return None
+    try:
+        preserved_tests = yaml.safe_load(candidate.tests)
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        return f"preserved repair overlay tests must be valid UTF-8 YAML: {exc}"
+    if isinstance(preserved_tests, dict):
+        if set(preserved_tests) != {"cases"}:
+            return "preserved companion test mapping must contain cases"
+        preserved_cases = preserved_tests["cases"]
+    else:
+        preserved_cases = preserved_tests
+    if not isinstance(preserved_cases, list):
+        return "preserved companion test cases must be a list"
+    try:
+        _merge_named_yaml_items([], preserved_cases, label="companion tests")
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
 def _overlay_validation_retry_candidate(
     rulespec_file: Path,
     *,
@@ -16963,13 +17077,22 @@ def _overlay_validation_retry_candidate(
 ) -> tuple[str, ...]:
     """Overlay partial repair output onto its integrity-bound prior candidate."""
 
+    base_issue = _repair_overlay_candidate_base_issue(candidate)
+    if base_issue is not None:
+        raise _PreservedRepairOverlayError(base_issue)
     try:
         generated = yaml.safe_load(rulespec_file.read_text(encoding="utf-8"))
-        preserved = yaml.safe_load(candidate.rulespec)
     except (OSError, UnicodeError, yaml.YAMLError, RecursionError) as exc:
-        raise ValueError("repair overlay RuleSpec must be valid UTF-8 YAML") from exc
-    if not isinstance(generated, dict) or not isinstance(preserved, dict):
-        raise ValueError("repair overlay RuleSpec must be a YAML mapping")
+        raise ValueError(
+            "generated repair overlay RuleSpec must be valid UTF-8 YAML"
+        ) from exc
+    preserved = yaml.safe_load(candidate.rulespec)
+    if not isinstance(generated, dict):
+        raise ValueError("generated repair overlay RuleSpec must be a YAML mapping")
+    if not isinstance(preserved, dict):
+        raise _PreservedRepairOverlayError(
+            "preserved repair overlay RuleSpec must be a YAML mapping"
+        )
 
     repairs: list[str] = []
     generated_imports = generated.get("imports", [])

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1733"
+ENCODER_VERSION = "0.2.1734"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1733"
+ENCODER_VERSION = "0.2.1734"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1733"
+ENCODER_VERSION = "0.2.1734"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1733"
+ENCODER_VERSION = "0.2.1734"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1733"
+ENCODER_VERSION = "0.2.1734"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1733"
+ENCODER_VERSION = "0.2.1734"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1733"
+ENCODER_VERSION = "0.2.1734"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_repair_overlay_failure_is_retryable.py
+++ b/tests/test_repair_overlay_failure_is_retryable.py
@@ -1,0 +1,266 @@
+"""An unreadable generated RuleSpec must not kill the bounded retry loop.
+
+A protected re-encode of ``ca/policy/cra/benefits-2026/federal-family-and-
+climate-benefits`` died on its second attempt because the model emitted one
+proof excerpt as an unquoted YAML scalar containing ``": "``. The overlay
+step raised ``ValueError`` before any validator ran, the exception escaped
+``_run_single_eval``, and the run lost its two remaining attempts, its
+final rejected candidate, and the near-passing artifact from attempt one.
+
+An artifact the overlay cannot read is an ordinary validator rejection: the
+overlay failure is recorded as a CI issue and returned with the standard CI
+failure classification so the bounded retry loop regenerates it with feedback.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from axiom_encode.harness.evals import (
+    EvalPromptResponse,
+    EvalWorkspace,
+    ValidationRetryCandidate,
+    _repair_overlay_candidate_base_issue,
+    _run_single_eval,
+    parse_runner_spec,
+    resolve_corpus_source_unit,
+)
+from tests.release_object_fixtures import bind_test_corpus_release
+
+_OVERLAY_ERROR = "repair overlay RuleSpec must be valid UTF-8 YAML"
+
+
+def _make_workspace(root: Path) -> EvalWorkspace:
+    root.mkdir(parents=True, exist_ok=True)
+    source_text_file = root / "source.txt"
+    source_text_file.write_text("operative source text\n")
+    manifest_file = root / "context-manifest.json"
+    manifest_file.write_text("{}")
+    return EvalWorkspace(
+        root=root,
+        source_text_file=source_text_file,
+        manifest_file=manifest_file,
+    )
+
+
+def _bind_corpus(tmp_path: Path):
+    corpus_path = tmp_path / "corpus"
+    (corpus_path / "data/corpus/provisions").mkdir(parents=True)
+    selector = corpus_path / "manifests/releases/overlay-retry-test-release.json"
+    selector.parent.mkdir(parents=True)
+    selector.write_text(
+        json.dumps(
+            {
+                "name": "overlay-retry-test-release",
+                "scopes": [
+                    {
+                        "jurisdiction": "us-ca",
+                        "document_class": "regulation",
+                        "version": "test-version",
+                    }
+                ],
+            }
+        )
+    )
+    provision_file = (
+        corpus_path / "data/corpus/provisions/us-ca/regulation/test-version.jsonl"
+    )
+    provision_file.parent.mkdir(parents=True, exist_ok=True)
+    provision_file.write_text(
+        json.dumps(
+            {
+                "id": "overlay-retry",
+                "citation_path": "us-ca/regulation/mpp/63-503",
+                "body": "63-503 operative source text",
+                "jurisdiction": "us-ca",
+                "document_class": "regulation",
+                "version": "test-version",
+                "source_path": "sources/us-ca/regulation/test-version",
+                "source_as_of": "2026-01-01",
+                "expression_date": "2026-01-01",
+            }
+        )
+        + "\n"
+    )
+    return bind_test_corpus_release(
+        corpus_path,
+        "overlay-retry-test-release",
+        [("us-ca", "regulation", "test-version")],
+    )
+
+
+def test_unreadable_overlay_candidate_does_not_abort_the_eval(tmp_path, capsys):
+    output_root = tmp_path / "out"
+    workspace = _make_workspace(output_root / "_eval_workspaces" / "workspace")
+    policy_path = tmp_path / "policy"
+    policy_path.mkdir()
+    rules_path = tmp_path / "rules"
+    rules_path.mkdir()
+
+    corpus_release = _bind_corpus(tmp_path)
+    source_unit = resolve_corpus_source_unit(
+        "us-ca/regulation/mpp/63-503",
+        corpus_release,
+    )
+    response = EvalPromptResponse(
+        text="format: rulespec/v1\nmodule:\n  summary: stub\nrules: []\n",
+        duration_ms=1,
+    )
+    candidate = ValidationRetryCandidate(
+        rulespec=(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: preserved\n"
+            "    kind: parameter\n"
+            "    dtype: Count\n"
+            "    versions: [{effective_from: '2026-01-01', formula: 1}]\n"
+        )
+    )
+
+    with (
+        patch(
+            "axiom_encode.harness.evals.resolve_corpus_source_unit",
+            return_value=source_unit,
+        ),
+        patch(
+            "axiom_encode.harness.evals.prepare_eval_workspace",
+            return_value=workspace,
+        ),
+        patch("axiom_encode.harness.evals._run_prompt_eval", return_value=response),
+        patch("axiom_encode.harness.evals.evaluate_artifact", return_value=None),
+        patch("axiom_encode.harness.evals._hydrate_eval_root"),
+        patch(
+            "axiom_encode.harness.evals._overlay_validation_retry_candidate",
+            side_effect=ValueError(_OVERLAY_ERROR),
+        ),
+    ):
+        result = _run_single_eval(
+            citation="us-ca/regulation/mpp/63-503",
+            runner=parse_runner_spec("codex:gpt-5.5"),
+            output_root=output_root,
+            policy_path=policy_path,
+            runtime_axiom_rules_path=rules_path,
+            corpus_release=corpus_release,
+            mode="cold",
+            extra_context_paths=[],
+            source_unit=source_unit,
+            validation_retry_candidate=candidate,
+        )
+
+    assert result is not None, (
+        "An unreadable overlay candidate must be reported through the normal "
+        "eval result so the bounded retry loop keeps its remaining attempts"
+    )
+    assert result.success is False
+    assert result.error == "Generated RuleSpec failed CI validation"
+    assert result.failure_kind == "validation"
+    assert Path(result.output_file).read_text() == candidate.rulespec
+    assert (
+        f"repair_candidate_overlay_skipped:{_OVERLAY_ERROR}" in capsys.readouterr().out
+    )
+
+
+def test_unreadable_retained_candidate_does_not_replace_valid_generation(
+    tmp_path, capsys
+):
+    output_root = tmp_path / "out"
+    workspace = _make_workspace(output_root / "_eval_workspaces" / "workspace")
+    policy_path = tmp_path / "policy"
+    policy_path.mkdir()
+    rules_path = tmp_path / "rules"
+    rules_path.mkdir()
+
+    corpus_release = _bind_corpus(tmp_path)
+    source_unit = resolve_corpus_source_unit(
+        "us-ca/regulation/mpp/63-503",
+        corpus_release,
+    )
+    generated = "format: rulespec/v1\nmodule:\n  summary: recovered\nrules: []\n"
+    response = EvalPromptResponse(text=generated, duration_ms=1)
+    candidate = ValidationRetryCandidate(rulespec="format: [unterminated\n")
+
+    with (
+        patch(
+            "axiom_encode.harness.evals.resolve_corpus_source_unit",
+            return_value=source_unit,
+        ),
+        patch(
+            "axiom_encode.harness.evals.prepare_eval_workspace",
+            return_value=workspace,
+        ),
+        patch("axiom_encode.harness.evals._run_prompt_eval", return_value=response),
+        patch("axiom_encode.harness.evals.evaluate_artifact", return_value=None),
+        patch("axiom_encode.harness.evals._hydrate_eval_root"),
+    ):
+        result = _run_single_eval(
+            citation="us-ca/regulation/mpp/63-503",
+            runner=parse_runner_spec("codex:gpt-5.5"),
+            output_root=output_root,
+            policy_path=policy_path,
+            runtime_axiom_rules_path=rules_path,
+            corpus_release=corpus_release,
+            mode="cold",
+            extra_context_paths=[],
+            source_unit=source_unit,
+            validation_retry_candidate=candidate,
+        )
+
+    assert result is not None
+    assert result.success is False
+    assert result.error == "Generated RuleSpec failed CI validation"
+    assert Path(result.output_file).read_text() == generated
+    assert "repair_candidate_overlay_base_skipped:" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected_issue"),
+    [
+        (
+            ValidationRetryCandidate(
+                rulespec="format: rulespec/v1\nimports: [valid, 7]\nrules: []\n"
+            ),
+            "imports must be a list of strings",
+        ),
+        (
+            ValidationRetryCandidate(
+                rulespec=(
+                    "format: rulespec/v1\nrules:\n"
+                    "  - {name: duplicate, kind: parameter}\n"
+                    "  - {name: duplicate, kind: parameter}\n"
+                )
+            ),
+            "preserved rules contains duplicate name `duplicate`",
+        ),
+        (
+            ValidationRetryCandidate(
+                rulespec="format: rulespec/v1\nrules: {name: broken}\n"
+            ),
+            "preserved repair overlay rules must be a list",
+        ),
+        (
+            ValidationRetryCandidate(
+                rulespec="format: rulespec/v1\nrules: []\n",
+                tests=(
+                    "- {name: duplicate, period: '2026-01-01'}\n"
+                    "- {name: duplicate, period: '2026-01-01'}\n"
+                ),
+            ),
+            "preserved companion tests contains duplicate name `duplicate`",
+        ),
+        (
+            ValidationRetryCandidate(
+                rulespec="format: rulespec/v1\nrules: []\n",
+                tests="cases: broken\n",
+            ),
+            "preserved companion test cases must be a list",
+        ),
+    ],
+)
+def test_retained_overlay_base_rejects_ambiguous_structures(candidate, expected_issue):
+    issue = _repair_overlay_candidate_base_issue(candidate)
+    assert issue is not None
+    assert expected_issue in issue

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1733"')
+        .startswith('__version__ = "0.2.1734"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1733"
+    assert encoder_package["version"] == "0.2.1734"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1733"
+    assert project["project"]["version"] == "0.2.1734"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1733"')
+        .startswith('__version__ = "0.2.1734"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1733"
+    assert encoder_package["version"] == "0.2.1734"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1733"
+    assert project["project"]["version"] == "0.2.1734"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1733"')
+        .startswith('__version__ = "0.2.1734"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1733"
+ENCODER_VERSION = "0.2.1734"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1733"
+version = "0.2.1734"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- Turn generated repair-overlay failures into ordinary validator feedback instead of aborting the bounded retry loop.
- Restore a structurally valid retained candidate when the new partial repair is malformed.
- Reject unusable retained bases, keep the new output for recovery, and require a complete replacement on the next attempt.
- Distinguish malformed retained YAML, imports, rules, deferred outputs, and companion tests.

This directly addresses protected immigration run 32889510208, where a duplicate companion-test name aborted the remaining encoder attempts.

## Review cycle

- Independent `codex review` repeated after every substantive correction.
- Final review: no actionable correctness regression identified.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- Focused retry/overlay tests: 28 passed.
- Validation/version suite: 2,494 passed, 31 skipped.

Unrelated local workflow/cache edits were excluded from this PR.
