### PR TITLE
Handle repositories without retired manifest inventory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1737"
+version = "0.2.1738"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1737"
+__version__ = "0.2.1738"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -7,12 +7,14 @@ import argparse
 import ast
 import contextlib
 import hashlib
+import io
 import json
 import math
 import os
 import re
 import stat
 import subprocess
+import tokenize
 from datetime import date
 from pathlib import Path, PurePosixPath
 
@@ -1626,15 +1628,17 @@ def _retired_manifest_inventory_without_entry(
             "retired manifest inventory is not valid UTF-8 Python"
         ) from exc
 
+    inventory_name_present = any(
+        token.type == tokenize.NAME and token.string == "KNOWN_RETIRED_SCHEMA_MANIFESTS"
+        for token in tokenize.generate_tokens(io.StringIO(text).readline)
+    )
     assignments: list[ast.AnnAssign] = []
-    inventory_name_present = False
     for node in ast.walk(module):
         if (
             isinstance(node, ast.AnnAssign)
             and isinstance(node.target, ast.Name)
             and node.target.id == "KNOWN_RETIRED_SCHEMA_MANIFESTS"
         ):
-            inventory_name_present = True
             assignments.append(node)
         elif isinstance(node, ast.Assign) and any(
             isinstance(target, ast.Name)
@@ -1642,8 +1646,6 @@ def _retired_manifest_inventory_without_entry(
             for target in node.targets
         ):
             raise ValueError("retired manifest inventory assignment is not canonical")
-        elif isinstance(node, ast.Name) and node.id == "KNOWN_RETIRED_SCHEMA_MANIFESTS":
-            inventory_name_present = True
     if not inventory_name_present:
         if manifest in text:
             raise ValueError(

--- a/src/axiom_encode/prepare_signed_backfill.py
+++ b/src/axiom_encode/prepare_signed_backfill.py
@@ -1627,12 +1627,14 @@ def _retired_manifest_inventory_without_entry(
         ) from exc
 
     assignments: list[ast.AnnAssign] = []
+    inventory_name_present = False
     for node in ast.walk(module):
         if (
             isinstance(node, ast.AnnAssign)
             and isinstance(node.target, ast.Name)
             and node.target.id == "KNOWN_RETIRED_SCHEMA_MANIFESTS"
         ):
+            inventory_name_present = True
             assignments.append(node)
         elif isinstance(node, ast.Assign) and any(
             isinstance(target, ast.Name)
@@ -1640,6 +1642,14 @@ def _retired_manifest_inventory_without_entry(
             for target in node.targets
         ):
             raise ValueError("retired manifest inventory assignment is not canonical")
+        elif isinstance(node, ast.Name) and node.id == "KNOWN_RETIRED_SCHEMA_MANIFESTS":
+            inventory_name_present = True
+    if not inventory_name_present:
+        if manifest in text:
+            raise ValueError(
+                "retired manifest inventory path is present without an inventory"
+            )
+        return None
     if len(assignments) != 1 or assignments[0] not in module.body:
         raise ValueError(
             "retired manifest inventory lacks one canonical top-level assignment"

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1737"
+ENCODER_VERSION = "0.2.1738"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1737"
+ENCODER_VERSION = "0.2.1738"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1737"
+ENCODER_VERSION = "0.2.1738"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1737"
+ENCODER_VERSION = "0.2.1738"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1737"
+ENCODER_VERSION = "0.2.1738"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1737"
+ENCODER_VERSION = "0.2.1738"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1737"
+ENCODER_VERSION = "0.2.1738"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1382,6 +1382,18 @@ def test_reconcile_retired_manifest_inventory_is_noop_without_inventory_symbol(
             "assignment is not canonical",
         ),
         (
+            "from retired_inventory import KNOWN_RETIRED_SCHEMA_MANIFESTS\n",
+            "lacks one canonical top-level assignment",
+        ),
+        (
+            "import retired_inventory as KNOWN_RETIRED_SCHEMA_MANIFESTS\n",
+            "lacks one canonical top-level assignment",
+        ),
+        (
+            "def KNOWN_RETIRED_SCHEMA_MANIFESTS():\n    return frozenset()\n",
+            "lacks one canonical top-level assignment",
+        ),
+        (
             "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset({\n"
             "    '.axiom/encoding-manifests/us/policies/income_tax/schedule.json',  # stale\n"
             "})\n",

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1333,6 +1333,29 @@ def test_reconcile_retired_manifest_inventory_is_noop_when_absent(
     }
 
 
+def test_reconcile_retired_manifest_inventory_is_noop_without_inventory_symbol(
+    tmp_path: Path,
+) -> None:
+    repo, target, manifest, inventory = _retired_inventory_replacement_repo(
+        tmp_path,
+        inventory_text="KNOWN_ORPHANED_ENCODING_MANIFESTS: list[str] = []\n",
+    )
+    before = inventory.read_bytes()
+
+    assert (
+        reconcile_retired_manifest_inventory(
+            repo,
+            target.relative_to(repo).as_posix(),
+        )
+        is None
+    )
+    assert inventory.read_bytes() == before
+    assert authorized_changed_paths(repo) == {
+        PurePosixPath(target.relative_to(repo).as_posix()),
+        PurePosixPath(manifest.relative_to(repo).as_posix()),
+    }
+
+
 @pytest.mark.parametrize(
     ("inventory_text", "message"),
     [
@@ -1347,6 +1370,10 @@ def test_reconcile_retired_manifest_inventory_is_noop_when_absent(
             "KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset()\n"
             "# .axiom/encoding-manifests/us/policies/income_tax/schedule.json\n",
             "present outside an exact entry",
+        ),
+        (
+            "# .axiom/encoding-manifests/us/policies/income_tax/schedule.json\n",
+            "present without an inventory",
         ),
         (
             "KNOWN_RETIRED_SCHEMA_MANIFESTS = {\n"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6426,7 +6426,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1737"')
+        .startswith('__version__ = "0.2.1738"')
     )
 
 
@@ -6658,13 +6658,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1737"
+    assert encoder_package["version"] == "0.2.1738"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1737"
+    assert project["project"]["version"] == "0.2.1738"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1737"')
+        .startswith('__version__ = "0.2.1738"')
     )
 
 
@@ -6926,13 +6926,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1737"
+    assert encoder_package["version"] == "0.2.1738"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1737"
+    assert project["project"]["version"] == "0.2.1738"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1737"')
+        .startswith('__version__ = "0.2.1738"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1737"
+ENCODER_VERSION = "0.2.1738"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1737"
+version = "0.2.1738"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- treat a genuinely absent `KNOWN_RETIRED_SCHEMA_MANIFESTS` identifier as a verified no-op during signed canonical replacement
- detect the identifier as a Python name token and continue failing closed for noncanonical bindings or ambiguous inventory contents
- cover absent, imported, aliased, function-defined, duplicate, and misplaced inventory cases
- bump the encoder to 0.2.1738

This unblocks targeted signed re-encode run 33013932933, which applied the SNAP immigration candidate but failed after apply because the pinned RuleSpec repository has no retired-manifest inventory symbol.

## Checks

- `uv run pytest -q tests/test_prepare_signed_backfill.py` (186 passed before the review fix)
- focused reconciliation/version tests (15 passed locally; 16 passed in independent re-review)
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- exact pinned RuleSpec reproduction returns safe no-op

## Cycle

- independent review found one medium fail-open edge case for imported/aliased/function-defined inventory bindings
- fixed with Python NAME-token detection and three regression cases
- independent re-review at `437cd627`: no remaining actionable findings
- focused checks rerun after the fix