### PR TITLE
Recognize flat federal proof ownership

### DIFF
--- a/changelog.d/allow-flat-federal-proof-scope.fixed.md
+++ b/changelog.d/allow-flat-federal-proof-scope.fixed.md
@@ -1,0 +1,1 @@
+Allow proof validation to recover flat alphabetic, numeric, and Roman subsection ownership without accepting sibling evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1735"
+version = "0.2.1736"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1735"
+__version__ = "0.2.1736"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -1835,6 +1835,212 @@ def _source_flattened_roman_coordinate_occurrences(
             next_roman_value = roman_value + 1
             roman_sequence_established = True
         record_offset += len(record) + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
+    occurrences.extend(
+        _source_flattened_alpha_numeric_roman_coordinate_occurrences(source_text)
+    )
+    return list(dict.fromkeys(occurrences))
+
+
+def _source_flattened_alpha_numeric_roman_coordinate_occurrences(
+    source_text: str,
+) -> list[tuple[tuple[str, ...], str, int]]:
+    """Recover flat ``(a) -> (1) -> (i)`` federal-style ownership.
+
+    Flat federal regulation text commonly places every coordinate at the same
+    indentation.  This pass recognizes only alphabetic parents established in
+    ascending order and Roman children established in canonical ascending
+    order.  Those constraints keep an isolated Roman-looking letter or a
+    numeric sibling from being assigned to the claimed parent.
+    """
+    flat_coordinate_token = rf"(?:{_STRUCTURAL_COORDINATE_TOKEN}|[A-Z])"
+    header_pattern = re.compile(
+        r"(?m)^(?P<indent>[ \t]*)(?P<bundle>"
+        rf"(?:\({flat_coordinate_token}\)[ \t]*)+"
+        r")"
+    )
+    coordinate_pattern = re.compile(rf"\((?P<value>{flat_coordinate_token})\)")
+    occurrences: list[tuple[tuple[str, ...], str, int]] = []
+    record_offset = 0
+    for record in source_text.split(PROOF_EVIDENCE_SEGMENT_SEPARATOR):
+        headers = list(header_pattern.finditer(record))
+        baseline_indent = min(
+            (len(header.group("indent").expandtabs(2)) for header in headers),
+            default=None,
+        )
+        baseline_headers = [
+            header
+            for header in headers
+            if baseline_indent is not None
+            and len(header.group("indent").expandtabs(2)) == baseline_indent
+        ]
+        alpha_parent: str | None = None
+        next_alpha = "a"
+        current_chain: tuple[str, str] | None = None
+        next_roman_value = 1
+        roman_sequence_established = False
+        alpha_sequence_started = False
+        leading_numeric_owner_seen = False
+        suspended_chain: tuple[str, str] | None = None
+        suspended_next_roman_value = 1
+        suspended_chain_tainted = False
+        for header_index, header in enumerate(baseline_headers):
+            tokens = [
+                match.group("value")
+                for match in coordinate_pattern.finditer(header.group("bundle"))
+            ]
+            if len(tokens) != 1:
+                if suspended_chain is not None:
+                    suspended_chain_tainted = True
+                alpha_parent = None
+                current_chain = None
+                roman_sequence_established = False
+                continue
+            token = tokens[0]
+            successor_tokens = (
+                [
+                    match.group("value")
+                    for match in coordinate_pattern.finditer(
+                        baseline_headers[header_index + 1].group("bundle")
+                    )
+                ]
+                if header_index + 1 < len(baseline_headers)
+                else []
+            )
+            roman_value = (
+                _canonical_roman_value(token)
+                if re.fullmatch(r"[ivxlcdmIVXLCDM]+", token) is not None
+                else None
+            )
+            successor_roman_value = (
+                _canonical_roman_value(successor_tokens[0])
+                if len(successor_tokens) == 1
+                and re.fullmatch(r"[ivxlcdmIVXLCDM]+", successor_tokens[0]) is not None
+                else None
+            )
+            successor_is_numeric = (
+                len(successor_tokens) == 1 and successor_tokens[0].isdigit()
+            )
+            successor_is_expected_alpha = (
+                len(successor_tokens) == 1
+                and len(successor_tokens[0]) == 1
+                and successor_tokens[0] == next_alpha
+            )
+            ambiguous_single_letter = len(token) == 1 and token.islower()
+            successor_is_next_alpha_after_token = (
+                len(successor_tokens) == 1
+                and len(successor_tokens[0]) == 1
+                and ambiguous_single_letter
+                and successor_tokens[0] == chr(ord(token) + 1)
+            )
+            successor_is_upper_alpha = (
+                len(successor_tokens) == 1
+                and len(successor_tokens[0]) == 1
+                and successor_tokens[0].isupper()
+            )
+            uppercase_roman_transition = (
+                token.isupper()
+                and current_chain is not None
+                and roman_value == next_roman_value
+                and (
+                    len(token) > 1
+                    or successor_roman_value == roman_value + 1
+                    or successor_is_numeric
+                    or successor_is_expected_alpha
+                    or successor_is_upper_alpha
+                    or not successor_tokens
+                )
+            )
+            if token.isupper() and not uppercase_roman_transition:
+                if current_chain is not None and suspended_chain is None:
+                    suspended_chain = current_chain
+                    suspended_next_roman_value = next_roman_value
+                    suspended_chain_tainted = False
+                current_chain = None
+                roman_sequence_established = False
+                continue
+            if suspended_chain is not None and token.isdigit():
+                suspended_chain_tainted = True
+                current_chain = None
+                roman_sequence_established = False
+                continue
+            if suspended_chain is not None and roman_value is not None:
+                if (
+                    not suspended_chain_tainted
+                    and roman_value == suspended_next_roman_value
+                ):
+                    current_chain = suspended_chain
+                    next_roman_value = suspended_next_roman_value
+                suspended_chain = None
+                suspended_chain_tainted = False
+            alpha_transition = (
+                ambiguous_single_letter
+                and token == next_alpha
+                and not (leading_numeric_owner_seen and not alpha_sequence_started)
+                and (
+                    successor_is_numeric
+                    or current_chain is None
+                    or roman_value != next_roman_value
+                    or successor_is_next_alpha_after_token
+                )
+            )
+            roman_transition = (
+                current_chain is not None
+                and roman_value == next_roman_value
+                and not alpha_transition
+                and (
+                    token != next_alpha
+                    or successor_roman_value == roman_value + 1
+                    or successor_is_numeric
+                    or successor_is_upper_alpha
+                )
+                and (
+                    not ambiguous_single_letter
+                    or roman_sequence_established
+                    or successor_roman_value == roman_value + 1
+                    or successor_is_numeric
+                    or successor_is_expected_alpha
+                    or successor_is_upper_alpha
+                    or not successor_tokens
+                )
+            )
+            if alpha_transition:
+                alpha_parent = token
+                suspended_chain = None
+                suspended_chain_tainted = False
+                alpha_sequence_started = True
+                next_alpha = chr(ord(token) + 1)
+                current_chain = None
+                next_roman_value = 1
+                roman_sequence_established = False
+                continue
+            if token.isdigit():
+                if alpha_parent is None and not alpha_sequence_started:
+                    leading_numeric_owner_seen = True
+                current_chain = (
+                    (alpha_parent, token) if alpha_parent is not None else None
+                )
+                next_roman_value = 1
+                roman_sequence_established = False
+                continue
+            if roman_transition:
+                occurrences.append(
+                    (
+                        current_chain,
+                        _canonical_roman_marker(roman_value),
+                        record_offset + header.start("bundle"),
+                    )
+                )
+                next_roman_value = roman_value + 1
+                roman_sequence_established = True
+                continue
+            alpha_parent = None
+            current_chain = None
+            suspended_chain = None
+            suspended_chain_tainted = False
+            roman_sequence_established = False
+            if ambiguous_single_letter:
+                next_alpha = ""
+        record_offset += len(record) + len(PROOF_EVIDENCE_SEGMENT_SEPARATOR)
     return occurrences
 
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1735"
+ENCODER_VERSION = "0.2.1736"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1735"
+ENCODER_VERSION = "0.2.1736"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1735"
+ENCODER_VERSION = "0.2.1736"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1735"
+ENCODER_VERSION = "0.2.1736"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1735"
+ENCODER_VERSION = "0.2.1736"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1735"
+ENCODER_VERSION = "0.2.1736"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1735"
+ENCODER_VERSION = "0.2.1736"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1735"')
+        .startswith('__version__ = "0.2.1736"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1735"
+    assert encoder_package["version"] == "0.2.1736"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1735"
+    assert project["project"]["version"] == "0.2.1736"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1735"')
+        .startswith('__version__ = "0.2.1736"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1735"
+    assert encoder_package["version"] == "0.2.1736"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1735"
+    assert project["project"]["version"] == "0.2.1736"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1735"')
+        .startswith('__version__ = "0.2.1736"')
     )
 
 
@@ -18400,6 +18400,550 @@ def test_rulespec_proof_validator_allows_flat_roman_continuation():
 
     assert result.passed is True
     assert result.issues == []
+
+
+_FLAT_FEDERAL_ALPHA_NUMERIC_ROMAN_SOURCE = """(a) First top-level paragraph.
+
+(1) First numeric child under paragraph a.
+
+(i) First Roman child under paragraph a one.
+
+(ii) Second Roman child under paragraph a one.
+
+(b) Second top-level paragraph.
+
+(1) First numeric child under paragraph b.
+
+(i) First Roman child under paragraph b one.
+
+(ii) Second Roman child under paragraph b one.
+
+(iii) Third Roman child under paragraph b one.
+
+(iv) Fourth Roman child under paragraph b one.
+
+(c) Third top-level paragraph.
+
+(2) Second numeric child under paragraph c.
+
+(i) First Roman child under paragraph c two.
+
+(ii) Second Roman child under paragraph c two.
+
+(iii) Third Roman child under paragraph c two.
+
+(iv) Fourth Roman child under paragraph c two.
+
+(3) Third numeric child under paragraph c.
+
+(i) First Roman child under paragraph c three.
+
+(ii) Second Roman child under paragraph c three.
+
+(iii) Third Roman child under paragraph c three.
+
+(iv) Fourth Roman child under paragraph c three.
+"""
+
+
+def test_rulespec_proof_validator_allows_flat_alpha_numeric_roman_excerpt():
+    excerpt = "(iv) Fourth Roman child under paragraph c three."
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 273.4(c)(3)(iv)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={
+            "us-nj/statute/54a:4-7": _FLAT_FEDERAL_ALPHA_NUMERIC_ROMAN_SOURCE,
+        },
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_flat_alpha_siblings_without_children():
+    excerpt = "(iv) Fourth Roman child under paragraph c three."
+    source_text = """(a) First top-level paragraph without children.
+
+(b) Second top-level paragraph without children.
+
+(c) Third top-level paragraph.
+
+(3) Third numeric child under paragraph c.
+
+(i) First Roman child under paragraph c three.
+
+(ii) Second Roman child under paragraph c three.
+
+(iii) Third Roman child under paragraph c three.
+
+(iv) Fourth Roman child under paragraph c three.
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 273.4(c)(3)(iv)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_clears_stale_flat_alpha_parent():
+    excerpt = "(ii) Second Roman child under paragraph x one."
+    source_text = f"""(a) First top-level paragraph.
+
+(1) Numeric child under paragraph a.
+
+(x) Nonsequential top-level paragraph.
+
+(1) Numeric child under paragraph x.
+
+(i) First Roman child under paragraph x one.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 273.4(a)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_allows_lone_flat_roman_before_numeric_sibling():
+    excerpt = "(i) Only Roman child under paragraph a one."
+    source_text = f"""(a) First top-level paragraph.
+
+(1) First numeric child under paragraph a.
+
+{excerpt}
+
+(2) Second numeric child under paragraph a.
+
+(b) Second top-level paragraph.
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(a)(1)(i)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_terminal_lone_flat_roman():
+    excerpt = "(i) Only terminal Roman child under paragraph a one."
+    source_text = f"""(a) First top-level paragraph.
+
+(1) First numeric child under paragraph a.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(a)(1)(i)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_lone_flat_roman_before_uppercase_child():
+    excerpt = "(i) Only Roman child before uppercase children."
+    source_text = f"""(a) First top-level paragraph.
+
+(1) First numeric child under paragraph a.
+
+{excerpt}
+
+(A) First uppercase child under the Roman paragraph.
+
+(b) Second top-level paragraph.
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(a)(1)(i)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_resumes_after_flat_uppercase_children():
+    excerpt = "(ii) Second Roman child after uppercase children."
+    source_text = f"""(a) First top-level paragraph.
+
+(1) First numeric child under paragraph a.
+
+(i) First Roman child under paragraph a one.
+
+(A) First uppercase child under the Roman paragraph.
+
+(B) Second uppercase child under the Roman paragraph.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(a)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_flat_uppercase_roman_sequence():
+    excerpt = "(II) Second uppercase Roman child."
+    source_text = f"""(a) First top-level paragraph.
+
+(1) First numeric child under paragraph a.
+
+(I) First uppercase Roman child.
+
+{excerpt}
+
+(III) Third uppercase Roman child.
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(a)(1)(II)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_lone_flat_uppercase_roman():
+    excerpt = "(I) Only uppercase Roman child."
+    source_text = f"""(a) First top-level paragraph.
+
+(1) First numeric child under paragraph a.
+
+{excerpt}
+
+(2) Second numeric child under paragraph a.
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(a)(1)(I)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_sequential_flat_alpha_i_parent():
+    excerpt = "(ii) Second Roman child under paragraph i one."
+    source_text = f"""(a) Paragraph a.
+
+(b) Paragraph b.
+
+(c) Paragraph c.
+
+(d) Paragraph d.
+
+(e) Paragraph e.
+
+(f) Paragraph f.
+
+(g) Paragraph g.
+
+(h) Paragraph h.
+
+(1) Numeric child under paragraph h.
+
+(i) Paragraph i.
+
+(1) Numeric child under paragraph i.
+
+(i) First Roman child under paragraph i one.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(i)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_preserves_childless_flat_alpha_i_parent():
+    excerpt = "(ii) Second Roman child under paragraph j one."
+    alpha_prefix = "\n\n".join(
+        f"({marker}) Paragraph {marker}." for marker in "abcdefg"
+    )
+    source_text = f"""{alpha_prefix}
+
+(h) Paragraph h.
+
+(1) Numeric child under paragraph h.
+
+(i) Childless paragraph i.
+
+(j) Paragraph j.
+
+(1) Numeric child under paragraph j.
+
+(i) First Roman child under paragraph j one.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(j)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_does_not_resume_invalid_flat_alpha_progression():
+    excerpt = "(ii) Second Roman child under later paragraph b one."
+    source_text = f"""(a) First top-level paragraph.
+
+(1) Numeric child under paragraph a.
+
+(x) Unexpected top-level paragraph.
+
+(b) Later paragraph b must not resume the sequence.
+
+(1) Numeric child under later paragraph b.
+
+(i) First Roman child under later paragraph b one.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(b)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "excerpt",
+    [
+        "(iv) Fourth Roman child under paragraph b one.",
+        "(iv) Fourth Roman child under paragraph c two.",
+    ],
+)
+def test_rulespec_proof_validator_rejects_wrong_flat_alpha_numeric_roman_parent(
+    excerpt: str,
+):
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 273.4(c)(3)(iv)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={
+            "us-nj/statute/54a:4-7": _FLAT_FEDERAL_ALPHA_NUMERIC_ROMAN_SOURCE,
+        },
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_does_not_drop_leading_numeric_owner():
+    excerpt = "(i) Roman child under outer one alpha a numeric one."
+    source_text = f"""(1) Outer numeric paragraph.
+
+(a) Alpha child under outer one.
+
+(1) Numeric child under outer one alpha a.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(a)(1)(i)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_does_not_reparent_uppercase_descendants():
+    excerpt = "(ii) Deep Roman child under uppercase A numeric one."
+    source_text = f"""(a) Alpha parent.
+
+(1) Numeric child under alpha a.
+
+(i) Outer Roman child under alpha a numeric one.
+
+(A) Uppercase child under the outer Roman child.
+
+(1) Numeric child under uppercase A.
+
+(i) First deep Roman child under uppercase A numeric one.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(a)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_does_not_reparent_compound_descendants():
+    excerpt = "(ii) Deep Roman child after a compound descendant."
+    source_text = f"""(a) Alpha parent.
+
+(1) Numeric child under alpha a.
+
+(i) Outer Roman child under alpha a numeric one.
+
+(A) Uppercase child under the outer Roman child.
+
+(A) (1) Compound descendant under the uppercase child.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(a)(1)(ii)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_terminal_alpha_roman_collision():
+    excerpt = "(v) Childless top-level paragraph v."
+    alpha_prefix = "\n\n".join(
+        f"({marker}) Top-level paragraph {marker}."
+        for marker in "abcdefghijklmnopqrstu"
+    )
+    source_text = f"""{alpha_prefix}
+
+(1) Numeric child under paragraph u.
+
+(i) First Roman child under paragraph u one.
+
+(ii) Second Roman child under paragraph u one.
+
+(iii) Third Roman child under paragraph u one.
+
+(iv) Fourth Roman child under paragraph u one.
+
+{excerpt}
+"""
+    content = _proof_scope_fixture(
+        rule_source="7 CFR 1.2(u)(1)(v)",
+        excerpt=excerpt,
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        for issue in result.issues
+    )
 
 
 def test_rulespec_proof_validator_rejects_flat_roman_under_wrong_alpha_parent():

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1735"
+ENCODER_VERSION = "0.2.1736"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1735"
+version = "0.2.1736"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- recover flat federal `(a) -> (1) -> (i)` proof ownership for released CFR text
- fail closed across numeric owners, alpha/Roman collisions, uppercase descendants, compound descendants, and evidence records
- preserve lowercase and uppercase Roman coordinate support

This unblocks the exact `7 CFR 273.4(c)(3)(iv)` indigent-alien formula proof required by the SNAP immigration repair.

## Validation
- independent review/fix cycle repeated until clean; resolved all actionable ownership and compatibility findings
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `pytest -q tests/test_rulespec_validation.py` (2488 passed, 31 skipped)
- exact archived immigration candidate proof: 159 atoms checked, 0 issues

## Review cycle
Independent review specifically exercised stale alpha ownership, leading numeric owners, nested/compound uppercase descendants, Roman/alpha collisions, terminal children, and uppercase Roman sequences. The final pass reported no actionable findings.