### PR TITLE
Preserve inputs in repair overlays

### DIFF
--- a/changelog.d/preserve-repair-overlay-inputs.fixed.md
+++ b/changelog.d/preserve-repair-overlay-inputs.fixed.md
@@ -1,0 +1,1 @@
+Preserve omitted root-level input declarations when partial validation-repair output is overlaid onto its retained RuleSpec candidate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1734"
+version = "0.2.1735"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1734"
+__version__ = "0.2.1735"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -17024,6 +17024,13 @@ def _repair_overlay_candidate_base_issue(
         not isinstance(import_target, str) for import_target in imports
     ):
         return "preserved repair overlay imports must be a list of strings"
+    preserved_inputs = preserved.get("inputs", [])
+    if not isinstance(preserved_inputs, list):
+        return "preserved repair overlay inputs must be a list"
+    try:
+        _merge_named_yaml_items([], preserved_inputs, label="inputs")
+    except ValueError as exc:
+        return str(exc)
     preserved_rules = preserved.get("rules")
     if not isinstance(preserved_rules, list):
         return "preserved repair overlay rules must be a list"
@@ -17110,6 +17117,21 @@ def _overlay_validation_retry_candidate(
             repairs.append(f"import:{import_target}")
     if imports:
         generated["imports"] = imports
+
+    generated_inputs = generated.get("inputs", [])
+    preserved_inputs = preserved.get("inputs", [])
+    if not isinstance(generated_inputs, list) or not isinstance(preserved_inputs, list):
+        raise ValueError("repair overlay inputs must be lists")
+    inputs, restored_inputs, removed_inputs = _merge_named_yaml_items(
+        generated_inputs,
+        preserved_inputs,
+        label="inputs",
+    )
+    if removed_inputs:
+        raise ValueError("repair overlay cannot remove retained inputs")
+    if inputs:
+        generated["inputs"] = inputs
+    repairs.extend(f"input:{name}" for name in restored_inputs)
 
     generated_rules = generated.get("rules")
     rules, restored_rules, removed_rules = _merge_named_yaml_items(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1734"
+ENCODER_VERSION = "0.2.1735"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -918,6 +918,15 @@ def test_repair_candidate_overlay_restores_omitted_named_items(tmp_path):
         "      reason: new\n"
         "imports:\n"
         "  - us:source#new\n"
+        "inputs:\n"
+        "  - name: existing_changed_input\n"
+        "    entity: Person\n"
+        "    dtype: Boolean\n"
+        "    period: Month\n"
+        "  - name: added_input\n"
+        "    entity: Person\n"
+        "    dtype: Boolean\n"
+        "    period: Month\n"
         "rules:\n"
         "  - name: existing_changed\n"
         "    kind: parameter\n"
@@ -944,6 +953,15 @@ def test_repair_candidate_overlay_restores_omitted_named_items(tmp_path):
             "      reason: replaced by the generated rule\n"
             "imports:\n"
             "  - us:source#preserved\n"
+            "inputs:\n"
+            "  - name: existing_changed_input\n"
+            "    entity: Person\n"
+            "    dtype: Boolean\n"
+            "    period: Year\n"
+            "  - name: omitted_input\n"
+            "    entity: Person\n"
+            "    dtype: Integer\n"
+            "    period: Month\n"
             "rules:\n"
             "  - name: existing_changed\n"
             "    kind: parameter\n"
@@ -969,6 +987,13 @@ def test_repair_candidate_overlay_restores_omitted_named_items(tmp_path):
     rules = {rule["name"]: rule for rule in payload["rules"]}
     assert rules["existing_changed"]["versions"][0]["formula"] == 2
     assert set(rules) == {"existing_changed", "added", "omitted"}
+    inputs = {item["name"]: item for item in payload["inputs"]}
+    assert set(inputs) == {
+        "existing_changed_input",
+        "added_input",
+        "omitted_input",
+    }
+    assert inputs["existing_changed_input"]["period"] == "Month"
     assert payload["imports"] == ["us:source#new", "us:source#preserved"]
     assert {item["output"] for item in payload["module"]["deferred_outputs"]} == {
         "us:section#new_deferred",
@@ -979,8 +1004,41 @@ def test_repair_candidate_overlay_restores_omitted_named_items(tmp_path):
     )
     assert {case["name"] for case in tests} == {"added_case", "preserved_case"}
     assert "rule:omitted" in repairs
+    assert "input:omitted_input" in repairs
     assert "test:preserved_case" in repairs
     assert "resolved_deferred_output:us:section#added" in repairs
+
+
+def test_repair_candidate_overlay_rejects_input_removal(tmp_path):
+    artifact_root = tmp_path / "generated"
+    rulespec_file = artifact_root / "regulations" / "section.yaml"
+    rulespec_file.parent.mkdir(parents=True)
+    rulespec_file.write_text(
+        "format: rulespec/v1\n"
+        "inputs:\n"
+        "  - name: required_fact\n"
+        "    repair_remove: true\n"
+        "rules: []\n",
+        encoding="utf-8",
+    )
+    candidate = ValidationRetryCandidate(
+        rulespec=(
+            "format: rulespec/v1\n"
+            "inputs:\n"
+            "  - name: required_fact\n"
+            "    entity: Person\n"
+            "    dtype: Boolean\n"
+            "    period: Month\n"
+            "rules: []\n"
+        )
+    )
+
+    with pytest.raises(ValueError, match="cannot remove retained inputs"):
+        evals_module._overlay_validation_retry_candidate(
+            rulespec_file,
+            artifact_root=artifact_root,
+            candidate=candidate,
+        )
 
 
 def test_repair_candidate_overlay_removes_explicit_named_tombstones(tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1734"
+ENCODER_VERSION = "0.2.1735"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1734"
+ENCODER_VERSION = "0.2.1735"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1734"
+ENCODER_VERSION = "0.2.1735"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1734"
+ENCODER_VERSION = "0.2.1735"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1734"
+ENCODER_VERSION = "0.2.1735"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1734"
+ENCODER_VERSION = "0.2.1735"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_repair_overlay_failure_is_retryable.py
+++ b/tests/test_repair_overlay_failure_is_retryable.py
@@ -227,6 +227,23 @@ def test_unreadable_retained_candidate_does_not_replace_valid_generation(
         ),
         (
             ValidationRetryCandidate(
+                rulespec="format: rulespec/v1\ninputs: {name: broken}\nrules: []\n"
+            ),
+            "preserved repair overlay inputs must be a list",
+        ),
+        (
+            ValidationRetryCandidate(
+                rulespec=(
+                    "format: rulespec/v1\ninputs:\n"
+                    "  - {name: duplicate, entity: Person}\n"
+                    "  - {name: duplicate, entity: Person}\n"
+                    "rules: []\n"
+                )
+            ),
+            "preserved inputs contains duplicate name `duplicate`",
+        ),
+        (
+            ValidationRetryCandidate(
                 rulespec=(
                     "format: rulespec/v1\nrules:\n"
                     "  - {name: duplicate, kind: parameter}\n"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1734"')
+        .startswith('__version__ = "0.2.1735"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1734"
+    assert encoder_package["version"] == "0.2.1735"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1734"
+    assert project["project"]["version"] == "0.2.1735"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1734"')
+        .startswith('__version__ = "0.2.1735"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1734"
+    assert encoder_package["version"] == "0.2.1735"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1734"
+    assert project["project"]["version"] == "0.2.1735"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1734"')
+        .startswith('__version__ = "0.2.1735"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1734"
+ENCODER_VERSION = "0.2.1735"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1734"
+version = "0.2.1735"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Preserves omitted root-level RuleSpec input declarations when validation repair output is overlaid onto a retained candidate. Generated declarations with the same name still replace retained declarations, while input deletion markers are rejected so retained rules cannot lose required facts.

This fixes the failure observed in SNAP immigration repair run 32897317233, where a narrow repair output retained 104 rules but dropped seven existing root inputs.

Review cycle:
- Independent Codex review: no actionable findings.
- Focused overlay suites: 800 passed.
- Ruff: clean.
- Compileall: clean.

Full repository CI is required before merge.